### PR TITLE
Trim whitespace on RPName

### DIFF
--- a/gamemode/modules/base/sv_entityvars.lua
+++ b/gamemode/modules/base/sv_entityvars.lua
@@ -155,7 +155,9 @@ local function RPName(ply, args)
 		DarkRP.notify(ply, 1, 6,  DarkRP.getPhrase("disabled", "RPname", ""))
 		return ""
 	end
-
+	
+	args = (args:find'^%s*$' and '' or args:match'^%s*(.*%S)')
+	
 	local len = string.len(args)
 	local low = string.lower(args)
 


### PR DESCRIPTION
This will reformat the args to not have leading or trailing spaces. This is to deter users from having names nearly matching others.
