### PR TITLE
Database error fixes

### DIFF
--- a/gamemode/server/database.lua
+++ b/gamemode/server/database.lua
@@ -180,7 +180,7 @@ function queryValue(sqlText, callback, errorCallback)
 	local lastError = sql.LastError()
 	local val = sql.QueryValue(sqlText)
 	if sql.LastError() and sql.LastError() ~= lastError then
-		error("SQLite error: " .. lastError)
+		error("SQLite error: " .. sql.LastError())
 	end
 
 	if callback then callback(val) end


### PR DESCRIPTION
- Fixed queryValue printing the previous error when using SQLite.
- Fixed a Lua error on reconnect to a MySQL database after calling queryValue when not connected to the database.
