### PR TITLE
Continuation of fix to #912

### DIFF
--- a/gamemode/fadmin/playeractions/chatmute/cl_init.lua
+++ b/gamemode/fadmin/playeractions/chatmute/cl_init.lua
@@ -14,13 +14,21 @@ FAdmin.StartHooks["Chatmute"] = function()
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Chatmute", ply) end, function(ply, button)
 		if not ply:FAdmin_GetGlobal("FAdmin_chatmuted") then
 			FAdmin.PlayerActions.addTimeMenu(function(secs)
-				RunConsoleCommand("_FAdmin", "chatmute", ply:SteamID(), secs)
+				if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+					RunConsoleCommand("_FAdmin", "chatmute", ply:Nick(), secs)
+				else
+					RunConsoleCommand("_FAdmin", "chatmute", ply:SteamID(), secs)
+				end
 				button:SetImage2("null")
 				button:SetText("Unmute chat")
 				button:GetParent():InvalidateLayout()
 			end)
 		else
-			RunConsoleCommand("_FAdmin", "UnChatmute", ply:SteamID())
+			if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+				RunConsoleCommand("_FAdmin", "UnChatmute", ply:Nick())
+			else
+				RunConsoleCommand("_FAdmin", "UnChatmute", ply:SteamID())
+			end
 		end
 
 		button:SetImage2("FAdmin/icons/disable")

--- a/gamemode/fadmin/playeractions/cloak/cl_init.lua
+++ b/gamemode/fadmin/playeractions/cloak/cl_init.lua
@@ -13,9 +13,17 @@ FAdmin.StartHooks["zz_Cloak"] = function()
 
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Cloak", ply) end, function(ply, button)
 		if not ply:FAdmin_GetGlobal("FAdmin_cloaked") then
-			RunConsoleCommand("_FAdmin", "Cloak", ply:SteamID())
+			if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+				RunConsoleCommand("_FAdmin", "Cloak", ply:Nick())
+			else
+				RunConsoleCommand("_FAdmin", "Cloak", ply:SteamID())
+			end
 		else
-			RunConsoleCommand("_FAdmin", "Uncloak", ply:SteamID())
+			if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+				RunConsoleCommand("_FAdmin", "Uncloak", ply:Nick())
+			else
+				RunConsoleCommand("_FAdmin", "Uncloak", ply:SteamID())
+			end
 		end
 
 		if not ply:FAdmin_GetGlobal("FAdmin_cloaked") then button:SetImage2("FAdmin/icons/disable") button:SetText("Uncloak") button:GetParent():InvalidateLayout() return end

--- a/gamemode/fadmin/playeractions/freeze/cl_init.lua
+++ b/gamemode/fadmin/playeractions/freeze/cl_init.lua
@@ -14,13 +14,21 @@ FAdmin.StartHooks["Freeze"] = function()
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Freeze", ply) end, function(ply, button)
 		if not ply:FAdmin_GetGlobal("FAdmin_frozen") then
 			FAdmin.PlayerActions.addTimeMenu(function(secs)
-				RunConsoleCommand("_FAdmin", "freeze", ply:SteamID(), secs)
+				if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+					RunConsoleCommand("_FAdmin", "freeze", ply:Nick(), secs)
+				else
+					RunConsoleCommand("_FAdmin", "freeze", ply:SteamID(), secs)
+				end
 				button:SetImage2("FAdmin/icons/disable")
 				button:SetText("Unfreeze")
 				button:GetParent():InvalidateLayout()
 			end)
 		else
-			RunConsoleCommand("_FAdmin", "unfreeze", ply:SteamID())
+			if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+				RunConsoleCommand("_FAdmin", "unfreeze", ply:Nick())
+			else
+				RunConsoleCommand("_FAdmin", "unfreeze", ply:SteamID())
+			end
 		end
 
 		button:SetImage2("null")

--- a/gamemode/fadmin/playeractions/giveweapons/cl_init.lua
+++ b/gamemode/fadmin/playeractions/giveweapons/cl_init.lua
@@ -12,8 +12,11 @@ local function GiveWeaponGui(ply)
 	function WeaponMenu:DoGiveWeapon(SpawnName, IsAmmo)
 		if not ply:IsValid() then return end
 		local giveWhat = (IsAmmo and "ammo") or "weapon"
-
-		RunConsoleCommand("FAdmin", "give"..giveWhat, ply:SteamID(), SpawnName)
+		if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+			RunConsoleCommand("FAdmin", "give"..giveWhat, ply:Nick(), SpawnName)
+		else
+			RunConsoleCommand("FAdmin", "give"..giveWhat, ply:SteamID(), SpawnName)
+		end
 	end
 
 	WeaponMenu:BuildList()

--- a/gamemode/fadmin/playeractions/god/cl_init.lua
+++ b/gamemode/fadmin/playeractions/god/cl_init.lua
@@ -13,9 +13,17 @@ FAdmin.StartHooks["God"] = function()
 
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "God") end, function(ply, button)
 		if not ply:FAdmin_GetGlobal("FAdmin_godded") then
-			RunConsoleCommand("_FAdmin", "god", ply:SteamID())
+			if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+				RunConsoleCommand("_FAdmin", "god", ply:Nick())
+			else
+				RunConsoleCommand("_FAdmin", "god", ply:SteamID())
+			end
 		else
-			RunConsoleCommand("_FAdmin", "ungod", ply:SteamID())
+			if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+				RunConsoleCommand("_FAdmin", "ungod", ply:Nick())
+			else
+				RunConsoleCommand("_FAdmin", "ungod", ply:SteamID())
+			end
 		end
 
 		if not ply:FAdmin_GetGlobal("FAdmin_godded") then button:SetImage2("FAdmin/icons/disable") button:SetText("Ungod") button:GetParent():InvalidateLayout() return end

--- a/gamemode/fadmin/playeractions/health/cl_init.lua
+++ b/gamemode/fadmin/playeractions/health/cl_init.lua
@@ -13,7 +13,11 @@ FAdmin.StartHooks["Health"] = function()
 			local window = Derma_StringRequest("Select health", "What do you want the health of the person to be?", "",
 				function(text)
 					local health = tonumber(text or 100) or 100
-					RunConsoleCommand("_fadmin", "SetHealth", ply:SteamID(), health)
+					if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+						RunConsoleCommand("_fadmin", "SetHealth", ply:Nick(), health)
+					else
+						RunConsoleCommand("_fadmin", "SetHealth", ply:SteamID(), health)
+					end
 				end
 			)
 

--- a/gamemode/fadmin/playeractions/ignite/cl_init.lua
+++ b/gamemode/fadmin/playeractions/ignite/cl_init.lua
@@ -9,12 +9,20 @@ FAdmin.StartHooks["Ignite"] = function()
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Ignite", ply) end,
 	function(ply, button)
 		if not ply:FAdmin_GetGlobal("FAdmin_ignited") then
-			RunConsoleCommand("_FAdmin", "ignite", ply:SteamID())
+			if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+				RunConsoleCommand("_FAdmin", "ignite", ply:Nick())
+			else
+				RunConsoleCommand("_FAdmin", "ignite", ply:SteamID())
+			end
 			button:SetImage2("FAdmin/icons/disable")
 			button:SetText("Extinguish")
 			button:GetParent():InvalidateLayout()
 		else
-			RunConsoleCommand("_FAdmin", "unignite", ply:SteamID())
+			if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+				RunConsoleCommand("_FAdmin", "unignite", ply:Nick())
+			else
+				RunConsoleCommand("_FAdmin", "unignite", ply:SteamID())
+			end
 			button:SetImage2("null")
 			button:SetText("Ignite")
 			button:GetParent():InvalidateLayout()

--- a/gamemode/fadmin/playeractions/jail/cl_init.lua
+++ b/gamemode/fadmin/playeractions/jail/cl_init.lua
@@ -4,7 +4,11 @@ FAdmin.StartHooks["Jail"] = function()
 	FAdmin.Commands.AddCommand("UnJail", nil, "<Player>")
 
 	FAdmin.ScoreBoard.Main.AddPlayerRightClick("Jail", function(ply)
-		RunConsoleCommand("_FAdmin", "jail", ply:SteamID())
+		if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+			RunConsoleCommand("_FAdmin", "jail", ply:Nick())
+		else
+			RunConsoleCommand("_FAdmin", "jail", ply:SteamID())
+		end
 	end)
 
 	FAdmin.ScoreBoard.Player:AddActionButton(function(ply)
@@ -18,7 +22,9 @@ FAdmin.StartHooks["Jail"] = function()
 	Color(255, 130, 0, 255),
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Jail", ply) end,
 	function(ply, button)
-		if ply:FAdmin_GetGlobal("fadmin_jailed") then RunConsoleCommand("_FAdmin", "unjail", ply:SteamID()) button:SetImage2("null") button:SetText("Jail") button:GetParent():InvalidateLayout() return end
+		if ply:FAdmin_GetGlobal("fadmin_jailed") then 
+			if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then RunConsoleCommand("_FAdmin", "unjail", ply:Nick()) else RunConsoleCommand("_FAdmin", "unjail", ply:SteamID()) end button:SetImage2("null") button:SetText("Jail") button:GetParent():InvalidateLayout() return end
+		-- I assume there is a good reason why this was all in one line. Figured I keep it that way.
 
 		local menu = DermaMenu()
 		local Title = vgui.Create("DLabel")
@@ -33,12 +39,20 @@ FAdmin.StartHooks["Jail"] = function()
 			if v == "Unjail" then continue end
 			FAdmin.PlayerActions.addTimeSubmenu(menu, v .. " jail",
 				function()
-					RunConsoleCommand("_FAdmin", "Jail", ply:SteamID(), k)
+					if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+						RunConsoleCommand("_FAdmin", "Jail", ply:Nick(), k)
+					else
+						RunConsoleCommand("_FAdmin", "Jail", ply:SteamID(), k)
+					end
 					button:SetText("Unjail") button:GetParent():InvalidateLayout()
 					button:SetImage2("FAdmin/icons/disable")
 				end,
 				function(secs)
-					RunConsoleCommand("_FAdmin", "Jail", ply:SteamID(), k, secs)
+					if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+						RunConsoleCommand("_FAdmin", "Jail", ply:Nick(), k, secs)
+					else
+						RunConsoleCommand("_FAdmin", "Jail", ply:SteamID(), k, secs)
+					end
 					button:SetText("Unjail")
 					button:GetParent():InvalidateLayout()
 					button:SetImage2("FAdmin/icons/disable")

--- a/gamemode/fadmin/playeractions/kickban/cl_init.lua
+++ b/gamemode/fadmin/playeractions/kickban/cl_init.lua
@@ -204,7 +204,11 @@ FAdmin.StartHooks["CL_KickBan"] = function()
 	FAdmin.Commands.AddCommand("unban", "<SteamID>")
 
 	FAdmin.ScoreBoard.Main.AddPlayerRightClick("Quick Kick", function(ply, Panel)
-		RunConsoleCommand("_FAdmin", "kick", ply:SteamID(), "Quick kick")
+		if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+			RunConsoleCommand("_FAdmin", "kick", ply:Nick(), "Quick kick")
+		else
+			RunConsoleCommand("_FAdmin", "kick", ply:SteamID(), "Quick kick")
+		end
 		if ValidPanel(Panel) then Panel:Remove() end
 	end)
 
@@ -214,8 +218,12 @@ FAdmin.StartHooks["CL_KickBan"] = function()
 		if not IsValid(ply) then return end
 		local SteamID = ply:SteamID()
 		local NICK = ply:Nick()
-
-		RunConsoleCommand("FAdmin", "kick", SteamID, "start")
+		-- bots...
+		if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+			RunConsoleCommand("FAdmin", "kick", NICK, "start")
+		else
+			RunConsoleCommand("FAdmin", "kick", SteamID, "start")
+		end
 		local Window = vgui.Create("DFrame")
 		Window:SetTitle("Reason for kicking")
 		Window:SetDraggable( false )
@@ -233,10 +241,14 @@ FAdmin.StartHooks["CL_KickBan"] = function()
 
 		local TextEntry = vgui.Create("DTextEntry", InnerPanel )
 			function TextEntry:OnTextChanged()
-				RunConsoleCommand("_FAdmin", "kick", SteamID, "update", self:GetValue())
+				if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+					RunConsoleCommand("_FAdmin", "kick", NICK, "update", self:GetValue())
+				else
+					RunConsoleCommand("_FAdmin", "kick", SteamID, "update", self:GetValue())
+				end
 			end
 			TextEntry:SetText("Enter reason here")
-			TextEntry.OnEnter = function() Window:Close() RunConsoleCommand("_FAdmin", "kick", SteamID, "execute", TextEntry:GetValue()) end
+			TextEntry.OnEnter = function() Window:Close() if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then RunConsoleCommand("_FAdmin", "kick", NICK, "execute", TextEntry:GetValue()) else RunConsoleCommand("_FAdmin", "kick", SteamID, "execute", TextEntry:GetValue()) end end
 			function TextEntry:OnFocusChanged(changed)
 				self:RequestFocus()
 				self:SelectAllText(true)
@@ -253,7 +265,7 @@ FAdmin.StartHooks["CL_KickBan"] = function()
 			Button:SetTall( 20 )
 			Button:SetWide( Button:GetWide() + 20 )
 			Button:SetPos( 5, 5 )
-			Button.DoClick = function() Window:Close() RunConsoleCommand("_FAdmin", "kick", SteamID, "execute", TextEntry:GetValue()) end
+			Button.DoClick = function() Window:Close() if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then RunConsoleCommand("_FAdmin", "kick", NICK, "execute", TextEntry:GetValue()) else RunConsoleCommand("_FAdmin", "kick", SteamID, "execute", TextEntry:GetValue()) end end
 
 		local ButtonCancel = vgui.Create("DButton", ButtonPanel )
 			ButtonCancel:SetText("Cancel")
@@ -261,7 +273,7 @@ FAdmin.StartHooks["CL_KickBan"] = function()
 			ButtonCancel:SetTall( 20 )
 			ButtonCancel:SetWide( Button:GetWide() + 20 )
 			ButtonCancel:SetPos( 5, 5 )
-			ButtonCancel.DoClick = function() Window:Close() RunConsoleCommand("FAdmin", "kick", SteamID, "cancel") end
+			ButtonCancel.DoClick = function() Window:Close() if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then RunConsoleCommand("FAdmin", "kick", NICK, "cancel") else RunConsoleCommand("FAdmin", "kick", SteamID, "cancel") end end
 			ButtonCancel:MoveRightOf( Button, 5 )
 
 		ButtonPanel:SetWide( Button:GetWide() + 5 + ButtonCancel:GetWide() + 10 )
@@ -289,6 +301,7 @@ FAdmin.StartHooks["CL_KickBan"] = function()
 	end)
 
 	-- Ban button
+	-- Not adding bot support here. I smell trouble if support is added.
 	FAdmin.ScoreBoard.Player:AddActionButton("Ban", "FAdmin/icons/Ban", nil, function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Ban", ply) end, function(ply)
 		local SteamID = ply:SteamID()
 		local NICK = ply:Nick()

--- a/gamemode/fadmin/playeractions/message/cl_init.lua
+++ b/gamemode/fadmin/playeractions/message/cl_init.lua
@@ -60,7 +60,11 @@ local function MessageGui(ply)
 	OK:AlignBottom(20)
 	function OK:DoClick()
 		frame:Close()
-		RunConsoleCommand("_FAdmin", "Message", ply:SteamID(), MsgType, TextBox:GetValue())
+		if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- Why am I even doing bot support for messages?
+			RunConsoleCommand("_FAdmin", "Message", ply:Nick(), MsgType, TextBox:GetValue())
+		else
+			RunConsoleCommand("_FAdmin", "Message", ply:SteamID(), MsgType, TextBox:GetValue())
+		end
 	end
 end
 

--- a/gamemode/fadmin/playeractions/noclip/cl_init.lua
+++ b/gamemode/fadmin/playeractions/noclip/cl_init.lua
@@ -19,9 +19,17 @@ FAdmin.StartHooks["zz_Noclip"] = function()
 
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "SetNoclip") end, function(ply, button)
 		if EnableDisableNoclip(ply) then
-			RunConsoleCommand("_FAdmin", "SetNoclip", ply:SteamID(), 0)
+			if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+				RunConsoleCommand("_FAdmin", "SetNoclip", ply:Nick(), 0)
+			else
+				RunConsoleCommand("_FAdmin", "SetNoclip", ply:SteamID(), 0)
+			end
 		else
-			RunConsoleCommand("_FAdmin", "SetNoclip", ply:SteamID(), 1)
+			if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+				RunConsoleCommand("_FAdmin", "SetNoclip", ply:Nick(), 1)
+			else
+				RunConsoleCommand("_FAdmin", "SetNoclip", ply:SteamID(), 1)
+			end
 		end
 
 		if EnableDisableNoclip(ply) then

--- a/gamemode/fadmin/playeractions/ragdoll/cl_init.lua
+++ b/gamemode/fadmin/playeractions/ragdoll/cl_init.lua
@@ -15,7 +15,11 @@ FAdmin.StartHooks["Ragdoll"] = function()
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Ragdoll", ply) end,
 	function(ply, button)
 		if ply:FAdmin_GetGlobal("fadmin_ragdolled") then
-			RunConsoleCommand("_FAdmin", "unragdoll", ply:SteamID())
+			if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+				RunConsoleCommand("_FAdmin", "unragdoll", ply:Nick())
+			else
+				RunConsoleCommand("_FAdmin", "unragdoll", ply:SteamID())
+			end
 			button:SetImage2("null")
 			button:SetText("Ragdoll")
 			button:GetParent():InvalidateLayout()
@@ -34,13 +38,21 @@ FAdmin.StartHooks["Ragdoll"] = function()
 			if v == "Unragdoll" then continue end
 			FAdmin.PlayerActions.addTimeSubmenu(menu, v,
 				function()
-					RunConsoleCommand("_FAdmin", "Ragdoll", ply:SteamID(), k)
+					if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+						RunConsoleCommand("_FAdmin", "Ragdoll", ply:Nick(), k)
+					else
+						RunConsoleCommand("_FAdmin", "Ragdoll", ply:SteamID(), k)
+					end
 					button:SetImage2("FAdmin/icons/disable")
 					button:SetText("Unragdoll")
 					button:GetParent():InvalidateLayout()
 				end,
 				function(secs)
-					RunConsoleCommand("_FAdmin", "Ragdoll", ply:SteamID(), k, secs)
+					if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+						RunConsoleCommand("_FAdmin", "Ragdoll", ply:Nick(), k, secs)
+					else
+						RunConsoleCommand("_FAdmin", "Ragdoll", ply:SteamID(), k, secs)
+					end
 					button:SetImage2("FAdmin/icons/disable")
 					button:SetText("Unragdoll")
 					button:GetParent():InvalidateLayout()

--- a/gamemode/fadmin/playeractions/slap/cl_init.lua
+++ b/gamemode/fadmin/playeractions/slap/cl_init.lua
@@ -7,7 +7,11 @@ FAdmin.StartHooks["Slap"] = function()
 
 	-- Right click option
 	FAdmin.ScoreBoard.Main.AddPlayerRightClick("Slap", function(ply)
-		RunConsoleCommand("_FAdmin", "Slap", ply:SteamID())
+		if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+			RunConsoleCommand("_FAdmin", "Slap", ply:Nick())
+		else
+			RunConsoleCommand("_FAdmin", "Slap", ply:SteamID())
+		end
 	end)
 
 	-- Slap option in player menu
@@ -22,7 +26,7 @@ FAdmin.StartHooks["Slap"] = function()
 		menu:AddPanel(Title)
 
 		for k,v in ipairs(Damages) do
-			local SubMenu = menu:AddSubMenu(v, function() RunConsoleCommand("_FAdmin", "slap", ply:SteamID(), v) end)
+			local SubMenu = menu:AddSubMenu(v, function() if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then RunConsoleCommand("_FAdmin", "slap", ply:Nick(), v) else RunConsoleCommand("_FAdmin", "slap", ply:SteamID(), v) end end)
 
 			local SubMenuTitle = vgui.Create("DLabel")
 			SubMenuTitle:SetText("  "..v .. " damage\n")
@@ -33,7 +37,7 @@ FAdmin.StartHooks["Slap"] = function()
 			SubMenu:AddPanel(SubMenuTitle)
 
 			for reps, Name in SortedPairs(Repetitions) do
-				SubMenu:AddOption(Name, function() RunConsoleCommand("_FAdmin", "slap", ply:SteamID(), v, reps) end)
+				SubMenu:AddOption(Name, function() if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then RunConsoleCommand("_FAdmin", "slap", ply:Nick(), v, reps) else RunConsoleCommand("_FAdmin", "slap", ply:SteamID(), v, reps) end end)
 			end
 		end
 		menu:Open()

--- a/gamemode/fadmin/playeractions/slay/cl_init.lua
+++ b/gamemode/fadmin/playeractions/slay/cl_init.lua
@@ -3,7 +3,11 @@ FAdmin.StartHooks["Slay"] = function()
 	FAdmin.Commands.AddCommand("Slay", nil, "<Player>", "[Normal/Silent/Explode/Rocket]")
 
 	FAdmin.ScoreBoard.Main.AddPlayerRightClick("Slay", function(ply)
-		RunConsoleCommand("_FAdmin", "slay", ply:SteamID())
+		if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+			RunConsoleCommand("_FAdmin", "slay", ply:Nick())
+		else
+			RunConsoleCommand("_FAdmin", "slay", ply:SteamID())
+		end
 	end)
 
 	FAdmin.ScoreBoard.Player:AddActionButton("Slay", "FAdmin/icons/slay", Color(255, 130, 0, 255),
@@ -20,7 +24,11 @@ FAdmin.StartHooks["Slay"] = function()
 
 		for k,v in pairs(FAdmin.PlayerActions.SlayTypes) do
 			menu:AddOption(v, function()
-				RunConsoleCommand("_FAdmin", "slay", ply:SteamID(), k)
+				if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+					RunConsoleCommand("_FAdmin", "slay", ply:Nick(), k)
+				else
+					RunConsoleCommand("_FAdmin", "slay", ply:SteamID(), k)
+				end
 			end)
 		end
 

--- a/gamemode/fadmin/playeractions/spectate/cl_init.lua
+++ b/gamemode/fadmin/playeractions/spectate/cl_init.lua
@@ -16,12 +16,20 @@ FAdmin.StartHooks["zzSpectate"] = function()
 
 	-- Right click option
 	FAdmin.ScoreBoard.Main.AddPlayerRightClick("Spectate", function(ply)
-		RunConsoleCommand("_FAdmin", "Spectate", ply:SteamID())
+		if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+			RunConsoleCommand("_FAdmin", "Spectate", ply:Nick())
+		else
+			RunConsoleCommand("_FAdmin", "Spectate", ply:SteamID())
+		end
 	end)
 
 	-- Slap option in player menu
 	FAdmin.ScoreBoard.Player:AddActionButton("Spectate", "FAdmin/icons/spectate", Color(0, 200, 0, 255), function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Spectate") and ply ~= LocalPlayer() end, function(ply)
-		RunConsoleCommand("_FAdmin", "Spectate", ply:SteamID())
+		if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+			RunConsoleCommand("_FAdmin", "Spectate", ply:Nick())
+		else
+			RunConsoleCommand("_FAdmin", "Spectate", ply:SteamID())
+		end
 	end)
 end
 
@@ -118,8 +126,11 @@ local function spectateLookingAt()
 	end
 
 	if not IsValid(foundPly) then return end
-
-	RunConsoleCommand("FAdmin", "Spectate", foundPly:SteamID())
+	if foundPly:SteamID() == "NULL" or foundPly:SteamID() == "BOT" or foundPly:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+		RunConsoleCommand("FAdmin", "Spectate", foundPly:Nick())
+	else
+		RunConsoleCommand("FAdmin", "Spectate", foundPly:SteamID())
+	end
 end
 
 /*---------------------------------------------------------------------------

--- a/gamemode/fadmin/playeractions/strip_weapons/cl_init.lua
+++ b/gamemode/fadmin/playeractions/strip_weapons/cl_init.lua
@@ -5,6 +5,10 @@ FAdmin.StartHooks["StripWeapons"] = function()
 
 	FAdmin.ScoreBoard.Player:AddActionButton("Strip weapons", {"FAdmin/icons/weapon", "FAdmin/icons/disable"}, Color(255, 130, 0, 255),
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "StripWeapons", ply) end, function(ply, button)
-		RunConsoleCommand("_FAdmin", "StripWeapons", ply:SteamID())
+		if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+			RunConsoleCommand("_FAdmin", "StripWeapons", ply:Nick())
+		else
+			RunConsoleCommand("_FAdmin", "StripWeapons", ply:SteamID())
+		end
 	end)
 end

--- a/gamemode/fadmin/playeractions/teleport/cl_init.lua
+++ b/gamemode/fadmin/playeractions/teleport/cl_init.lua
@@ -16,13 +16,21 @@ FAdmin.StartHooks["zz_Teleport"] = function()
 	FAdmin.ScoreBoard.Player:AddActionButton("Teleport", "FAdmin/icons/Teleport", Color(0, 200, 0, 255),
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Teleport")/* and ply == LocalPlayer()*/ end,
 	function(ply, button)
-		RunConsoleCommand("_FAdmin", "Teleport", ply:SteamID())
+		if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+			RunConsoleCommand("_FAdmin", "Teleport", ply:Nick())
+		else
+			RunConsoleCommand("_FAdmin", "Teleport", ply:SteamID())
+		end
 	end)
 
 	FAdmin.ScoreBoard.Player:AddActionButton("Goto", "FAdmin/icons/Teleport", Color(0, 200, 0, 255),
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Teleport") and ply ~= LocalPlayer() end,
 	function(ply, button)
-		RunConsoleCommand("_FAdmin", "goto", ply:SteamID())
+		if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- I'm almost certain its "" but idk... best to cover all bases.
+			RunConsoleCommand("_FAdmin", "goto", ply:Nick())
+		else
+			RunConsoleCommand("_FAdmin", "goto", ply:SteamID())
+		end
 	end)
 
 	FAdmin.ScoreBoard.Player:AddActionButton("Bring", "FAdmin/icons/Teleport", Color(0, 200, 0, 255),
@@ -38,10 +46,24 @@ FAdmin.StartHooks["zz_Teleport"] = function()
 
 		menu:AddPanel(Title)
 
-		menu:AddOption("Yourself", function() RunConsoleCommand("_FAdmin", "bring", ply:SteamID()) end)
+		menu:AddOption("Yourself", function() if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then RunConsoleCommand("_FAdmin", "bring", ply:Nick()) else RunConsoleCommand("_FAdmin", "bring", ply:SteamID()) end end)
 		for k, v in pairs(player.GetAll()) do
-			if v ~= LocalPlayer() then
-				menu:AddOption(v:Nick(), function() RunConsoleCommand("_FAdmin", "bring", ply:SteamID(), v:SteamID()) end)
+			if v ~= LocalPlayer() then -- Oh joy, Egypt inbound.
+				menu:AddOption(v:Nick(), function()
+					if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then
+						if v:SteamID() == "NULL" or v:SteamID() == "BOT" or v:SteamID() == "" then
+							RunConsoleCommand("_FAdmin", "bring", ply:Nick(), v:Nick())
+						else
+							RunConsoleCommand("_FAdmin", "bring", ply:Nick(), v:SteamID())
+						end
+					else
+						if v:SteamID() == "NULL" or v:SteamID() == "BOT" or v:SteamID() == "" then
+							RunConsoleCommand("_FAdmin", "bring", ply:SteamID(), v:Nick())
+						else
+							RunConsoleCommand("_FAdmin", "bring", ply:SteamID(), v:SteamID())
+						end
+					end
+				end)
 			end
 		end
 		menu:Open()

--- a/gamemode/fadmin/playeractions/voicemute/cl_init.lua
+++ b/gamemode/fadmin/playeractions/voicemute/cl_init.lua
@@ -23,13 +23,21 @@ FAdmin.StartHooks["Voicemute"] = function()
 	function(ply, button)
 		if not ply:FAdmin_GetGlobal("FAdmin_voicemuted") then
 			FAdmin.PlayerActions.addTimeMenu(function(secs)
-				RunConsoleCommand("_FAdmin", "Voicemute", ply:SteamID(), secs)
+				if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- Why am I supporting bots here?
+					RunConsoleCommand("_FAdmin", "Voicemute", ply:Nick(), secs)
+				else
+					RunConsoleCommand("_FAdmin", "Voicemute", ply:SteamID(), secs)
+				end
 				button:SetImage2("null")
 				button:SetText("Unmute voice")
 				button:GetParent():InvalidateLayout()
 			end)
 		else
-			RunConsoleCommand("_FAdmin", "UnVoicemute", ply:SteamID())
+			if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then -- Why am I supporting bots here?
+				RunConsoleCommand("_FAdmin", "UnVoicemute", ply:Nick())
+			else
+				RunConsoleCommand("_FAdmin", "UnVoicemute", ply:SteamID())
+			end
 		end
 
 		button:SetImage2("FAdmin/icons/disable")


### PR DESCRIPTION
Applied same fix to all of the FAdmin commands, and banning bots appears
to only kick them and say that they have been banned. Ragdolling bots
(kicking in the nuts indefinitely) can glitch the ragdoll button but
apart from that the fix is flawless.

Also the quick commands context menu works fine too. No more "Player not
found" errors.
