### PR TITLE
Workaround F1 HTML controls being broken.

### DIFF
--- a/gamemode/modules/f1menu/cl_f1menupanel.lua
+++ b/gamemode/modules/f1menu/cl_f1menupanel.lua
@@ -24,10 +24,10 @@ function PANEL:Init()
 	self.lblWiki = vgui.Create("F1MenuTitleLabel", self)
 	self.lblWiki:SetText(DarkRP.getPhrase("f1WikiTitle"))
 
-	self.htmlWikiControls = vgui.Create("DHTMLControls", self)
+	self.htmlWikiControls = vgui.Create("F1HTMLControls", self)
 	self.htmlWikiControls.HomeURL = GAMEMODE.Config.F1MenuHelpPage
 
-	self.htmlWiki = vgui.Create("HTML", self)
+	self.htmlWiki = vgui.Create("F1HTML", self)
 	self.htmlWiki:OpenURL(GAMEMODE.Config.F1MenuHelpPage)
 	self.htmlWikiControls:SetHTML(self.htmlWiki)
 end
@@ -93,7 +93,7 @@ end
 function PANEL:Paint()
 	local x, y = self:GetPos()
 	local w, h = self:GetSize()
-	draw.RoundedBox(4, 0, 0, w, h, self:GetBackgroundColor())
+	draw.RoundedBoxEx(4, 0, 0, w, h, self:GetBackgroundColor(), false, true, false, true)
 end
 
 derma.DefineControl("F1MenuPanel", "", PANEL, "EditablePanel")

--- a/gamemode/modules/f1menu/cl_htmlcontrols.lua
+++ b/gamemode/modules/f1menu/cl_htmlcontrols.lua
@@ -1,0 +1,129 @@
+surface.CreateFont ("F1AddressBar", {
+		size = 14,
+		weight = 400,
+		antialias = true,
+		shadow = false,
+		font = "coolvetica"})
+
+local PANEL = {}
+
+function PANEL:Init()
+	self.BaseClass.Init(self)
+
+	self.history = {}
+	self.currentIndex = 0
+
+	self:AddFunction("darkrp", "urlLoaded", function(url)
+		self:urlLoaded(url)
+	end)
+end
+
+function PANEL:Think()
+	self.BaseClass.Think(self)
+
+	if self.loaded and self:IsLoading() then
+		self.loaded = false
+	elseif not self.loaded and not self:IsLoading() then
+		self.loaded = true
+		self:QueueJavascript([[darkrp.urlLoaded(document.location.href)]])
+	end
+end
+
+function PANEL:OpenURL(url, noHistory)
+	self.noHistory = noHistory == nil and false or noHistory
+
+	self.BaseClass.OpenURL(self, url)
+end
+
+function PANEL:urlLoaded(url)
+	if not self.noHistory and self.history[self.currentIndex] ~= url then
+		if #self.history > self.currentIndex then
+			for i=self.currentIndex+1,#self.history do
+				self.history[i] = nil
+			end
+		end
+		self.currentIndex = self.currentIndex + 1
+		self.history[self.currentIndex] = url
+	end
+
+	self.noHistory = false
+	self.URL = url
+end
+
+function PANEL:HTMLBack()
+	if self.currentIndex <= 1 then return end
+	self.currentIndex = self.currentIndex - 1
+	self:OpenURL(self.history[self.currentIndex], true)
+end
+
+function PANEL:HTMLForward()
+	if self.currentIndex >= #self.history then return end
+	self.currentIndex = self.currentIndex + 1
+	self:OpenURL(self.history[self.currentIndex], true)
+end
+
+function PANEL:Refresh()
+	self:OpenURL(self.URL, true)
+end
+
+derma.DefineControl("F1HTML", "HTML Derma is fucking broken. Let's fix that.", PANEL, "DHTML")
+
+local PANEL = {}
+
+function PANEL:Init()
+	self.BackButton:SetDisabled(true)
+	self.ForwardButton:SetDisabled(true)
+	self.RefreshButton:SetDisabled(true)
+	self.HomeButton:SetDisabled(true)
+	self.StopButton:Remove()
+	self.AddressBar:DockMargin(0, 6, 6, 6)
+	self.AddressBar:SetFont("F1AddressBar")
+	self.AddressBar:SetTextColor(Color(255, 255, 255, 255))
+end
+
+function PANEL:Think()
+	if self.HTML and self.htmlLoaded and self.HTML:IsLoading() then
+		self.htmlLoaded = false
+		self:StartedLoading()
+	elseif self.HTML and not self.htmlLoaded and not self.HTML:IsLoading() then
+		self.htmlLoaded = true
+	end
+end
+
+function PANEL:SetHTML(html)
+	local oldOpeningURL = html.OpeningURL
+	local oldFinishedURL = html.FinishedURL
+	self.BaseClass.SetHTML(self, html)
+	self.HTML.OpeningURL = oldOpeningURL
+	self.HTML.FinishedURL = oldFinishedURL
+
+	local oldUrlLoaded = self.HTML.urlLoaded
+	self.HTML.urlLoaded = function(panel, url)
+		if oldUrlLoaded then oldUrlLoaded(panel, url) end
+		self:FinishedLoading()
+	end
+end
+
+function PANEL:StartedLoading()
+	self.BackButton:SetDisabled(true)
+	self.ForwardButton:SetDisabled(true)
+	self.RefreshButton:SetDisabled(true)
+	self.HomeButton:SetDisabled(true)
+end
+
+function PANEL:FinishedLoading()
+	self.RefreshButton:SetDisabled(false)
+	self.HomeButton:SetDisabled(false)
+	self:UpdateNavButtonStatus()
+end
+
+function PANEL:UpdateHistory(url)
+	-- Do nothing.
+end
+
+function PANEL:UpdateNavButtonStatus()
+	self.BackButton:SetDisabled(self.HTML.currentIndex <= 1)
+	self.ForwardButton:SetDisabled(self.HTML.currentIndex >= #self.HTML.history)
+end
+
+derma.DefineControl("F1HTMLControls", "HTML Derma is fucking broken. Let's fix that.", PANEL, "DHTMLControls")


### PR DESCRIPTION
I decided to keep this separate from my misc-fixes branch as this is a workaround rather than a fix.

I doubt HTML events will be fixed anytime soon. Especially since Garry is working on Rust 24/7.

What I did was create my own history system and basic event system which seems to work without problems through my testing. However, stop is still broken. I removed the button - I don't think we can fix this. Other than that it seems to work nicely.

I also made the address bar font a bit nicer at some resolutions. On some resolutions the default address bar font just looked like shit before. I also made it a readable colour (white) rather than black on dark grey.

The controls are called F1HTML and F1HTMLControls and are drop-in replacements. But I've already changed that in the F1 menu panel anyway.

If Garry does fix the events then this shouldn't break all of a sudden but I cannot guarantee that without testing. It's a workaround though so it should be removed once it's properly fixed.
