### PR TITLE
Fixed my own issue #855

### DIFF
--- a/gamemode/fadmin/cl_interface/cl_scoreboardServer.lua
+++ b/gamemode/fadmin/cl_interface/cl_scoreboardServer.lua
@@ -173,7 +173,7 @@ function FAdmin.ScoreBoard.Server.Show(ply)
 		function Text:OnMousePressed(mcode)
 			self:SetToolTip(v.name.." copied to clipboard!")
 			ChangeTooltip(self)
-			SetClipboardText(v.func())
+			SetClipboardText(v.func() or "")
 			self:SetToolTip("Click to copy "..v.name.." to clipboard")
 		end
 


### PR DESCRIPTION
Instead of spitting errors, it does nothing with the clipboard if the
string is empty.

Tested on my server. No side effects noticed.
