### PR TITLE
Added IsValid check for physics object

### DIFF
--- a/entities/entities/spawned_shipment/init.lua
+++ b/entities/entities/spawned_shipment/init.lua
@@ -32,7 +32,9 @@ function ENT:Initialize()
 	self:GetgunModel():SetParent(self)
 
 	phys = self:GetgunModel():GetPhysicsObject()
-	phys:EnableMotion(false)
+	if IsValid(phys) then
+		phys:EnableMotion(false)
+	end
 
 	-- The following code should not be reached
 	if self:Getcount() < 1 then


### PR DESCRIPTION
To prevent errors like this:
[ERROR] gamemodes/darkrp/entities/entities/spawned_shipment/init.lua:35: Tried to use invalid object (type IPhysicsObject) (Object was NULL or not of the right type)
