### PR TITLE
Edit on line 78, fixed pocketing ragdolls.

### DIFF
--- a/entities/weapons/pocket/sv_init.lua
+++ b/entities/weapons/pocket/sv_init.lua
@@ -275,6 +275,7 @@ local function canPocket(ply, item)
 	if item.jailWall then return false, DarkRP.getPhrase("cannot_pocket_x") end
 	if GAMEMODE.Config.PocketBlacklist[class] then return false, DarkRP.getPhrase("cannot_pocket_x") end
 	if string.find(class, "func_") then return false, DarkRP.getPhrase("cannot_pocket_x") end
+	if item:IsRagdoll() then return false, DarkRP.getPhrase("cannot_pocket_x") end
 
 	local trace = ply:GetEyeTrace()
 	if ply:EyePos():Distance(trace.HitPos) > 150 then return false end


### PR DESCRIPTION
Ragdolls can be pocketed by default this can cause unexpected glitches such as the one specified here, Link: https://github.com/Nayruden/Ulysses/issues/279

---

Also I am going to take this opportunity to ask, why am I no longer credited for my avatar sizing fix? Link: https://github.com/FPtje/DarkRP/commit/3a3eed57c9c7f8348beaf1af8614479a4738cf6e come to think of it, its probably because I changed my name on Github...
