### PR TITLE
Fixed some Spawn Icons in the giveweapons module

### DIFF
--- a/gamemode/modules/fadmin/fadmin/playeractions/giveweapons/cl_controls.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/giveweapons/cl_controls.lua
@@ -36,7 +36,7 @@ end
 
 function PANEL:CreateAdminIcon()
 	self.imgAdmin = vgui.Create("DImage", self)
-	self.imgAdmin:SetImage("gui/silkicons/shield")
+	self.imgAdmin:SetImage("icon16/shield.png") -- SilkIcons are now merged into GMOD as materials/icon16
 	self.imgAdmin:SetTooltip("#Admin Only")
 end
 
@@ -95,7 +95,7 @@ function PANEL2:BuildList()
 
 		for k, v in SortedPairs(FAdmin.AmmoTypes) do
 			local Icon = vgui.CreateFromTable(WeaponIcon, self)
-			Icon:Setup(k, k, "vgui/achievements/ep1_beat_game_onebullet", false, self, true)
+			Icon:Setup(k, k, "spawnicons/models/items/boxmrounds60x60.png", false, self, true) -- Gets created clientside by GMOD when someone is after that model, or trying to buy ammo.
 			AmmoPan:AddItem(Icon)
 		end
 	end


### PR DESCRIPTION
... Again.

Didn't I already do this? Falco, silkicons are now built into GMOD. The
evidence is in my old SRCDS folder.

And vgui/achievements/ep1_beat_game_onebullet is no longer in GMOD for
clients. We cant FastDL it as thats copyright issues as previously
discussed, so we need to use a different image. The ammobox works fine
for now, until someone feels like finding something better.

For everyone else, this removes missing textures from spawn icons in the "Give Weapon" menu in fadmin.,, or atleast, it removes some missing textures such as admin only icons and ammo. Still thinking about finding an "Unknown weapon" icon.
