### PR TITLE
Fixed doc error: "getKeysDoorOwners" -> "getKeysCoOwners"

### DIFF
--- a/gamemode/modules/doorsystem/sh_interface.lua
+++ b/gamemode/modules/doorsystem/sh_interface.lua
@@ -248,7 +248,7 @@ DarkRP.ENTITY.getKeysAllowedToOwn = DarkRP.stub{
 }
 
 DarkRP.ENTITY.getKeysCoOwners = DarkRP.stub{
-	name = "getKeysDoorOwners",
+	name = "getKeysCoOwners",
 	description = "The list of people who co-own the door.",
 	parameters = {
 	},


### PR DESCRIPTION
Entity.getKeysDoorOwners does not exist.
