### PR TITLE
Updated Remove Class Items

### DIFF
--- a/gamemode/modules/jobs/sv_jobs.lua
+++ b/gamemode/modules/jobs/sv_jobs.lua
@@ -91,19 +91,15 @@ function meta:changeTeam(t, force)
 
 	self.LastJob = CurTime()
 
+	GAMEMODE.Config.ignoreClassItem = GAMEMODE.Config.ignoreClassItem or {}
 	if GAMEMODE.Config.removeclassitems then
-		for k, v in pairs(ents.FindByClass("microwave")) do
-			if v.allowed and type(v.allowed) == "table" and table.HasValue(v.allowed, t) then continue end
-			if v.SID == self.SID then v:Remove() end
-		end
-		for k, v in pairs(ents.FindByClass("gunlab")) do
-			if v.allowed and type(v.allowed) == "table" and table.HasValue(v.allowed, t) then continue end
-			if v.SID == self.SID then v:Remove() end
-		end
-
-		for k, v in pairs(ents.FindByClass("drug_lab")) do
-			if v.allowed and type(v.allowed) == "table" and table.HasValue(v.allowed, t) then continue end
-			if v.SID == self.SID then v:Remove() end
+		for k, v in pairs(DarkRPEntities) do
+			if GAMEMODE.Config.ignoreClassItem[v.ent] then continue end
+			if not v.allowed then continue end
+			if type(v.allowed) == "table" and (table.HasValue(v.allowed, t) or not table.HasValue(v.allowed, prevTeam)) then continue end
+			for _, e in pairs(ents.FindByClass(v.ent)) do
+				if e.SID == self.SID then e:Remove() end
+			end
 		end
 
 		for k,v in pairs(ents.FindByClass("spawned_shipment")) do


### PR DESCRIPTION
Now includes all class assigned items (not just the default dark rp entities) for class based removal.
Included additional config "ignoreClassItem" table to exclude the termination of specific class based entities. Format: GAMEMODE.Config.ignoreClassItem = { ["entityclass"] = true }
