### PR TITLE
Pocket fixes

### DIFF
--- a/entities/weapons/pocket/shared.lua
+++ b/entities/weapons/pocket/shared.lua
@@ -178,6 +178,7 @@ if CLIENT then
 	local function Reload()
 		if not ValidPanel(frame) or not frame:IsVisible() then return end
 		local items = LocalPlayer():GetTable().Pocket
+		if not items or next(items) == nil then frame:Close() return end
 		frame:SetSize(#items * 64, 90)
 		frame:Center()
 		for k,v in pairs(items) do
@@ -218,7 +219,7 @@ if CLIENT then
 			end
 		end
 	end
-	
+
 	local function StorePocketItem(um)
 		LocalPlayer():GetTable().Pocket = LocalPlayer():GetTable().Pocket or {}
 


### PR DESCRIPTION
- Fixed various Lua errors with the pocket, most when interacting with the pocket when dead.
- Made the menu reload, if open, when adding and removing pocket items.
- Fixed an issue where the pocket menu would be invisible (height 0) if it was reloaded with an empty pocket.
