### PR TITLE
Renamed variable to match parameter

### DIFF
--- a/gamemode/modules/hitmenu/sv_init.lua
+++ b/gamemode/modules/hitmenu/sv_init.lua
@@ -78,7 +78,7 @@ end
 function plyMeta:abortHit(message)
 	if not hits[self] then error("This person has no active hit!") end
 
-	local message = message or ""
+	message = message or ""
 
 	hook.Call("onHitFailed", DarkRP.hooks, self, self:getHitTarget(), message)
 	DarkRP.notifyAll(0, 4, DarkRP.getPhrase("hit_aborted", message))


### PR DESCRIPTION
Probably fixes an error, as that seems to be the reason it's put there. Made variable local too.
