### PR TITLE
Fixed Demotion Logging

### DIFF
--- a/gamemode/modules/jobs/sv_jobs.lua
+++ b/gamemode/modules/jobs/sv_jobs.lua
@@ -293,8 +293,7 @@ local function Demote(ply, args)
 		else
 			DarkRP.talkToPerson(p, team.GetColor(ply:Team()), DarkRP.getPhrase("demote") .. " " ..ply:Nick(),Color(255,0,0,255), DarkRP.getPhrase("i_want_to_demote_you", reason), p)
 			DarkRP.notifyAll(0, 4, DarkRP.getPhrase("demote_vote_started", ply:Nick(), p:Nick()))
-			DarkRP.log(DarkRP.getPhrase("demote_vote_started", ply:Nick(), p:Nick()) .. " (" .. reason .. ")",
-				false, Color(255, 128, 255, 255))
+			DarkRP.log(DarkRP.getPhrase("demote_vote_started", string.format("%s(%s)[%s]", ply:Nick(), ply:SteamID(), team.GetName(ply:Team())), string.format("%s(%s)[%s]", p:Nick(), p:SteamID(), team.GetName(p:Team()))) .. " for " ..  reason, Color(255, 128, 255, 255))
 			p.IsBeingDemoted = true
 
 			DarkRP.createVote(p:Nick() .. ":\n"..DarkRP.getPhrase("demote_vote_text", reason), "demote", p, 20, FinishDemote,


### PR DESCRIPTION
Additionally included the logging of the caller/target SteamID's and Team Name's

Being completely honest, all of the logging methods involving players should include their SteamID's considering people can change their RP Name potentially at will. Unless you want people playing detective looking through logs to find their ID from when they joined.
