### PR TITLE
More fixes towards #912 (my proposed alternative to PR #917)

### DIFF
--- a/gamemode/fadmin/access/cl_init.lua
+++ b/gamemode/fadmin/access/cl_init.lua
@@ -49,7 +49,7 @@ FAdmin.StartHooks["1SetAccess"] = function() -- 1 in hook name so it will be exe
 		for k,v in SortedPairsByMemberValue(FAdmin.Access.Groups, "ADMIN", true) do
 			menu:AddOption(k, function()
 				if not IsValid(ply) then return end
-				RunConsoleCommand("_FAdmin", "setaccess", ply:SteamID(), k)
+				RunConsoleCommand("_FAdmin", "setaccess", ply:UserID(), k)
 			end)
 		end
 
@@ -134,7 +134,7 @@ ContinueNewGroup = function(ply, name, admin_access, func)
 	OKButton:StretchToParent(5, 30 + TickBoxPanel:GetTall(), Window:GetWide()/2 + 2, 5)
 	function OKButton:DoClick()
 		if ply then
-			RunConsoleCommand("_FAdmin", "setaccess", ply:SteamID(), name, admin_access, unpack(privs))
+			RunConsoleCommand("_FAdmin", "setaccess", ply:UserID(), name, admin_access, unpack(privs))
 		else
 			RunConsoleCommand("_FAdmin", "AddGroup", name, admin_access, unpack(privs))
 		end

--- a/gamemode/fadmin/playeractions/changeteam/cl_init.lua
+++ b/gamemode/fadmin/playeractions/changeteam/cl_init.lua
@@ -13,11 +13,7 @@ FAdmin.StartHooks["zzSetTeam"] = function()
 
 		menu:AddPanel(Title)
 		for k,v in SortedPairsByMemberValue(team.GetAllTeams(), "Name") do
-			if ply:SteamID() == "NULL" or ply:SteamID() == "BOT" or ply:SteamID() == "" then 
-				menu:AddOption(v.Name, function() RunConsoleCommand("_FAdmin", "setteam", ply:Nick(), k) end)
-			else
-				menu:AddOption(v.Name, function() RunConsoleCommand("_FAdmin", "setteam", ply:SteamID(), k) end)
-			end
+			menu:AddOption(v.Name, function() RunConsoleCommand("_FAdmin", "setteam", ply:UserID(), k) end)
 		end
 		menu:Open()
 	end)

--- a/gamemode/fadmin/playeractions/chatmute/cl_init.lua
+++ b/gamemode/fadmin/playeractions/chatmute/cl_init.lua
@@ -14,13 +14,13 @@ FAdmin.StartHooks["Chatmute"] = function()
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Chatmute", ply) end, function(ply, button)
 		if not ply:FAdmin_GetGlobal("FAdmin_chatmuted") then
 			FAdmin.PlayerActions.addTimeMenu(function(secs)
-				RunConsoleCommand("_FAdmin", "chatmute", ply:SteamID(), secs)
+				RunConsoleCommand("_FAdmin", "chatmute", ply:UserID(), secs)
 				button:SetImage2("null")
 				button:SetText("Unmute chat")
 				button:GetParent():InvalidateLayout()
 			end)
 		else
-			RunConsoleCommand("_FAdmin", "UnChatmute", ply:SteamID())
+			RunConsoleCommand("_FAdmin", "UnChatmute", ply:UserID())
 		end
 
 		button:SetImage2("FAdmin/icons/disable")

--- a/gamemode/fadmin/playeractions/cloak/cl_init.lua
+++ b/gamemode/fadmin/playeractions/cloak/cl_init.lua
@@ -13,9 +13,9 @@ FAdmin.StartHooks["zz_Cloak"] = function()
 
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Cloak", ply) end, function(ply, button)
 		if not ply:FAdmin_GetGlobal("FAdmin_cloaked") then
-			RunConsoleCommand("_FAdmin", "Cloak", ply:SteamID())
+			RunConsoleCommand("_FAdmin", "Cloak", ply:UserID())
 		else
-			RunConsoleCommand("_FAdmin", "Uncloak", ply:SteamID())
+			RunConsoleCommand("_FAdmin", "Uncloak", ply:UserID())
 		end
 
 		if not ply:FAdmin_GetGlobal("FAdmin_cloaked") then button:SetImage2("FAdmin/icons/disable") button:SetText("Uncloak") button:GetParent():InvalidateLayout() return end

--- a/gamemode/fadmin/playeractions/freeze/cl_init.lua
+++ b/gamemode/fadmin/playeractions/freeze/cl_init.lua
@@ -14,13 +14,13 @@ FAdmin.StartHooks["Freeze"] = function()
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Freeze", ply) end, function(ply, button)
 		if not ply:FAdmin_GetGlobal("FAdmin_frozen") then
 			FAdmin.PlayerActions.addTimeMenu(function(secs)
-				RunConsoleCommand("_FAdmin", "freeze", ply:SteamID(), secs)
+				RunConsoleCommand("_FAdmin", "freeze", ply:UserID(), secs)
 				button:SetImage2("FAdmin/icons/disable")
 				button:SetText("Unfreeze")
 				button:GetParent():InvalidateLayout()
 			end)
 		else
-			RunConsoleCommand("_FAdmin", "unfreeze", ply:SteamID())
+			RunConsoleCommand("_FAdmin", "unfreeze", ply:UserID())
 		end
 
 		button:SetImage2("null")

--- a/gamemode/fadmin/playeractions/giveweapons/cl_init.lua
+++ b/gamemode/fadmin/playeractions/giveweapons/cl_init.lua
@@ -13,7 +13,7 @@ local function GiveWeaponGui(ply)
 		if not ply:IsValid() then return end
 		local giveWhat = (IsAmmo and "ammo") or "weapon"
 
-		RunConsoleCommand("FAdmin", "give"..giveWhat, ply:SteamID(), SpawnName)
+		RunConsoleCommand("FAdmin", "give"..giveWhat, ply:UserID(), SpawnName)
 	end
 
 	WeaponMenu:BuildList()

--- a/gamemode/fadmin/playeractions/god/cl_init.lua
+++ b/gamemode/fadmin/playeractions/god/cl_init.lua
@@ -13,9 +13,9 @@ FAdmin.StartHooks["God"] = function()
 
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "God") end, function(ply, button)
 		if not ply:FAdmin_GetGlobal("FAdmin_godded") then
-			RunConsoleCommand("_FAdmin", "god", ply:SteamID())
+			RunConsoleCommand("_FAdmin", "god", ply:UserID())
 		else
-			RunConsoleCommand("_FAdmin", "ungod", ply:SteamID())
+			RunConsoleCommand("_FAdmin", "ungod", ply:UserID())
 		end
 
 		if not ply:FAdmin_GetGlobal("FAdmin_godded") then button:SetImage2("FAdmin/icons/disable") button:SetText("Ungod") button:GetParent():InvalidateLayout() return end

--- a/gamemode/fadmin/playeractions/health/cl_init.lua
+++ b/gamemode/fadmin/playeractions/health/cl_init.lua
@@ -13,7 +13,7 @@ FAdmin.StartHooks["Health"] = function()
 			local window = Derma_StringRequest("Select health", "What do you want the health of the person to be?", "",
 				function(text)
 					local health = tonumber(text or 100) or 100
-					RunConsoleCommand("_fadmin", "SetHealth", ply:SteamID(), health)
+					RunConsoleCommand("_fadmin", "SetHealth", ply:UserID(), health)
 				end
 			)
 

--- a/gamemode/fadmin/playeractions/ignite/cl_init.lua
+++ b/gamemode/fadmin/playeractions/ignite/cl_init.lua
@@ -9,12 +9,12 @@ FAdmin.StartHooks["Ignite"] = function()
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Ignite", ply) end,
 	function(ply, button)
 		if not ply:FAdmin_GetGlobal("FAdmin_ignited") then
-			RunConsoleCommand("_FAdmin", "ignite", ply:SteamID())
+			RunConsoleCommand("_FAdmin", "ignite", ply:UserID())
 			button:SetImage2("FAdmin/icons/disable")
 			button:SetText("Extinguish")
 			button:GetParent():InvalidateLayout()
 		else
-			RunConsoleCommand("_FAdmin", "unignite", ply:SteamID())
+			RunConsoleCommand("_FAdmin", "unignite", ply:UserID())
 			button:SetImage2("null")
 			button:SetText("Ignite")
 			button:GetParent():InvalidateLayout()

--- a/gamemode/fadmin/playeractions/jail/cl_init.lua
+++ b/gamemode/fadmin/playeractions/jail/cl_init.lua
@@ -4,7 +4,7 @@ FAdmin.StartHooks["Jail"] = function()
 	FAdmin.Commands.AddCommand("UnJail", nil, "<Player>")
 
 	FAdmin.ScoreBoard.Main.AddPlayerRightClick("Jail", function(ply)
-		RunConsoleCommand("_FAdmin", "jail", ply:SteamID())
+		RunConsoleCommand("_FAdmin", "jail", ply:UserID())
 	end)
 
 	FAdmin.ScoreBoard.Player:AddActionButton(function(ply)
@@ -18,7 +18,7 @@ FAdmin.StartHooks["Jail"] = function()
 	Color(255, 130, 0, 255),
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Jail", ply) end,
 	function(ply, button)
-		if ply:FAdmin_GetGlobal("fadmin_jailed") then RunConsoleCommand("_FAdmin", "unjail", ply:SteamID()) button:SetImage2("null") button:SetText("Jail") button:GetParent():InvalidateLayout() return end
+		if ply:FAdmin_GetGlobal("fadmin_jailed") then RunConsoleCommand("_FAdmin", "unjail", ply:UserID()) button:SetImage2("null") button:SetText("Jail") button:GetParent():InvalidateLayout() return end
 
 		local menu = DermaMenu()
 		local Title = vgui.Create("DLabel")
@@ -33,12 +33,12 @@ FAdmin.StartHooks["Jail"] = function()
 			if v == "Unjail" then continue end
 			FAdmin.PlayerActions.addTimeSubmenu(menu, v .. " jail",
 				function()
-					RunConsoleCommand("_FAdmin", "Jail", ply:SteamID(), k)
+					RunConsoleCommand("_FAdmin", "Jail", ply:UserID(), k)
 					button:SetText("Unjail") button:GetParent():InvalidateLayout()
 					button:SetImage2("FAdmin/icons/disable")
 				end,
 				function(secs)
-					RunConsoleCommand("_FAdmin", "Jail", ply:SteamID(), k, secs)
+					RunConsoleCommand("_FAdmin", "Jail", ply:UserID(), k, secs)
 					button:SetText("Unjail")
 					button:GetParent():InvalidateLayout()
 					button:SetImage2("FAdmin/icons/disable")

--- a/gamemode/fadmin/playeractions/kickban/cl_init.lua
+++ b/gamemode/fadmin/playeractions/kickban/cl_init.lua
@@ -204,7 +204,7 @@ FAdmin.StartHooks["CL_KickBan"] = function()
 	FAdmin.Commands.AddCommand("unban", "<SteamID>")
 
 	FAdmin.ScoreBoard.Main.AddPlayerRightClick("Quick Kick", function(ply, Panel)
-		RunConsoleCommand("_FAdmin", "kick", ply:SteamID(), "Quick kick")
+		RunConsoleCommand("_FAdmin", "kick", ply:UserID(), "Quick kick")
 		if ValidPanel(Panel) then Panel:Remove() end
 	end)
 
@@ -212,10 +212,10 @@ FAdmin.StartHooks["CL_KickBan"] = function()
 	-- Kick button
 	FAdmin.ScoreBoard.Player:AddActionButton("Kick", "FAdmin/icons/kick", nil, function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Kick", ply) end, function(ply)
 		if not IsValid(ply) then return end
-		local SteamID = ply:SteamID()
+		local UserID = ply:UserID()
 		local NICK = ply:Nick()
 
-		RunConsoleCommand("FAdmin", "kick", SteamID, "start")
+		RunConsoleCommand("FAdmin", "kick", UserID, "start")
 		local Window = vgui.Create("DFrame")
 		Window:SetTitle("Reason for kicking")
 		Window:SetDraggable( false )
@@ -233,10 +233,10 @@ FAdmin.StartHooks["CL_KickBan"] = function()
 
 		local TextEntry = vgui.Create("DTextEntry", InnerPanel )
 			function TextEntry:OnTextChanged()
-				RunConsoleCommand("_FAdmin", "kick", SteamID, "update", self:GetValue())
+				RunConsoleCommand("_FAdmin", "kick", UserID, "update", self:GetValue())
 			end
 			TextEntry:SetText("Enter reason here")
-			TextEntry.OnEnter = function() Window:Close() RunConsoleCommand("_FAdmin", "kick", SteamID, "execute", TextEntry:GetValue()) end
+			TextEntry.OnEnter = function() Window:Close() RunConsoleCommand("_FAdmin", "kick", UserID, "execute", TextEntry:GetValue()) end
 			function TextEntry:OnFocusChanged(changed)
 				self:RequestFocus()
 				self:SelectAllText(true)
@@ -253,7 +253,7 @@ FAdmin.StartHooks["CL_KickBan"] = function()
 			Button:SetTall( 20 )
 			Button:SetWide( Button:GetWide() + 20 )
 			Button:SetPos( 5, 5 )
-			Button.DoClick = function() Window:Close() RunConsoleCommand("_FAdmin", "kick", SteamID, "execute", TextEntry:GetValue()) end
+			Button.DoClick = function() Window:Close() RunConsoleCommand("_FAdmin", "kick", UserID, "execute", TextEntry:GetValue()) end
 
 		local ButtonCancel = vgui.Create("DButton", ButtonPanel )
 			ButtonCancel:SetText("Cancel")
@@ -261,7 +261,7 @@ FAdmin.StartHooks["CL_KickBan"] = function()
 			ButtonCancel:SetTall( 20 )
 			ButtonCancel:SetWide( Button:GetWide() + 20 )
 			ButtonCancel:SetPos( 5, 5 )
-			ButtonCancel.DoClick = function() Window:Close() RunConsoleCommand("FAdmin", "kick", SteamID, "cancel") end
+			ButtonCancel.DoClick = function() Window:Close() RunConsoleCommand("FAdmin", "kick", UserID, "cancel") end
 			ButtonCancel:MoveRightOf( Button, 5 )
 
 		ButtonPanel:SetWide( Button:GetWide() + 5 + ButtonCancel:GetWide() + 10 )
@@ -313,7 +313,7 @@ FAdmin.StartHooks["CL_KickBan"] = function()
 		BanList:AddColumn("SteamID")
 		BanList:AddColumn("Name")
 		BanList:AddColumn("Time")
-				BanList:AddColumn("Reason")
+		BanList:AddColumn("Reason")
 		BanList:AddColumn("Banned by")
 		BanList:AddColumn("Banned by SteamID")
 

--- a/gamemode/fadmin/playeractions/message/cl_init.lua
+++ b/gamemode/fadmin/playeractions/message/cl_init.lua
@@ -69,7 +69,7 @@ FAdmin.StartHooks["zzSendMessage"] = function()
 	FAdmin.Commands.AddCommand("Message", nil, "<Player>", "[type]", "<text>")
 
 	FAdmin.ScoreBoard.Player:AddActionButton("Send message", "FAdmin/icons/Message", Color(0, 200, 0, 255),
-		function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Message") end, function(ply, button)
+		function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Message") and not ply:IsBot() end, function(ply, button)
 			MessageGui(ply)
 		end
 	)

--- a/gamemode/fadmin/playeractions/noclip/cl_init.lua
+++ b/gamemode/fadmin/playeractions/noclip/cl_init.lua
@@ -19,9 +19,9 @@ FAdmin.StartHooks["zz_Noclip"] = function()
 
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "SetNoclip") end, function(ply, button)
 		if EnableDisableNoclip(ply) then
-			RunConsoleCommand("_FAdmin", "SetNoclip", ply:SteamID(), 0)
+			RunConsoleCommand("_FAdmin", "SetNoclip", ply:UserID(), 0)
 		else
-			RunConsoleCommand("_FAdmin", "SetNoclip", ply:SteamID(), 1)
+			RunConsoleCommand("_FAdmin", "SetNoclip", ply:UserID(), 1)
 		end
 
 		if EnableDisableNoclip(ply) then

--- a/gamemode/fadmin/playeractions/ragdoll/cl_init.lua
+++ b/gamemode/fadmin/playeractions/ragdoll/cl_init.lua
@@ -15,7 +15,7 @@ FAdmin.StartHooks["Ragdoll"] = function()
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Ragdoll", ply) end,
 	function(ply, button)
 		if ply:FAdmin_GetGlobal("fadmin_ragdolled") then
-			RunConsoleCommand("_FAdmin", "unragdoll", ply:SteamID())
+			RunConsoleCommand("_FAdmin", "unragdoll", ply:UserID())
 			button:SetImage2("null")
 			button:SetText("Ragdoll")
 			button:GetParent():InvalidateLayout()
@@ -34,13 +34,13 @@ FAdmin.StartHooks["Ragdoll"] = function()
 			if v == "Unragdoll" then continue end
 			FAdmin.PlayerActions.addTimeSubmenu(menu, v,
 				function()
-					RunConsoleCommand("_FAdmin", "Ragdoll", ply:SteamID(), k)
+					RunConsoleCommand("_FAdmin", "Ragdoll", ply:UserID(), k)
 					button:SetImage2("FAdmin/icons/disable")
 					button:SetText("Unragdoll")
 					button:GetParent():InvalidateLayout()
 				end,
 				function(secs)
-					RunConsoleCommand("_FAdmin", "Ragdoll", ply:SteamID(), k, secs)
+					RunConsoleCommand("_FAdmin", "Ragdoll", ply:UserID(), k, secs)
 					button:SetImage2("FAdmin/icons/disable")
 					button:SetText("Unragdoll")
 					button:GetParent():InvalidateLayout()

--- a/gamemode/fadmin/playeractions/slap/cl_init.lua
+++ b/gamemode/fadmin/playeractions/slap/cl_init.lua
@@ -7,7 +7,7 @@ FAdmin.StartHooks["Slap"] = function()
 
 	-- Right click option
 	FAdmin.ScoreBoard.Main.AddPlayerRightClick("Slap", function(ply)
-		RunConsoleCommand("_FAdmin", "Slap", ply:SteamID())
+		RunConsoleCommand("_FAdmin", "Slap", ply:UserID())
 	end)
 
 	-- Slap option in player menu
@@ -22,7 +22,7 @@ FAdmin.StartHooks["Slap"] = function()
 		menu:AddPanel(Title)
 
 		for k,v in ipairs(Damages) do
-			local SubMenu = menu:AddSubMenu(v, function() RunConsoleCommand("_FAdmin", "slap", ply:SteamID(), v) end)
+			local SubMenu = menu:AddSubMenu(v, function() RunConsoleCommand("_FAdmin", "slap", ply:UserID(), v) end)
 
 			local SubMenuTitle = vgui.Create("DLabel")
 			SubMenuTitle:SetText("  "..v .. " damage\n")
@@ -33,7 +33,7 @@ FAdmin.StartHooks["Slap"] = function()
 			SubMenu:AddPanel(SubMenuTitle)
 
 			for reps, Name in SortedPairs(Repetitions) do
-				SubMenu:AddOption(Name, function() RunConsoleCommand("_FAdmin", "slap", ply:SteamID(), v, reps) end)
+				SubMenu:AddOption(Name, function() RunConsoleCommand("_FAdmin", "slap", ply:UserID(), v, reps) end)
 			end
 		end
 		menu:Open()

--- a/gamemode/fadmin/playeractions/slay/cl_init.lua
+++ b/gamemode/fadmin/playeractions/slay/cl_init.lua
@@ -3,7 +3,7 @@ FAdmin.StartHooks["Slay"] = function()
 	FAdmin.Commands.AddCommand("Slay", nil, "<Player>", "[Normal/Silent/Explode/Rocket]")
 
 	FAdmin.ScoreBoard.Main.AddPlayerRightClick("Slay", function(ply)
-		RunConsoleCommand("_FAdmin", "slay", ply:SteamID())
+		RunConsoleCommand("_FAdmin", "slay", ply:UserID())
 	end)
 
 	FAdmin.ScoreBoard.Player:AddActionButton("Slay", "FAdmin/icons/slay", Color(255, 130, 0, 255),
@@ -20,7 +20,7 @@ FAdmin.StartHooks["Slay"] = function()
 
 		for k,v in pairs(FAdmin.PlayerActions.SlayTypes) do
 			menu:AddOption(v, function()
-				RunConsoleCommand("_FAdmin", "slay", ply:SteamID(), k)
+				RunConsoleCommand("_FAdmin", "slay", ply:UserID(), k)
 			end)
 		end
 

--- a/gamemode/fadmin/playeractions/spectate/cl_init.lua
+++ b/gamemode/fadmin/playeractions/spectate/cl_init.lua
@@ -16,12 +16,12 @@ FAdmin.StartHooks["zzSpectate"] = function()
 
 	-- Right click option
 	FAdmin.ScoreBoard.Main.AddPlayerRightClick("Spectate", function(ply)
-		RunConsoleCommand("_FAdmin", "Spectate", ply:SteamID())
+		RunConsoleCommand("_FAdmin", "Spectate", ply:UserID())
 	end)
 
-	-- Slap option in player menu
+	-- Spectate option in player menu
 	FAdmin.ScoreBoard.Player:AddActionButton("Spectate", "FAdmin/icons/spectate", Color(0, 200, 0, 255), function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Spectate") and ply ~= LocalPlayer() end, function(ply)
-		RunConsoleCommand("_FAdmin", "Spectate", ply:SteamID())
+		RunConsoleCommand("_FAdmin", "Spectate", ply:UserID())
 	end)
 end
 

--- a/gamemode/fadmin/playeractions/strip_weapons/cl_init.lua
+++ b/gamemode/fadmin/playeractions/strip_weapons/cl_init.lua
@@ -5,6 +5,6 @@ FAdmin.StartHooks["StripWeapons"] = function()
 
 	FAdmin.ScoreBoard.Player:AddActionButton("Strip weapons", {"FAdmin/icons/weapon", "FAdmin/icons/disable"}, Color(255, 130, 0, 255),
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "StripWeapons", ply) end, function(ply, button)
-		RunConsoleCommand("_FAdmin", "StripWeapons", ply:SteamID())
+		RunConsoleCommand("_FAdmin", "StripWeapons", ply:UserID())
 	end)
 end

--- a/gamemode/fadmin/playeractions/teleport/cl_init.lua
+++ b/gamemode/fadmin/playeractions/teleport/cl_init.lua
@@ -16,13 +16,13 @@ FAdmin.StartHooks["zz_Teleport"] = function()
 	FAdmin.ScoreBoard.Player:AddActionButton("Teleport", "FAdmin/icons/Teleport", Color(0, 200, 0, 255),
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Teleport")/* and ply == LocalPlayer()*/ end,
 	function(ply, button)
-		RunConsoleCommand("_FAdmin", "Teleport", ply:SteamID())
+		RunConsoleCommand("_FAdmin", "Teleport", ply:UserID())
 	end)
 
 	FAdmin.ScoreBoard.Player:AddActionButton("Goto", "FAdmin/icons/Teleport", Color(0, 200, 0, 255),
 	function(ply) return FAdmin.Access.PlayerHasPrivilege(LocalPlayer(), "Teleport") and ply ~= LocalPlayer() end,
 	function(ply, button)
-		RunConsoleCommand("_FAdmin", "goto", ply:SteamID())
+		RunConsoleCommand("_FAdmin", "goto", ply:UserID())
 	end)
 
 	FAdmin.ScoreBoard.Player:AddActionButton("Bring", "FAdmin/icons/Teleport", Color(0, 200, 0, 255),
@@ -38,10 +38,10 @@ FAdmin.StartHooks["zz_Teleport"] = function()
 
 		menu:AddPanel(Title)
 
-		menu:AddOption("Yourself", function() RunConsoleCommand("_FAdmin", "bring", ply:SteamID()) end)
+		menu:AddOption("Yourself", function() RunConsoleCommand("_FAdmin", "bring", ply:UserID()) end)
 		for k, v in pairs(player.GetAll()) do
 			if v ~= LocalPlayer() then
-				menu:AddOption(v:Nick(), function() RunConsoleCommand("_FAdmin", "bring", ply:SteamID(), v:SteamID()) end)
+				menu:AddOption(v:Nick(), function() RunConsoleCommand("_FAdmin", "bring", ply:UserID(), v:UserID()) end)
 			end
 		end
 		menu:Open()

--- a/gamemode/fadmin/playeractions/voicemute/cl_init.lua
+++ b/gamemode/fadmin/playeractions/voicemute/cl_init.lua
@@ -23,13 +23,13 @@ FAdmin.StartHooks["Voicemute"] = function()
 	function(ply, button)
 		if not ply:FAdmin_GetGlobal("FAdmin_voicemuted") then
 			FAdmin.PlayerActions.addTimeMenu(function(secs)
-				RunConsoleCommand("_FAdmin", "Voicemute", ply:SteamID(), secs)
+				RunConsoleCommand("_FAdmin", "Voicemute", ply:UserID(), secs)
 				button:SetImage2("null")
 				button:SetText("Unmute voice")
 				button:GetParent():InvalidateLayout()
 			end)
 		else
-			RunConsoleCommand("_FAdmin", "UnVoicemute", ply:SteamID())
+			RunConsoleCommand("_FAdmin", "UnVoicemute", ply:UserID())
 		end
 
 		button:SetImage2("FAdmin/icons/disable")


### PR DESCRIPTION
Here's my proposed alternative to PR #917 that does not include a lot of extra if logic. It simply makes use of `UserID` which is unique throughout the uptime of the server for bots as well as players. It was also hook into as FAdmin.FindPlayer already accepts User IDs which means that Steam IDs will still work - I did not touch the commands themselves.

This fixes all issues connecting to #912.
