### PR TITLE
Changed trigger for Animation Menu

### DIFF
--- a/entities/weapons/keys/shared.lua
+++ b/entities/weapons/keys/shared.lua
@@ -101,6 +101,7 @@ function SWEP:PrimaryAttack()
 	local trace = self.Owner:GetEyeTrace()
 
 	if not lookingAtLockable(self.Owner, trace.Entity) then
+		if CLIENT then RunConsoleCommand("_DarkRP_AnimationMenu") end
 		return
 	end
 
@@ -122,6 +123,7 @@ function SWEP:SecondaryAttack()
 	local trace = self.Owner:GetEyeTrace()
 
 	if not lookingAtLockable(self.Owner, trace.Entity) then
+		if CLIENT then RunConsoleCommand("_DarkRP_AnimationMenu") end
 		return
 	end
 
@@ -142,12 +144,6 @@ end
 SWEP.OnceReload = false
 function SWEP:Reload()
 	local trace = self.Owner:GetEyeTrace()
-	
-	if not lookingAtLockable(self.Owner, trace.Entity) then
-		if CLIENT then RunConsoleCommand("_DarkRP_AnimationMenu") end
-		return
-	end
-	
 	if not IsValid(trace.Entity) or (IsValid(trace.Entity) and ((not trace.Entity:isDoor() and not trace.Entity:IsVehicle()) or self.Owner:EyePos():Distance(trace.HitPos) > 200)) then
 		if not self.OnceReload then
 			if SERVER then DarkRP.notify(self.Owner, 1, 3, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("door_or_vehicle"))) end

--- a/entities/weapons/keys/shared.lua
+++ b/entities/weapons/keys/shared.lua
@@ -101,7 +101,6 @@ function SWEP:PrimaryAttack()
 	local trace = self.Owner:GetEyeTrace()
 
 	if not lookingAtLockable(self.Owner, trace.Entity) then
-		if CLIENT then RunConsoleCommand("_DarkRP_AnimationMenu") end
 		return
 	end
 
@@ -123,7 +122,6 @@ function SWEP:SecondaryAttack()
 	local trace = self.Owner:GetEyeTrace()
 
 	if not lookingAtLockable(self.Owner, trace.Entity) then
-		if CLIENT then RunConsoleCommand("_DarkRP_AnimationMenu") end
 		return
 	end
 
@@ -144,6 +142,12 @@ end
 SWEP.OnceReload = false
 function SWEP:Reload()
 	local trace = self.Owner:GetEyeTrace()
+	
+	if not lookingAtLockable(self.Owner, trace.Entity) then
+		if CLIENT then RunConsoleCommand("_DarkRP_AnimationMenu") end
+		return
+	end
+	
 	if not IsValid(trace.Entity) or (IsValid(trace.Entity) and ((not trace.Entity:isDoor() and not trace.Entity:IsVehicle()) or self.Owner:EyePos():Distance(trace.HitPos) > 200)) then
 		if not self.OnceReload then
 			if SERVER then DarkRP.notify(self.Owner, 1, 3, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("door_or_vehicle"))) end

--- a/gamemode/modules/base/cl_entityvars.lua
+++ b/gamemode/modules/base/cl_entityvars.lua
@@ -95,6 +95,7 @@ RP name override
 ---------------------------------------------------------------------------*/
 pmeta.SteamName = pmeta.SteamName or pmeta.Name
 function pmeta:Name()
+	if not self:IsValid() then DarkRP.error("Attempt to call Name/Nick/GetName on a non-existing player!", 2) end
 	return GAMEMODE.Config.allowrpnames and self:getDarkRPVar("rpname")
 		or self:SteamName()
 end

--- a/gamemode/modules/base/sh_simplerr.lua
+++ b/gamemode/modules/base/sh_simplerr.lua
@@ -13,7 +13,8 @@ DarkRP.error = fc{
     simplerr.wrapError,
     simplerr.wrapHook,
     simplerr.wrapLog,
-    simplerr.runError
+    simplerr.runError,
+    function(msg, err, ...) return msg, err and err + 1 or 2, ... end -- Raise error level one higher
 }
 
 -- Print errors from the server in the console and show a message in chat

--- a/gamemode/modules/base/sv_entityvars.lua
+++ b/gamemode/modules/base/sv_entityvars.lua
@@ -178,7 +178,8 @@ Nickname override to show RP name
 ---------------------------------------------------------------------------*/
 meta.SteamName = meta.SteamName or meta.Name
 function meta:Name()
-	if not IsValid(self) then return DarkRP.error("Tried to use a NULL entity!", 2) end
+	-- Error level is 1 because this file is somehow left out of the trace.
+	if not self:IsValid() then return DarkRP.error("Attempt to call Name/Nick/GetName on a non-existing player!", 1) end
 	return GAMEMODE.Config.allowrpnames and self.DarkRPVars and self:getDarkRPVar("rpname")
 		or self:SteamName()
 end

--- a/gamemode/modules/workarounds/sh_workarounds.lua
+++ b/gamemode/modules/workarounds/sh_workarounds.lua
@@ -172,6 +172,7 @@ That calculation is slow
 local plyMeta = FindMetaTable("Player")
 local oldUID = plyMeta.UniqueID
 function plyMeta:UniqueID()
+	if not self:IsValid() then DarkRP.error("Attempt to get UniqueID of non-existing player", 2) end
 	self.UIDCache = self.UIDCache or oldUID(self)
 
 	return self.UIDCache


### PR DESCRIPTION
Keys won't open the DarkRP Animation Menu anymore when (mostly) wrongly
Left- or Right Clicking. The Menu can now be triggered through pressing
Reload.