### PR TITLE
Add a hook to modify the doorInfo table

### DIFF
--- a/gamemode/modules/doorsystem/cl_doors.lua
+++ b/gamemode/modules/doorsystem/cl_doors.lua
@@ -68,7 +68,9 @@ function meta:drawOwnableInfo()
 			break
 		end
 	end
-
+	
+	hook.Call( "HUDModifyDoorData", nil, self, doorInfo )
+	
 	local x, y = ScrW()/2, ScrH() / 2
 	draw.DrawNonParsedText(table.concat(doorInfo, "\n"), "TargetID", x , y + 1 , black, 1)
 	draw.DrawNonParsedText(table.concat(doorInfo, "\n"), "TargetID", x, y, (blocked or owned) and white or red, 1)


### PR DESCRIPTION
Hook: HUDModifyDoorData
Arguments: Entity door, Table doorInfo
Returns: nil

Would be beneficial to have a way to modify this table so that scripts can modify what the door displays without having to manually draw everything themselves
