### PR TITLE
Player speed fixes

### DIFF
--- a/entities/entities/drug/init.lua
+++ b/entities/entities/drug/init.lua
@@ -12,7 +12,7 @@ local function UnDrugPlayer(ply)
 	SendUserMessage("DrugEffects", ply, false)
 
 	ply:SetJumpPower(190)
-	GAMEMODE:SetPlayerSpeed(ply, GAMEMODE.Config.walkspeed, GAMEMODE.Config.runspeed)
+	GAMEMODE:UpdatePlayerSpeed(ply)
 
 	hook.Remove("PlayerDeath", ply)
 end
@@ -23,7 +23,7 @@ local function DrugPlayer(ply)
 	SendUserMessage("DrugEffects", ply, true)
 
 	ply:SetJumpPower(300)
-	GAMEMODE:SetPlayerSpeed(ply, GAMEMODE.Config.walkspeed * 2, GAMEMODE.Config.runspeed * 2)
+	GAMEMODE:UpdatePlayerSpeed(ply, 2)
 
 	local IDSteam = ply:UniqueID()
 	if not timer.Exists(IDSteam.."DruggedHealth") and not timer.Exists(IDSteam) then

--- a/entities/weapons/door_ram/shared.lua
+++ b/entities/weapons/door_ram/shared.lua
@@ -62,7 +62,7 @@ end
 function SWEP:Holster()
 	if not self.Ready or not SERVER then return true end
 
-	GAMEMODE:SetPlayerSpeed(self.Owner, GAMEMODE.Config.walkspeed, GAMEMODE.Config.runspeed)
+	GAMEMODE:UpdatePlayerSpeed(self.Owner)
 	self.Owner:SetJumpPower(200)
 
 	return true
@@ -183,13 +183,13 @@ function SWEP:SecondaryAttack()
 		self:SetWeaponHoldType("rpg")
 		if SERVER then
 			-- Prevent them from being able to run and jump
-			GAMEMODE:SetPlayerSpeed(self.Owner, GAMEMODE.Config.walkspeed / 3, GAMEMODE.Config.runspeed / 3)
+			GAMEMODE:UpdatePlayerSpeed(self.Owner, 1/3)
 			self.Owner:SetJumpPower(0)
 		end
 	else
 		self:SetWeaponHoldType("normal")
 		if SERVER then
-			GAMEMODE:SetPlayerSpeed(self.Owner, GAMEMODE.Config.walkspeed, GAMEMODE.Config.runspeed)
+			GAMEMODE:UpdatePlayerSpeed(self.Owner)
 			self.Owner:SetJumpPower(200)
 		end
 	end

--- a/entities/weapons/weapon_cs_base2/shared.lua
+++ b/entities/weapons/weapon_cs_base2/shared.lua
@@ -99,7 +99,7 @@ end
 function SWEP:Holster()
 	if CLIENT then return end
 	if self:GetIronsights() then
-		GAMEMODE:SetPlayerSpeed(self.Owner, GAMEMODE.Config.walkspeed, GAMEMODE.Config.runspeed)
+		GAMEMODE:UpdatePlayerSpeed(self.Owner)
 	end
 	return true
 end
@@ -354,11 +354,15 @@ function SWEP:SetIronsights(b)
 	if b then
 		self:NewSetWeaponHoldType(self.HoldType)
 		self.CurHoldType = self.HoldType
-		if SERVER then GAMEMODE:SetPlayerSpeed(self.Owner, GAMEMODE.Config.walkspeed / 3, GAMEMODE.Config.runspeed / 3) end
+		if SERVER then
+			GAMEMODE:UpdatePlayerSpeed(self.Owner, 1/3)
+		end
 	else
 		self:NewSetWeaponHoldType("normal")
 		self.CurHoldType = "normal"
-		if SERVER then GAMEMODE:SetPlayerSpeed(self.Owner, GAMEMODE.Config.walkspeed, GAMEMODE.Config.runspeed) end
+		if SERVER then
+			GAMEMODE:UpdatePlayerSpeed(self.Owner)
+		end
 	end
 	self.Ironsights = b
 end

--- a/gamemode/modules/police/sv_init.lua
+++ b/gamemode/modules/police/sv_init.lua
@@ -182,6 +182,7 @@ function DarkRP.hooks:playerArrested(ply, time, arrester)
 	ply:unWarrant(arrester)
 	ply:SetSelfDarkRPVar("HasGunlicense", false)
 
+	-- GAMEMODE:UpdatePlayerSpeed(ply) won't work here as the "Arrested" DarkRPVar is set AFTER this hook
 	GAMEMODE:SetPlayerSpeed(ply, GAMEMODE.Config.arrestspeed, GAMEMODE.Config.arrestspeed)
 	ply:StripWeapons()
 
@@ -208,7 +209,8 @@ function DarkRP.hooks:playerUnArrested(ply, actor)
 		GAMEMODE:KnockoutToggle(ply, "force")
 	end
 
-	GAMEMODE:SetPlayerSpeed(ply, GAMEMODE.Config.walkspeed, GAMEMODE.Config.runspeed)
+	-- "Arrested" DarkRPVar is set to false BEFORE this hook however, so it is safe here.
+	GAMEMODE:UpdatePlayerSpeed(ply)
 	GAMEMODE:PlayerLoadout(ply)
 	if GAMEMODE.Config.telefromjail and (not FAdmin or not ply:FAdmin_GetGlobal("fadmin_jailed")) then
 		local _, pos = GAMEMODE:PlayerSelectSpawn(ply)

--- a/gamemode/server/gamemode_functions.lua
+++ b/gamemode/server/gamemode_functions.lua
@@ -85,6 +85,16 @@ function GM:CanSeeLogMessage(ply, message, colour)
 	return ply:IsAdmin()
 end
 
+function GM:UpdatePlayerSpeed(ply, multiplier)
+	if ply:isArrested() then
+		GAMEMODE:SetPlayerSpeed(ply, GAMEMODE.Config.arrestspeed * (multiplier or 1), GAMEMODE.Config.arrestspeed * (multiplier or 1))
+	elseif ply:IsCP() then
+		GAMEMODE:SetPlayerSpeed(ply, GAMEMODE.Config.walkspeed * (multiplier or 1), GAMEMODE.Config.runspeedcp * (multiplier or 1))
+	else
+		GAMEMODE:SetPlayerSpeed(ply, GAMEMODE.Config.walkspeed * (multiplier or 1), GAMEMODE.Config.runspeed * (multiplier or 1))
+	end
+end
+
 /*---------------------------------------------------------
  Gamemode functions
  ---------------------------------------------------------*/

--- a/gamemode/server/player.lua
+++ b/gamemode/server/player.lua
@@ -338,6 +338,7 @@ function meta:ChangeTeam(t, force)
 		effectdata:SetOrigin( vPoint )
 		effectdata:SetScale(1)
 		util.Effect("entity_remove", effectdata)
+		GAMEMODE:UpdatePlayerSpeed(self)
 		GAMEMODE:PlayerSetModel(self)
 		GAMEMODE:PlayerLoadout(self)
 	else


### PR DESCRIPTION
- Added UpdatePlayerSpeed hook.
- If GAMEMODE.Config.norespawn is set, the player's speed now gets set on job change without the need of respawning.
- The correct speed is now given back after unarrest, weapon (and door ram) holster and undrugging.
