### PR TITLE
Fix for #job.model == 1 showing model choice

### DIFF
--- a/gamemode/modules/f4menu/cl_jobstab.lua
+++ b/gamemode/modules/f4menu/cl_jobstab.lua
@@ -294,7 +294,7 @@ function PANEL:updateInfo(job)
 
 	self.btnGetJob:setJob(job, fn.Partial(self:GetParent():GetParent().Hide, self:GetParent():GetParent()))
 
-	if istable(job.model) and (not isfunction(job.PlayerSetModel) or not job.PlayerSetModel(LocalPlayer())) then
+	if istable(job.model) and #job.model > 1 and (not isfunction(job.PlayerSetModel) or not job.PlayerSetModel(LocalPlayer())) then
 		self.pnlChooseMdl:updateInfo(job)
 		self.pnlChooseMdl:SetVisible(true)
 	else


### PR DESCRIPTION
If the job.model is a table with only 1 model the model choice gui part thing won't show.