### PR TITLE
Fixed keyboard input controls (like DTextEntry) not working in the F4 menu.

### DIFF
--- a/gamemode/modules/f4menu/cl_frame.lua
+++ b/gamemode/modules/f4menu/cl_frame.lua
@@ -160,4 +160,5 @@ function PANEL:generateTabs()
 	self:SetSkin(GAMEMODE.Config.DarkRPSkin)
 end
 
-derma.DefineControl("F4MenuFrame", "", PANEL, "DPropertySheet")
+derma.DefineControl("F4EditablePropertySheet", "", vgui.GetControlTable("DPropertySheet"), "EditablePanel")
+derma.DefineControl("F4MenuFrame", "", PANEL, "F4EditablePropertySheet")


### PR DESCRIPTION
- Fixed keyboard input controls (like DTextEntry) not working in the F4 menu.
