### PR TITLE
Fixed some hooks after recent GMod dev update.

### DIFF
--- a/gamemode/libraries/database.lua
+++ b/gamemode/libraries/database.lua
@@ -216,7 +216,7 @@ function connectToMySQL(host, username, password, database_name, database_port)
 			end
 		end)
 
-		hook.Call("DatabaseInitialized")
+		hook.Call("DatabaseInitialized", GAMEMODE)
 	end
 	databaseObject:connect()
 end

--- a/gamemode/modules/chat/cl_chat.lua
+++ b/gamemode/modules/chat/cl_chat.lua
@@ -25,14 +25,14 @@ local function AddToChat(bits)
 	local shouldShow
 	if text and text ~= "" then
 		if IsValid(ply) then
-			shouldShow = hook.Call("OnPlayerChat", nil, ply, text, false, not ply:Alive(), prefixText, col1, col2)
+			shouldShow = hook.Call("OnPlayerChat", GAMEMODE, ply, text, false, not ply:Alive(), prefixText, col1, col2)
 		end
 
 		if shouldShow ~= true then
 			chat.AddNonParsedText(col1, prefixText, col2, ": "..text)
 		end
 	else
-		shouldShow = hook.Call("ChatText", nil, "0", prefixText, prefixText, "none")
+		shouldShow = hook.Call("ChatText", GAMEMODE, "0", prefixText, prefixText, "none")
 		if shouldShow ~= true then
 			chat.AddNonParsedText(col1, prefixText)
 		end


### PR DESCRIPTION
Following garrynewman/garrysmod#579, hook.Call no longer assumes a nil hook table is a GAMEMODE table. This means that the gamemode function will not call if you do not pass GAMEMODE into hook.Call (or you use hook.Run or gamemode.Call instead).
- MySQL was broken because of this. GM:DatabaseInitialized was not called which meant DarkRP.initDatabase was not called. Fixed in this PR.
- OnPlayerChat and ChatText hook calls now call the GM function again. They are GMod hooks rather than DarkRP hooks so they probably should call the GM function.

Everything else _seemed_ to work.
