### PR TITLE
Added Dynamic Fall Damage configuration

### DIFF
--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -133,6 +133,8 @@ GM.Config.wallettax 					= false
 GM.Config.wantedsuicide 				= false
 -- showcrosshairs - Enable/disable crosshair visibility
 GM.Config.showcrosshairs				= true
+-- realisticfalldamage - Enable/Disable dynamic fall damage. Setting mp_falldamage to 1 will over-ride this.
+GM.Config.realisticfalldamage			= true
 
 /*
 Value settings
@@ -221,6 +223,10 @@ GM.Config.wallettaxtime					= 600
 GM.Config.wantedtime					= 120
 -- walkspeed - Sets the max walking speed.
 GM.Config.walkspeed						= 160
+-- falldamagedamper - The damper on realistic fall damage. Default is 15. Decrease this for more damage.
+GM.Config.falldamagedamper				= 15
+-- falldamageamount - The base damage taken from falling for static fall damage. Default is 10
+GM.Config.falldamageamount				= 10
 
 /*---------------------------------------------------------------------------
 Other settings

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -832,12 +832,12 @@ function GM:PlayerDisconnected(ply)
 end
 
 function GM:GetFallDamage( ply, flFallSpeed )
-	if GetConVarNumber("mp_falldamage") == 1 then
-		return flFallSpeed / 15
+	if GetConVarNumber("mp_falldamage") == 1 or GAMEMODE.Config.realisticfalldamage then
+		if GAMEMODE.Config.falldamagedamper then return flFallSpeed / GAMEMODE.Config.falldamagedamper else return flFallSpeed / 15 end
+	else
+		if GAMEMODE.Config.falldamageamount then return GAMEMODE.Config.falldamageamount else return 10 end
 	end
-	return 10
-end
-
+end	
 local InitPostEntityCalled = false
 function GM:InitPostEntity()
 	InitPostEntityCalled = true


### PR DESCRIPTION
Too lazy to detail how to use it as its self explanatory beyond this,
but GM.Config.falldamageamount is your static damage, setting to 0
disables fall damage if you aren't using dynamic damage... setting to
negative should heal in theory but dont do it cause its stupid.

GM.Config.falldamagedamper is your damper on dynamic fall damage. The
higher the number, the more resistant you are to fall damage. The lower,
the less resistant.  This is used in division so don't set it to 0 or
you will destroy time and space.

GM.Config.realisticfalldamage is true by default. Set to false for
static fall damage. mp_falldamage being set to 1 will override this.

Redundancy is in place for idiots who dont update their config.
