### PR TITLE
Allow the price of a door be set on a per-door

### DIFF
--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -14,7 +14,7 @@ function GM:playerBuyDoor(ply, ent)
 end
 
 function GM:getDoorCost(ply, ent)
-	return GAMEMODE.Config.doorcost ~= 0 and GAMEMODE.Config.doorcost or 30
+	return ent.doorcost or GAMEMODE.Config.doorcost ~= 0 and GAMEMODE.Config.doorcost or 30
 end
 
 function GM:getVehicleCost(ply, ent)


### PR DESCRIPTION
This will allow doors to have their price set by scripts, allowing bigger building to be more expensive then a broom closet.
I'm not sure how to get this to be networked properly so I don't know how to make it work with the admin door menu.
