### PR TITLE
Fixed Lua error that occurs if GM.Config.customspawns is set and the team spawn position table is empty.

### DIFF
--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -563,7 +563,7 @@ function GM:PlayerSelectSpawn(ply)
 	end
 
 	local CustomSpawnPos = DarkRP.retrieveTeamSpawnPos(ply:Team())
-	if GAMEMODE.Config.customspawns and not ply:isArrested() and CustomSpawnPos then
+	if GAMEMODE.Config.customspawns and not ply:isArrested() and CustomSpawnPos and next(CustomSpawnPos) ~= nil then
 		POS = CustomSpawnPos[math.random(1, #CustomSpawnPos)]
 	end
 


### PR DESCRIPTION
_This is for the refactor branch because the issue only exists on the refactor branch._

Just a small fix for a Lua error that occurs if GM.Config.customspawns is set and the team spawn position table is empty.
