### PR TITLE
Gun lab fixes

### DIFF
--- a/entities/entities/drug_lab/init.lua
+++ b/entities/entities/drug_lab/init.lua
@@ -46,10 +46,10 @@ function ENT:Use(activator,caller)
 		GAMEMODE:Notify(activator, 1, 3, "You can't make anymore drugs as the limit is reached.")
 		timer.Simple(0.5, function() self.CanUse = true end)
 	else
-
 		local productioncost = math.random(math.Round(self:Getprice() / 8), math.Round(self:Getprice() / 4))
 		if not activator:CanAfford(productioncost) then
 			GAMEMODE:Notify(activator, 1, 4, "You do not have enough money to produce drugs.")
+			timer.Simple(0.5, function() self.CanUse = true end)
 			return false
 		end
 		activator:AddMoney(-productioncost)


### PR DESCRIPTION
- Fixed a small issue where the price of drug lab production cost sometimes contained decimal points.
- Fixed a problem where all players would be permanently locked out of the drug lab if one player who used it could not afford to produce drugs.
