### PR TITLE
Fixed cam.End3D workaround logic error

### DIFF
--- a/gamemode/modules/workarounds/sh_workarounds.lua
+++ b/gamemode/modules/workarounds/sh_workarounds.lua
@@ -57,7 +57,7 @@ if CLIENT then
 
 	-- cam.End3D should not crash a player when 3D hasn't been started
 	function cam.End3D()
-		if not cam3DStarted then return end
+		if not cam3DStarted or cam3DStarted <= 0 then return end
 		cam3DStarted = cam3DStarted - 1
 		return camend3D()
 	end


### PR DESCRIPTION
Previously, it never returned because cam3DStarted was set to a number beforehand, therefore it was never nil.