### PR TITLE
Duplicate Loadout Call

### DIFF
--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -668,7 +668,6 @@ function GM:PlayerSpawn(ply)
 	end
 
 	gamemode.Call("PlayerSetModel", ply)
-	gamemode.Call("PlayerLoadout", ply)
 
 	local _, pos = self:PlayerSelectSpawn(ply)
 	ply:SetPos(pos)


### PR DESCRIPTION
Line 617 Calls Loadout of PlayerSpawn. The removed line was only duplicating this.
