### PR TITLE
Updated DarkRP.getLaws documentation after structure change client side.

### DIFF
--- a/entities/entities/darkrp_laws/cl_init.lua
+++ b/entities/entities/darkrp_laws/cl_init.lua
@@ -23,7 +23,7 @@ function ENT:Draw()
 		local col = Color(255, 255, 255, 255)
 		local lastHeight = 0
 		for k,v in ipairs(Laws) do
-			draw.DrawNonParsedText(string.format("%s%s %s", k, ".", v), "TargetID", 5, 35 + lastHeight, col)
+			draw.DrawNonParsedText(string.format("%u. %s", k, v), "TargetID", 5, 35 + lastHeight, col)
 			lastHeight = lastHeight + ((fn.ReverseArgs(string.gsub(v, "\n", "")))+1)*21
 		end
 

--- a/entities/entities/darkrp_laws/shared.lua
+++ b/entities/entities/darkrp_laws/shared.lua
@@ -30,7 +30,7 @@ DarkRP.declareChatCommand{
 
 DarkRP.getLaws = DarkRP.stub{
 	name = "getLaws",
-	description = "Get the table of all current laws. While the law numbers are only found in the table keys serverside, the table also includes the law number in the table values on the client side.",
+	description = "Get the table of all current laws.",
 	parameters = {
 	},
 	returns = {


### PR DESCRIPTION
Following 812004e, the DarkRP.getLaws no longer returns the law number in the table values clientside. The documentation used to specifically mention this but now that it is no longer the case, this part is now removed.
