### PR TITLE
Added link to darkrp forum in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 https://github.com/FPtje/DarkRP/wiki/HOW-TO-REPORT-ISSUES
 ======
+DO NOT ASK FOR HELP ON THE GITHUB! THE GITHUB IS FOR BUGS AND FEATURE REQUESTS ONLY! USE THE FORUM!
+http://forum.darkrp.com/
+
 READ THIS FOR MODIFYING DARKRP! VERY USEFUL WIKI!
 http://wiki.darkrp.com/index.php/Main_Page
 


### PR DESCRIPTION
I wonder if this may help reduce the number of times Falco has to reply
with "Not a help forum".

- Added a link to the forum to the README.MD file, as well as a reminder
that the github is NOT a place to request help, whereas the forum IS.