### PR TITLE
Fixed help file pointing modders to 2.4.3 docs and to the DarkRP directory rather than DarkRPMod addon.

### DIFF
--- a/HELP/Avoid editing core files.txt
+++ b/HELP/Avoid editing core files.txt
@@ -6,9 +6,9 @@ If this isn't possible, it should be MADE possible.
 
 Open an issue on GitHub if there is no
 - DarkRP function that allows you to change DarkRP the way you want:
-	http://wiki.darkrp.com/index.php/DarkRP:Functions
+	http://wiki.darkrp.com/index.php/Category:Functions
 - DarkRP Hook that allows you to change DarkRP the way you want:
-	http://wiki.darkrp.com/index.php/DarkRP:Hooks
+	http://wiki.darkrp.com/index.php/Category:Hooks
 
 /*---------------------------------------------------------------------------
             How to configure 


### PR DESCRIPTION
- Fixed help file pointing modders to the DarkRP directory rather than the DarkRPMod addon.
- Fixed help file pointing to 2.4.3 function & hook docs.
