### PR TITLE
Fixed createPlayerData 'name' argument being documented as the wrong type.

### DIFF
--- a/gamemode/modules/base/sv_interface.lua
+++ b/gamemode/modules/base/sv_interface.lua
@@ -87,7 +87,7 @@ DarkRP.createPlayerData = DarkRP.stub{
 		{
 			name = "name",
 			description = "The name of the player.",
-			type = "name",
+			type = "string",
 			optional = false
 		},
 		{


### PR DESCRIPTION
'name' is not a valid type.
