### PR TITLE
Fixed adminweapons not working as intended

### DIFF
--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -121,7 +121,7 @@ function GM:PlayerSpawnSENT(ply, model)
 end
 
 local function canSpawnWeapon(ply, class)
-	if (not GAMEMODE.Config.adminweapons == 0 and ply:IsAdmin()) or
+	if (GAMEMODE.Config.adminweapons == 0 and ply:IsAdmin()) or
 	(GAMEMODE.Config.adminweapons == 1 and ply:IsSuperAdmin()) then
 		return true
 	end


### PR DESCRIPTION
When config.adminweapons was set to 0, which is defined as "admin only"
in the config addon, neither regular nor superadmins were able to spawn
weapons.

"-- adminweapons - Who can spawn weapons: 0: admins only, 1: supadmins
only, 2: no one"
