### PR TITLE
/removelaw fixes

### DIFF
--- a/entities/entities/darkrp_laws/cl_init.lua
+++ b/entities/entities/darkrp_laws/cl_init.lua
@@ -45,7 +45,7 @@ local function RemoveLaw(um)
 	local i = um:ReadChar()
 
 	while i < #Laws do
-		Laws[i] = i .. string.sub(Laws[i], 2)
+		Laws[i] = i .. string.sub(Laws[i+1], (fn.ReverseArgs(string.find(Laws[i+1], "%."))))
 		i = i + 1
 	end
 	Laws[i] = nil


### PR DESCRIPTION
_(master branch)_

I am surprised this was not previously reported.
- Fixed /removelaw not removing the correct law if there are laws after the law chosen.
- Fixed /removelaw causing law numbers to not display correctly if the removed law has double-digit laws after it.

I also used the functional library. Do I get bonus points? 
