### PR TITLE
Added function to get shipment by name

### DIFF
--- a/gamemode/modules/base/sh_createitems.lua
+++ b/gamemode/modules/base/sh_createitems.lua
@@ -471,6 +471,14 @@ AddDoorGroup = DarkRP.createEntityGroup
 
 CustomVehicles = {}
 CustomShipments = {}
+local shipByName = {}
+DarkRP.getShipmentByName = function(name)
+	name = string.lower(name or "")
+
+	if not shipByName[name] then return nil, nil end
+	return CustomShipments[shipByName[name]], shipByName[name]
+end
+
 function DarkRP.createShipment(name, model, entity, price, Amount_of_guns_in_one_shipment, Sold_seperately, price_seperately, noshipment, classes, shipmodel, CustomCheck)
 	local tableSyntaxUsed = type(model) == "table"
 
@@ -506,7 +514,7 @@ function DarkRP.createShipment(name, model, entity, price, Amount_of_guns_in_one
 	-- 	FPP.AddDefaultBlocked(blockTypes, customShipment.entity)
 	-- end
 
-	table.insert(CustomShipments, customShipment)
+	shipByName[string.lower(name or "")] = table.insert(CustomShipments, customShipment)
 	util.PrecacheModel(customShipment.model)
 end
 AddCustomShipment = DarkRP.createShipment

--- a/gamemode/modules/base/sv_purchasing.lua
+++ b/gamemode/modules/base/sv_purchasing.lua
@@ -41,17 +41,8 @@ local function BuyPistol(ply, args)
 		return ""
 	end
 
-	local shipment
-	for k, v in pairs(CustomShipments) do
-		if not v.seperate or string.lower(v.name) ~= string.lower(args) then
-			continue
-		end
-
-		shipment = v
-		break
-	end
-
-	if not shipment then
+	local shipment = DarkRP.getShipmentByName(args)
+	if not shipment or not shipment.seperate then
 		DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("unavailable", "weapon"))
 		return ""
 	end
@@ -144,16 +135,10 @@ local function BuyShipment(ply, args)
 		return ""
 	end
 
-	local found = false
-	local foundKey
-	for k,v in pairs(CustomShipments) do
-		if string.lower(args) ~= string.lower(v.name) or v.noship or not GAMEMODE:CustomObjFitsMap(v) then
-			continue
-		end
-
-		found = v
-		foundKey = k
-		break
+	local found, foundKey = DarkRP.getShipmentByName(args)
+	if not found or found.noship or not GAMEMODE:CustomObjFitsMap(found) then
+		DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("unavailable", "shipment"))
+		return ""
 	end
 
 	if not found then


### PR DESCRIPTION
If two or more shipments have no name, it will overwrite in the
shipByName table. Adding the name var to the validShipment check will
fix this.
