### PR TITLE
String exploit workaround fix for job name

### DIFF
--- a/gamemode/modules/jobs/sv_jobs.lua
+++ b/gamemode/modules/jobs/sv_jobs.lua
@@ -226,6 +226,11 @@ local function ChangeJob(ply, args)
 		DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("unable", "/job", "<26"))
 		return ""
 	end
+	
+	if not string.match(args, "^[a-zA-Z0-9-_ ]+$") then
+		DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("unable", "/job", "Bad name"))
+		return ""
+	end
 
 	local canChangeJob, message, replace = hook.Call("canChangeJob", nil, ply, args)
 	if canChangeJob == false then


### PR DESCRIPTION
Some Menus/GUIs/Scoreboards etc still do not sanitise the job name
leading to some strings being parsed incorrectly leading to an unwanted
outcome. This solution cures this problem at the root making it not
possible to enter bad strings for a job name.
