### PR TITLE
Prevents dropping more then 2147483647

### DIFF
--- a/gamemode/modules/money/sv_money.lua
+++ b/gamemode/modules/money/sv_money.lua
@@ -130,6 +130,11 @@ local function DropMoney(ply, args)
 		DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("invalid_x", "argument", ">1"))
 		return ""
 	end
+	
+	if amount <= 2147483647 then
+		DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("invalid_x", "argument", "<2,147,483,647"))
+		return ""
+	end
 
 	if not ply:canAfford(amount) then
 		DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("cant_afford", ""))


### PR DESCRIPTION
Money bags have a hard coded limit of 2147483647 meaning players dropping more then that lose any extra money.
This limits dropping of money to the hard coded limit.

Alternatively, the limit could be removed, although I am guessing it's limited to help with networking.
