### PR TITLE
Fixed problem with door notification

### DIFF
--- a/gamemode/modules/doorsystem/sv_doors.lua
+++ b/gamemode/modules/doorsystem/sv_doors.lua
@@ -508,7 +508,7 @@ local function AddDoorOwner(ply, args)
 	end
 
 	if trace.Entity:isKeysOwnedBy(target) or trace.Entity:isKeysAllowedToOwn(target) then
-		DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("rp_addowner_already_owns_door", ply:Nick()))
+		DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("rp_addowner_already_owns_door", target:Nick()))
 		return ""
 	end
 


### PR DESCRIPTION
It should show the target's name in the notification, not the name of
the person who is running the command
