### PR TITLE
No spam eating

### DIFF
--- a/entities/entities/spawned_food/init.lua
+++ b/entities/entities/spawned_food/init.lua
@@ -7,6 +7,7 @@ function ENT:Initialize()
 	self:PhysicsInit(SOLID_VPHYSICS)
 	self:SetMoveType(MOVETYPE_VPHYSICS)
 	self:SetSolid(SOLID_VPHYSICS)
+	self:SetUseType(SIMPLE_USE)
 	local phys = self:GetPhysicsObject()
 
 	phys:Wake()


### PR DESCRIPTION
Why is this not here by default? If you press E at a pile of food you eat it all at once, that's just silly.
