### PR TITLE
Added option to create hidden food in hurgermod

### DIFF
--- a/gamemode/modules/hungermod/cl_f4foodtab.lua
+++ b/gamemode/modules/hungermod/cl_f4foodtab.lua
@@ -14,6 +14,7 @@ end
 
 function PANEL:generateButtons()
 	for k,v in pairs(FoodItems) do
+		if v.hidden == true then continue end
 		local pnl = vgui.Create("F4MenuEntityButton", self)
 		pnl:setDarkRPItem(v)
 		pnl.DoClick = fn.Partial(RunConsoleCommand, "DarkRP", "buyfood", v.name)

--- a/gamemode/modules/hungermod/sh_init.lua
+++ b/gamemode/modules/hungermod/sh_init.lua
@@ -28,6 +28,7 @@ Valid members:
 	requiresCook = boolean, -- whether only cooks can buy this food
 	customCheck = function(ply) return boolean end, -- customCheck on purchase function
 	customCheckMessage = string -- message to people who cannot buy it because of the customCheck
+	hidden = boolean -- whether the food will be hidden or not on the F4 Food tab
 ]]
 DarkRP.DARKRP_LOADING = true
 


### PR DESCRIPTION
When the argument `hidden` is set to true the food will not be added to
the F4 Food tab, it's useful if someone wants to create custom food that
will only spawn under some custom reason and don't want it to be visible
to everyone.
