### PR TITLE
SWEP changes

### DIFF
--- a/entities/weapons/arrest_stick/shared.lua
+++ b/entities/weapons/arrest_stick/shared.lua
@@ -4,86 +4,18 @@ if CLIENT then
 	SWEP.PrintName = "Arrest Baton"
 	SWEP.Slot = 1
 	SWEP.SlotPos = 3
-	SWEP.DrawAmmo = false
-	SWEP.DrawCrosshair = false
 end
 
-SWEP.Base = "weapon_cs_base2"
+DEFINE_BASECLASS("stick_base")
 
-SWEP.Author = "DarkRP Developers"
 SWEP.Instructions = "Left click to arrest\nRight click to switch batons"
-SWEP.Contact = ""
-SWEP.Purpose = ""
-SWEP.IconLetter = ""
-
-SWEP.ViewModelFOV = 62
-SWEP.ViewModelFlip = false
-SWEP.AnimPrefix = "stunstick"
 
 SWEP.Spawnable = true
-SWEP.AdminOnly = true
 SWEP.Category = "DarkRP (Utility)"
 
-SWEP.NextStrike = 0
+SWEP.StickColor = Color(255, 0, 0)
 
-SWEP.ViewModel = Model("models/weapons/v_stunbaton.mdl")
-SWEP.WorldModel = Model("models/weapons/w_stunbaton.mdl")
-
-SWEP.Sound = Sound("weapons/stunstick/stunstick_swing1.wav")
-
-SWEP.Primary.ClipSize = -1
-SWEP.Primary.DefaultClip = 0
-SWEP.Primary.Automatic = false
-SWEP.Primary.Ammo = ""
-
-SWEP.Secondary.ClipSize = -1
-SWEP.Secondary.DefaultClip = 0
-SWEP.Secondary.Automatic = false
-SWEP.Secondary.Ammo = ""
-
-function SWEP:Initialize()
-	self:SetHoldType("normal")
-end
-
-function SWEP:Deploy()
-	if SERVER then
-		self:SetColor(Color(255,0,0,255))
-		self:SetMaterial("models/shiny")
-		local vm = self.Owner:GetViewModel()
-		if not IsValid(vm) then return end
-		vm:ResetSequence(vm:LookupSequence("idle01"))
-	end
-	return true
-end
-
-function SWEP:PreDrawViewModel()
-	if SERVER or not IsValid(self.Owner) or not IsValid(self.Owner:GetViewModel()) then return end
-	self.Owner:GetViewModel():SetColor(Color(255,0,0,255))
-	self.Owner:GetViewModel():SetMaterial("models/shiny")
-end
-
-function SWEP:Holster()
-	if SERVER then
-		self:SetColor(Color(255,255,255,255))
-		self:SetMaterial("")
-		timer.Stop(self:GetClass() .. "_idle" .. self:EntIndex())
-	elseif CLIENT and IsValid(self.Owner) and IsValid(self.Owner:GetViewModel()) then
-		self.Owner:GetViewModel():SetColor(Color(255,255,255,255))
-		self.Owner:GetViewModel():SetMaterial("")
-	end
-	return true
-end
-
-function SWEP:OnRemove()
-	if SERVER then
-		self:SetColor(Color(255,255,255,255))
-		self:SetMaterial("")
-		timer.Stop(self:GetClass() .. "_idle" .. self:EntIndex())
-	elseif CLIENT and IsValid(self.Owner) and IsValid(self.Owner:GetViewModel()) then
-		self.Owner:GetViewModel():SetColor(Color(255,255,255,255))
-		self.Owner:GetViewModel():SetMaterial("")
-	end
-end
+SWEP.Switched = true
 
 DarkRP.hookStub{
 	name = "canArrest",
@@ -144,90 +76,67 @@ local hookCanArrest = {canArrest = function(_, arrester, arrestee)
 	return true
 end}
 
+function SWEP:Deploy()
+	self.Switched = true
+	return BaseClass.Deploy(self)
+end
 
 function SWEP:PrimaryAttack()
-	if CurTime() < self.NextStrike then return end
-
-	self:SetHoldType("melee")
-	timer.Simple(0.3, function() if self:IsValid() then self:SetHoldType("normal") end end)
-
-	self.NextStrike = CurTime() + 0.51 -- Actual delay is set later.
+	BaseClass.PrimaryAttack(self)
 
 	if CLIENT then return end
 
-	timer.Stop(self:GetClass() .. "_idle" .. self:EntIndex())
-	local vm = self.Owner:GetViewModel()
-	if IsValid(vm) then
-		vm:ResetSequence(vm:LookupSequence("idle01"))
-		timer.Simple(0, function()
-			if not IsValid(self) or not IsValid(self.Owner) or not IsValid(self.Owner:GetActiveWeapon()) or self.Owner:GetActiveWeapon() ~= self then return end
-			self.Owner:SetAnimation(PLAYER_ATTACK1)
-
-			if IsValid(self.Weapon) then
-				self.Weapon:EmitSound(self.Sound)
-			end
-
-			local vm = self.Owner:GetViewModel()
-			if not IsValid(vm) then return end
-			vm:ResetSequence(vm:LookupSequence("attackch"))
-			vm:SetPlaybackRate(1 + 1/3)
-			local duration = vm:SequenceDuration() / vm:GetPlaybackRate()
-			timer.Create(self:GetClass() .. "_idle" .. self:EntIndex(), duration, 1, function()
-				if not IsValid(self) or not IsValid(self.Owner) then return end
-				local vm = self.Owner:GetViewModel()
-				if not IsValid(vm) then return end
-				vm:ResetSequence(vm:LookupSequence("idle01"))
-			end)
-			self.NextStrike = CurTime() + duration
-		end)
-	end
-
-	self.Owner:LagCompensation(true)
-	local trace = util.QuickTrace(self.Owner:EyePos(), self.Owner:GetAimVector() * 90, {self.Owner})
-	self.Owner:LagCompensation(false)
+	self:GetOwner():LagCompensation(true)
+	local trace = util.QuickTrace(self:GetOwner():EyePos(), self:GetOwner():GetAimVector() * 90, {self:GetOwner()})
+	self:GetOwner():LagCompensation(false)
 	if IsValid(trace.Entity) and trace.Entity.onArrestStickUsed then
-		trace.Entity:onArrestStickUsed(self.Owner)
+		trace.Entity:onArrestStickUsed(self:GetOwner())
 		return
 	end
 
-	local ent = self.Owner:getEyeSightHitEntity(nil, nil, function(p) return p ~= self.Owner and p:IsPlayer() and p:Alive() end)
+	local ent = self:GetOwner():getEyeSightHitEntity(nil, nil, function(p) return p ~= self:GetOwner() and p:IsPlayer() and p:Alive() end)
 
-	if not IsValid(ent) or (self.Owner:EyePos():Distance(ent:GetPos()) > 90) or (not ent:IsPlayer() and not ent:IsNPC()) then
+	if not IsValid(ent) or (self:GetOwner():EyePos():Distance(ent:GetPos()) > 90) or not ent:IsPlayer() then
 		return
 	end
 
-	local canArrest, message = hook.Call("canArrest", hookCanArrest, self.Owner, ent)
+	local canArrest, message = hook.Call("canArrest", hookCanArrest, self:GetOwner(), ent)
 	if not canArrest then
-		if message then DarkRP.notify(self.Owner, 1, 5, message) end
+		if message then DarkRP.notify(self:GetOwner(), 1, 5, message) end
 		return
 	end
 
 	local jpc = DarkRP.jailPosCount()
 
 	if not jpc or jpc == 0 then
-		DarkRP.notify(self.Owner, 1, 4, DarkRP.getPhrase("cant_arrest_no_jail_pos"))
+		DarkRP.notify(self:GetOwner(), 1, 4, DarkRP.getPhrase("cant_arrest_no_jail_pos"))
 	else
 		-- Send NPCs to Jail
 		if ent:IsNPC() then
 			ent:SetPos(DarkRP.retrieveJailPos())
 		else
 			if not ent.Babygod then
-				ent:arrest(nil, self.Owner)
-				DarkRP.notify(ent, 0, 20, DarkRP.getPhrase("youre_arrested_by", self.Owner:Nick()))
+				ent:arrest(nil, self:GetOwner())
+				DarkRP.notify(ent, 0, 20, DarkRP.getPhrase("youre_arrested_by", self:GetOwner():Nick()))
 
-				if self.Owner.SteamName then
-					DarkRP.log(self.Owner:Nick().." ("..self.Owner:SteamID()..") arrested "..ent:Nick(), Color(0, 255, 255))
+				if self:GetOwner().SteamName then
+					DarkRP.log(self:GetOwner():Nick().." ("..self:GetOwner():SteamID()..") arrested "..ent:Nick(), Color(0, 255, 255))
 				end
 			else
-				DarkRP.notify(self.Owner, 1, 4, DarkRP.getPhrase("cant_arrest_spawning_players"))
+				DarkRP.notify(self:GetOwner(), 1, 4, DarkRP.getPhrase("cant_arrest_spawning_players"))
 			end
 		end
 	end
 end
 
-function SWEP:SecondaryAttack()
-	if CLIENT then return end
-	if self.Owner:HasWeapon("unarrest_stick") then
-		self.Owner:SelectWeapon("unarrest_stick")
+function SWEP:StartCommand(ply, usrcmd)
+	if not IsValid(self) or not IsValid(self:GetOwner()) then return end
+	if not IsValid(self:GetOwner():GetActiveWeapon()) or self:GetOwner():GetActiveWeapon():EntIndex() ~= self:EntIndex() then return end
+	if usrcmd:KeyDown(IN_ATTACK2) then
+		if not self.Switched and self:GetOwner():HasWeapon("unarrest_stick") then
+			usrcmd:SelectWeapon(self:GetOwner():GetWeapon("unarrest_stick"))
+		end
+	else
+		self.Switched = false
 	end
 end

--- a/entities/weapons/keys/shared.lua
+++ b/entities/weapons/keys/shared.lua
@@ -46,8 +46,8 @@ function SWEP:Initialize()
 end
 
 function SWEP:Deploy()
-	if CLIENT or not IsValid(self.Owner) then return true end
-	self.Owner:DrawWorldModel(false)
+	if CLIENT or not IsValid(self:GetOwner()) then return true end
+	self:GetOwner():DrawWorldModel(false)
 	return true
 end
 
@@ -98,52 +98,51 @@ local function doKnock(ply, sound)
 end
 
 function SWEP:PrimaryAttack()
-	local trace = self.Owner:GetEyeTrace()
+	local trace = self:GetOwner():GetEyeTrace()
 
-	if not lookingAtLockable(self.Owner, trace.Entity) then return end
+	if not lookingAtLockable(self:GetOwner(), trace.Entity) then return end
 
-	self.Weapon:SetNextPrimaryFire(CurTime() + 0.3)
+	self:SetNextPrimaryFire(CurTime() + 0.3)
 
 	if CLIENT then return end
 
-	if self.Owner:canKeysLock(trace.Entity) then
+	if self:GetOwner():canKeysLock(trace.Entity) then
 		trace.Entity:keysLock() -- Lock the door immediately so it won't annoy people
-		lockUnlockAnimation(self.Owner, self.Sound)
+		lockUnlockAnimation(self:GetOwner(), self.Sound)
 	elseif trace.Entity:IsVehicle() then
-		DarkRP.notify(self.Owner, 1, 3, DarkRP.getPhrase("do_not_own_ent"))
+		DarkRP.notify(self:GetOwner(), 1, 3, DarkRP.getPhrase("do_not_own_ent"))
 	else
-		doKnock(self.Owner, "physics/wood/wood_crate_impact_hard2.wav")
+		doKnock(self:GetOwner(), "physics/wood/wood_crate_impact_hard2.wav")
 	end
 end
 
 function SWEP:SecondaryAttack()
-	local trace = self.Owner:GetEyeTrace()
+	local trace = self:GetOwner():GetEyeTrace()
 
-	if not lookingAtLockable(self.Owner, trace.Entity) then return end
+	if not lookingAtLockable(self:GetOwner(), trace.Entity) then return end
 
-	self.Weapon:SetNextSecondaryFire(CurTime() + 0.3)
+	self:SetNextSecondaryFire(CurTime() + 0.3)
 
 	if CLIENT then return end
 
-	if self.Owner:canKeysUnlock(trace.Entity) then
+	if self:GetOwner():canKeysUnlock(trace.Entity) then
 		trace.Entity:keysUnLock() -- Unlock the door immediately so it won't annoy people
-		lockUnlockAnimation(self.Owner, self.Sound)
+		lockUnlockAnimation(self:GetOwner(), self.Sound)
 	elseif trace.Entity:IsVehicle() then
-		DarkRP.notify(self.Owner, 1, 3, DarkRP.getPhrase("do_not_own_ent"))
+		DarkRP.notify(self:GetOwner(), 1, 3, DarkRP.getPhrase("do_not_own_ent"))
 	else
-		doKnock(self.Owner, "physics/wood/wood_crate_impact_hard3.wav")
+		doKnock(self:GetOwner(), "physics/wood/wood_crate_impact_hard3.wav")
 	end
 end
 
-SWEP.OnceReload = false
 function SWEP:Reload()
-	local trace = self.Owner:GetEyeTrace()
+	local trace = self:GetOwner():GetEyeTrace()
 	if not IsValid(trace.Entity) or (IsValid(trace.Entity) and ((not trace.Entity:isDoor() and not trace.Entity:IsVehicle()) or self.Owner:EyePos():Distance(trace.HitPos) > 200)) then
 		if CLIENT then RunConsoleCommand("_DarkRP_AnimationMenu") end
 		return
 	end
 	if SERVER then
-		umsg.Start("KeysMenu", self.Owner)
+		umsg.Start("KeysMenu", self:GetOwner())
 		umsg.End()
 	end
 end

--- a/entities/weapons/ls_sniper/cl_init.lua
+++ b/entities/weapons/ls_sniper/cl_init.lua
@@ -1,32 +1,17 @@
 include("shared.lua")
+local deltas = {-44, -34, -24, -14, 44, 34, 24, 14}
 function SWEP:DrawHUD()
-	self.ScopeLevel = self.ScopeLevel or 0
-	if self.ScopeLevel < 2 then return end
+	if self:GetScopeLevel() < 2 then return end
 
 	--Width hairs
-	draw.RoundedBox(1, ScrW() / 2 - 54, ScrH() / 2, 50, 1, Color(0,0,0,255))
-	draw.RoundedBox(1, ScrW() / 2 + 4, ScrH() / 2, 50, 1, Color(0,0,0,255))
+	draw.RoundedBox(1, ScrW() / 2 - 54, ScrH() / 2, 50, 1, color_black)
+	draw.RoundedBox(1, ScrW() / 2 + 4, ScrH() / 2, 50, 1, color_black)
 
-	draw.RoundedBox(1, ScrW() / 2, ScrH() / 2 - 54, 1, 50, Color(0,0,0,255))
-	draw.RoundedBox(1, ScrW() / 2, ScrH() / 2 + 4, 1, 50, Color(0,0,0,255))
+	draw.RoundedBox(1, ScrW() / 2, ScrH() / 2 - 54, 1, 50, color_black)
+	draw.RoundedBox(1, ScrW() / 2, ScrH() / 2 + 4, 1, 50, color_black)
 
-	draw.RoundedBox(1, ScrW() / 2 - 44, ScrH() / 2 - 5, 1, 11, Color(0,0,0,255))
-	draw.RoundedBox(1, ScrW() / 2 - 34, ScrH() / 2 - 5, 1, 11, Color(0,0,0,255))
-	draw.RoundedBox(1, ScrW() / 2 - 24, ScrH() / 2 - 5, 1, 11, Color(0,0,0,255))
-	draw.RoundedBox(1, ScrW() / 2 - 14, ScrH() / 2 - 5, 1, 11, Color(0,0,0,255))
-
-	draw.RoundedBox(1, ScrW() / 2 + 44, ScrH() / 2 - 5, 1, 11, Color(0,0,0,255))
-	draw.RoundedBox(1, ScrW() / 2 + 34, ScrH() / 2 - 5, 1, 11, Color(0,0,0,255))
-	draw.RoundedBox(1, ScrW() / 2 + 24, ScrH() / 2 - 5, 1, 11, Color(0,0,0,255))
-	draw.RoundedBox(1, ScrW() / 2 + 14, ScrH() / 2 - 5, 1, 11, Color(0,0,0,255))
-
-	draw.RoundedBox(1, ScrW() / 2 - 5, ScrH() / 2 - 44, 11, 1, Color(0,0,0,255))
-	draw.RoundedBox(1, ScrW() / 2 - 5, ScrH() / 2 - 34, 11, 1, Color(0,0,0,255))
-	draw.RoundedBox(1, ScrW() / 2 - 5, ScrH() / 2 - 24, 11, 1, Color(0,0,0,255))
-	draw.RoundedBox(1, ScrW() / 2 - 5, ScrH() / 2 - 14, 11, 1, Color(0,0,0,255))
-
-	draw.RoundedBox(1, ScrW() / 2 - 5, ScrH() / 2 + 44, 11, 1, Color(0,0,0,255))
-	draw.RoundedBox(1, ScrW() / 2 - 5, ScrH() / 2 + 34, 11, 1, Color(0,0,0,255))
-	draw.RoundedBox(1, ScrW() / 2 - 5, ScrH() / 2 + 24, 11, 1, Color(0,0,0,255))
-	draw.RoundedBox(1, ScrW() / 2 - 5, ScrH() / 2 + 14, 11, 1, Color(0,0,0,255))
+	for _,v in pairs(deltas) do
+		draw.RoundedBox(1, ScrW() / 2 + v, ScrH() / 2 - 5, 1, 11, color_black)
+		draw.RoundedBox(1, ScrW() / 2 - 5, ScrH() / 2 + v, 11, 1, color_black)
+	end
 end

--- a/entities/weapons/ls_sniper/shared.lua
+++ b/entities/weapons/ls_sniper/shared.lua
@@ -14,7 +14,7 @@ if CLIENT then
 	killicon.AddFont("ls_sniper", "CSKillIcons", SWEP.IconLetter, Color(200, 200, 200, 255))
 end
 
-SWEP.Base = "weapon_cs_base2"
+DEFINE_BASECLASS("weapon_cs_base2")
 
 SWEP.Spawnable = true
 SWEP.AdminOnly = false
@@ -40,53 +40,54 @@ SWEP.Primary.Ammo = "smg1"
 SWEP.IronSightsPos = Vector(0, 0, 0) -- this is just to make it disappear so it doesn't show up whilst scoped
 
 /*---------------------------------------------------------------------------
+SetupDataTables
+---------------------------------------------------------------------------*/
+function SWEP:SetupDataTables()
+	BaseClass.SetupDataTables(self)
+	-- Int 0 = BurstBulletNum
+	-- Int 1 = TotalUsedMagCount
+	self:NetworkVar("Int", 2, "ScopeLevel")
+end
+
+/*---------------------------------------------------------------------------
 Reload
 ---------------------------------------------------------------------------*/
 function SWEP:Reload()
-	if not IsValid(self.Owner) then return end
-	if SERVER then
-		self.Owner:SetFOV(0, 0)
-	end
+	if not IsValid(self:GetOwner()) then return end
 
-	self.ScopeLevel = 0
+	self:GetOwner():SetFOV(0, 0)
 
-	return self.BaseClass.Reload(self)
+	self:SetScopeLevel(0)
+
+	return BaseClass.Reload(self)
 end
 
 /*---------------------------------------------------------
 SecondaryAttack
 ---------------------------------------------------------*/
 local zoomFOV = {0, 0, 25, 5}
-SWEP.NextSecondaryAttack = 0
 function SWEP:SecondaryAttack()
-	if not IsValid(self.Owner) then return end
+	if not IsValid(self:GetOwner()) then return end
 	if not self.IronSightsPos then return end
 
-	if self.NextSecondaryAttack > CurTime() then return end
+	self:SetNextSecondaryFire(CurTime() + 0.1)
 
-	self.NextSecondaryAttack = CurTime() + 0.1
+	self:SetScopeLevel((self:GetScopeLevel() + 1) % 4)
+	self:SetIronsights(self:GetScopeLevel() > 0)
 
-	self.ScopeLevel = self.ScopeLevel or 0
-	self.ScopeLevel = (self.ScopeLevel + 1) % 4
-	self:SetIronsights(self.ScopeLevel > 0)
-	self:SetHoldType(self.ScopeLevel > 0 and self.HoldType or "normal")
-
-	if CLIENT then return end
-
-	self.Owner:SetFOV(zoomFOV[self.ScopeLevel + 1], 0)
+	self:GetOwner():SetFOV(zoomFOV[self:GetScopeLevel() + 1], 0)
 end
 
 /*---------------------------------------------------------------------------
 Holster the weapon
 ---------------------------------------------------------------------------*/
 function SWEP:Holster()
-	if not IsValid(self.Owner) then return end
-	if SERVER then
-		self.Owner:SetFOV(0, 0)
-	end
+	if not IsValid(self:GetOwner()) then return end
 
-	self.ScopeLevel = 0
+	self:GetOwner():SetFOV(0, 0)
+
+	self:SetScopeLevel(0)
 	self:SetIronsights(false)
 
-	return self.BaseClass.Holster(self)
+	return BaseClass.Holster(self)
 end

--- a/entities/weapons/med_kit/shared.lua
+++ b/entities/weapons/med_kit/shared.lua
@@ -33,21 +33,19 @@ SWEP.Secondary.Automatic = true
 SWEP.Secondary.Delay = 0.3
 SWEP.Secondary.Ammo = "none"
 
-
 function SWEP:PrimaryAttack()
-	self.Weapon:SetNextPrimaryFire(CurTime() + self.Primary.Delay)
-
-	if not SERVER then return end
+	self:SetNextPrimaryFire(CurTime() + self.Primary.Delay)
 
 	local found
 	local lastDot = -1 -- the opposite of what you're looking at
-	local aimVec = self.Owner:GetAimVector()
+	self:GetOwner():LagCompensation(true)
+	local aimVec = self:GetOwner():GetAimVector()
 
 	for k,v in pairs(player.GetAll()) do
 		local maxhealth = v:GetMaxHealth() or 100
-		if v == self.Owner or v:GetShootPos():Distance(self.Owner:GetShootPos()) > 85 or v:Health() >= maxhealth or not v:Alive() then continue end
+		if v == self:GetOwner() or v:GetShootPos():Distance(self:GetOwner():GetShootPos()) > 85 or v:Health() >= maxhealth or not v:Alive() then continue end
 
-		local direction = v:GetShootPos() - self.Owner:GetShootPos()
+		local direction = v:GetShootPos() - self:GetOwner():GetShootPos()
 		direction:Normalize()
 		local dot = direction:Dot(aimVec)
 
@@ -57,21 +55,20 @@ function SWEP:PrimaryAttack()
 			found = v
 		end
 	end
+	self:GetOwner():LagCompensation(false)
 
 	if found then
 		found:SetHealth(found:Health() + 1)
-		self.Owner:EmitSound("hl1/fvox/boop.wav", 150, found:Health())
+		self:EmitSound("hl1/fvox/boop.wav", 150, found:Health(), 1, CHAN_AUTO)
 	end
 end
 
 function SWEP:SecondaryAttack()
-	self.Weapon:SetNextSecondaryFire(CurTime() + self.Secondary.Delay)
-	if not SERVER then return end
+	self:SetNextSecondaryFire(CurTime() + self.Secondary.Delay)
 
-	local maxhealth = self.Owner:GetMaxHealth() or 100
-	if self.Owner:Health() < maxhealth then
-		self.Owner:SetHealth(self.Owner:Health() + 1)
-		self.Owner:EmitSound("hl1/fvox/boop.wav", 150, self.Owner:Health())
+	local maxhealth = self:GetOwner():GetMaxHealth() or 100
+	if self:GetOwner():Health() < maxhealth then
+		self:GetOwner():SetHealth(self:GetOwner():Health() + 1)
+		self:EmitSound("hl1/fvox/boop.wav", 150, self:GetOwner():Health(), 1, CHAN_AUTO)
 	end
 end
-

--- a/entities/weapons/pocket/cl_menu.lua
+++ b/entities/weapons/pocket/cl_menu.lua
@@ -46,7 +46,7 @@ end
 UI
 ---------------------------------------------------------------------------*/
 function reload()
-	if not ValidPanel(frame) or not frame:IsVisible() then return end
+	if not IsValid(frame) or not frame:IsVisible() then return end
 	if not pocket or next(pocket) == nil then frame:Close() return end
 
 	local itemCount = table.Count(pocket)

--- a/entities/weapons/pocket/shared.lua
+++ b/entities/weapons/pocket/shared.lua
@@ -58,38 +58,38 @@ end
 function SWEP:Holster()
 	if not SERVER then return true end
 
-	self.Owner:DrawViewModel(true)
-	self.Owner:DrawWorldModel(true)
+	self:GetOwner():DrawViewModel(true)
+	self:GetOwner():DrawWorldModel(true)
 
 	return true
 end
 
 function SWEP:PrimaryAttack()
-	self.Weapon:SetNextPrimaryFire(CurTime() + 0.2)
+	self:SetNextPrimaryFire(CurTime() + 0.2)
 
 	if not SERVER then return end
 
-	local ent = self.Owner:GetEyeTrace().Entity
-	local canPickup, message = hook.Call("canPocket", nil, self.Owner, ent)
+	local ent = self:GetOwner():GetEyeTrace().Entity
+	local canPickup, message = hook.Call("canPocket", nil, self:GetOwner(), ent)
 
 	if not canPickup then
-		if message then DarkRP.notify(self.Owner, 1, 4, message) end
+		if message then DarkRP.notify(self:GetOwner(), 1, 4, message) end
 		return
 	end
 
-	self.Owner:addPocketItem(ent)
+	self:GetOwner():addPocketItem(ent)
 end
 
 function SWEP:SecondaryAttack()
 	if not SERVER then return end
 
-	local item = #self.Owner:getPocketItems()
+	local item = #self:GetOwner():getPocketItems()
 	if item <= 0 then
-		DarkRP.notify(self.Owner, 1, 4, DarkRP.getPhrase("pocket_no_items"))
+		DarkRP.notify(self:GetOwner(), 1, 4, DarkRP.getPhrase("pocket_no_items"))
 		return
 	end
 
-	self.Owner:dropPocketItem(item)
+	self:GetOwner():dropPocketItem(item)
 end
 
 function SWEP:Reload()

--- a/entities/weapons/stick_base/shared.lua
+++ b/entities/weapons/stick_base/shared.lua
@@ -1,0 +1,159 @@
+AddCSLuaFile()
+
+if CLIENT then
+	SWEP.DrawAmmo = false
+	SWEP.DrawCrosshair = false
+end
+
+DEFINE_BASECLASS("weapon_cs_base2")
+
+SWEP.Author = "DarkRP Developers"
+SWEP.Contact = ""
+SWEP.Purpose = ""
+SWEP.IconLetter = ""
+
+SWEP.ViewModelFOV = 62
+SWEP.ViewModelFlip = false
+SWEP.AnimPrefix = "stunstick"
+
+SWEP.AdminOnly = true
+
+SWEP.StickColor = Color(255, 255, 255)
+
+SWEP.ViewModel = Model("models/weapons/v_stunbaton.mdl")
+SWEP.WorldModel = Model("models/weapons/w_stunbaton.mdl")
+
+SWEP.Sound = Sound("weapons/stunstick/stunstick_swing1.wav")
+
+SWEP.Primary.ClipSize = -1
+SWEP.Primary.DefaultClip = 0
+SWEP.Primary.Automatic = false
+SWEP.Primary.Ammo = ""
+
+SWEP.Secondary.ClipSize = -1
+SWEP.Secondary.DefaultClip = 0
+SWEP.Secondary.Automatic = false
+SWEP.Secondary.Ammo = ""
+
+function SWEP:Initialize()
+	self:SetHoldType("normal")
+end
+
+function SWEP:SetupDataTables()
+	BaseClass.SetupDataTables(self)
+	-- Bool 0 = Ironsights
+	-- Bool 1 = Reloading
+	self:NetworkVar("Bool", 2, "SeqIdling")
+	-- Float 0 = LastPrimaryAttack
+	-- Float 1 = ReloadEndTime
+	-- Float 2 = BurstTime
+	-- Float 3 = LastNonBurst
+	self:NetworkVar("Float", 4, "SeqIdleTime")
+	self:NetworkVar("Float", 5, "HoldTypeChangeTime")
+end
+
+function SWEP:StartCommand()
+end
+
+function SWEP:HookStartCommand()
+	hook.Add("StartCommand", "DarkRP_"..self:GetClass().."_StartCommand", fp{self.StartCommand, self})
+end
+
+function SWEP:Deploy()
+	BaseClass.Deploy(self)
+	if SERVER then
+		self:HookStartCommand()
+		self:CallOnClient("HookStartCommand")
+		self:SetColor(self.StickColor)
+		self:SetMaterial("models/shiny")
+	end
+	local vm = self:GetOwner():GetViewModel()
+	if not IsValid(vm) then return true end
+	self:PreDrawViewModel()
+	vm:SendViewModelMatchingSequence(vm:LookupSequence("idle01"))
+	return true
+end
+
+function SWEP:PreDrawViewModel()
+	if SERVER or not IsValid(self:GetOwner()) or not IsValid(self:GetOwner():GetViewModel()) then return end
+	self:GetOwner():GetViewModel():SetColor(self.StickColor)
+	self:GetOwner():GetViewModel():SetMaterial("models/shiny")
+end
+
+function SWEP:ResetStick(force)
+	if not IsValid(self:GetOwner()) or (not force and (not IsValid(self:GetOwner():GetActiveWeapon()) or self:GetOwner():GetActiveWeapon():GetClass() ~= self:GetClass())) then return end
+	if SERVER then
+		self:SetColor(Color(255, 255, 255))
+		self:SetMaterial("")
+	elseif IsValid(self:GetOwner()) and IsValid(self:GetOwner():GetViewModel()) then
+		self:GetOwner():GetViewModel():SetColor(Color(255, 255, 255))
+		self:GetOwner():GetViewModel():SetMaterial("")
+	end
+	self:SetSeqIdling(false)
+	self:SetSeqIdleTime(0)
+	self:SetHoldTypeChangeTime(0)
+	hook.Remove("StartCommand", "DarkRP_"..self:GetClass().."_StartCommand")
+end
+
+function SWEP:Holster()
+	BaseClass.Holster(self)
+	self:ResetStick(false)
+	return true
+end
+
+function SWEP:OnRemove()
+	BaseClass.OnRemove(self)
+	self:ResetStick(true)
+end
+
+function SWEP:Think()
+	if self:GetSeqIdling() then
+		self:SetSeqIdling(false)
+
+		if not IsValid(self:GetOwner()) then return end
+		self:GetOwner():SetAnimation(PLAYER_ATTACK1)
+		self:EmitSound(self.Sound)
+
+		local vm = self:GetOwner():GetViewModel()
+		if not IsValid(vm) then return end
+		vm:SendViewModelMatchingSequence(vm:LookupSequence("attackch"))
+		vm:SetPlaybackRate(1 + 1/3)
+		local duration = vm:SequenceDuration() / vm:GetPlaybackRate()
+		local time = CurTime() + duration
+		self:SetSeqIdleTime(time)
+		self:SetNextPrimaryFire(time)
+	end
+	if self:GetSeqIdleTime() ~= 0 and CurTime() >= self:GetSeqIdleTime() then
+		self:SetSeqIdleTime(0)
+
+		if not IsValid(self:GetOwner()) then return end
+		local vm = self:GetOwner():GetViewModel()
+		if not IsValid(vm) then return end
+		vm:SendViewModelMatchingSequence(vm:LookupSequence("idle01"))
+	end
+	if self:GetHoldTypeChangeTime() ~= 0 and CurTime() >= self:GetHoldTypeChangeTime() then
+		self:SetHoldTypeChangeTime(0)
+		self:SetHoldType("normal")
+	end
+end
+
+function SWEP:PrimaryAttack()
+	self:SetHoldType("melee")
+	self:SetHoldTypeChangeTime(CurTime() + 0.3)
+
+	self:SetNextPrimaryFire(CurTime() + 0.51) -- Actual delay is set later.
+
+	local vm = self:GetOwner():GetViewModel()
+	if IsValid(vm) then
+		vm:SendViewModelMatchingSequence(vm:LookupSequence("idle01"))
+		self:SetSeqIdling(true)
+	end
+end
+
+function SWEP:SecondaryAttack()
+	-- Do nothing
+end
+
+function SWEP:Reload()
+	-- Do nothing
+end

--- a/entities/weapons/stunstick/shared.lua
+++ b/entities/weapons/stunstick/shared.lua
@@ -4,45 +4,19 @@ if CLIENT then
 	SWEP.PrintName = "Stun Stick"
 	SWEP.Slot = 0
 	SWEP.SlotPos = 5
-	SWEP.DrawAmmo = false
-	SWEP.DrawCrosshair = false
 end
 
-SWEP.Base = "weapon_cs_base2"
+DEFINE_BASECLASS("stick_base")
 
-SWEP.Author = "DarkRP Developers"
 SWEP.Instructions = "Left click to discipline\nRight click to kill\nReload to threaten"
-SWEP.Contact = ""
-SWEP.Purpose = ""
-SWEP.IconLetter = ""
-
-SWEP.ViewModelFOV = 62
-SWEP.ViewModelFlip = false
-SWEP.AnimPrefix = "stunstick"
 
 SWEP.Spawnable = true
-SWEP.AdminOnly = true
 SWEP.Category = "DarkRP (Utility)"
 
-SWEP.NextStrike = 0
-
-SWEP.ViewModel = Model("models/weapons/v_stunbaton.mdl")
-SWEP.WorldModel = Model("models/weapons/w_stunbaton.mdl")
-
-SWEP.Sound = Sound("weapons/stunstick/stunstick_swing1.wav")
-
-SWEP.Primary.ClipSize = -1
-SWEP.Primary.DefaultClip = 0
-SWEP.Primary.Automatic = false
-SWEP.Primary.Ammo = ""
-
-SWEP.Secondary.ClipSize = -1
-SWEP.Secondary.DefaultClip = 0
-SWEP.Secondary.Automatic = false
-SWEP.Secondary.Ammo = ""
+SWEP.StickColor = Color(0, 0, 255)
 
 function SWEP:Initialize()
-	self:SetHoldType("normal")
+	BaseClass.Initialize(self)
 
 	self.Hit = {
 		Sound("weapons/stunstick/stunstick_impact1.wav"),
@@ -55,44 +29,15 @@ function SWEP:Initialize()
 	}
 end
 
-function SWEP:Deploy()
-	if SERVER then
-		self:SetColor(Color(0,0,255,255))
-		self:SetMaterial("models/shiny")
-		local vm = self.Owner:GetViewModel()
-		if not IsValid(vm) then return end
-		vm:ResetSequence(vm:LookupSequence("idle01"))
-	end
-	return true
-end
-
-function SWEP:PreDrawViewModel()
-	if SERVER or not IsValid(self.Owner) or not IsValid(self.Owner:GetViewModel()) then return end
-	self.Owner:GetViewModel():SetColor(Color(0,0,255,255))
-	self.Owner:GetViewModel():SetMaterial("models/shiny")
-end
-
-function SWEP:Holster()
-	if SERVER then
-		self:SetColor(Color(255,255,255,255))
-		self:SetMaterial("")
-		timer.Stop(self:GetClass() .. "_idle" .. self:EntIndex())
-	elseif CLIENT and IsValid(self.Owner) and IsValid(self.Owner:GetViewModel()) then
-		self.Owner:GetViewModel():SetColor(Color(255,255,255,255))
-		self.Owner:GetViewModel():SetMaterial("")
-	end
-	return true
-end
-
-function SWEP:OnRemove()
-	if SERVER then
-		self:SetColor(Color(255,255,255,255))
-		self:SetMaterial("")
-		timer.Stop(self:GetClass() .. "_idle" .. self:EntIndex())
-	elseif CLIENT and IsValid(self.Owner) and IsValid(self.Owner:GetViewModel()) then
-		self.Owner:GetViewModel():SetColor(Color(255,255,255,255))
-		self.Owner:GetViewModel():SetMaterial("")
-	end
+function SWEP:SetupDataTables()
+	BaseClass.SetupDataTables(self)
+	-- Float 0 = LastPrimaryAttack
+	-- Float 1 = ReloadEndTime
+	-- Float 2 = BurstTime
+	-- Float 3 = LastNonBurst
+	-- Float 4 = SeqIdleTime
+	-- Float 5 = HoldTypeChangeTime
+	self:NetworkVar("Float", 6, "LastReload")
 end
 
 function SWEP:DoFlash(ply)
@@ -103,101 +48,65 @@ end
 
 local entMeta = FindMetaTable("Entity")
 function SWEP:DoAttack(dmg)
-	if CurTime() < self.NextStrike then return end
-
-	self:SetHoldType("melee")
-	timer.Simple(0.3, function() if self:IsValid() then self:SetHoldType("normal") end end)
-
-	self.NextStrike = CurTime() + 0.51 -- Actual delay is set later.
-
 	if CLIENT then return end
 
-	timer.Stop(self:GetClass() .. "_idle" .. self:EntIndex())
-	local vm = self.Owner:GetViewModel()
-	if IsValid(vm) then
-		vm:ResetSequence(vm:LookupSequence("idle01"))
-		timer.Simple(0, function()
-			if not IsValid(self) or not IsValid(self.Owner) or not IsValid(self.Owner:GetActiveWeapon()) or self.Owner:GetActiveWeapon() ~= self then return end
-			self.Owner:SetAnimation(PLAYER_ATTACK1)
-
-			if IsValid(self.Weapon) then
-				self.Weapon:EmitSound(self.Sound)
-			end
-
-			local vm = self.Owner:GetViewModel()
-			if not IsValid(vm) then return end
-			vm:ResetSequence(vm:LookupSequence("attackch"))
-			vm:SetPlaybackRate(1 + 1/3)
-			local duration = vm:SequenceDuration() / vm:GetPlaybackRate()
-			timer.Create(self:GetClass() .. "_idle" .. self:EntIndex(), duration, 1, function()
-				if not IsValid(self) or not IsValid(self.Owner) then return end
-				local vm = self.Owner:GetViewModel()
-				if not IsValid(vm) then return end
-				vm:ResetSequence(vm:LookupSequence("idle01"))
-			end)
-			self.NextStrike = CurTime() + duration
-		end)
-	end
-
-	self.Owner:LagCompensation(true)
-	local trace = util.QuickTrace(self.Owner:EyePos(), self.Owner:GetAimVector() * 90, {self.Owner})
-	self.Owner:LagCompensation(false)
+	self:GetOwner():LagCompensation(true)
+	local trace = util.QuickTrace(self:GetOwner():EyePos(), self:GetOwner():GetAimVector() * 90, {self:GetOwner()})
+	self:GetOwner():LagCompensation(false)
 	if IsValid(trace.Entity) and trace.Entity.onStunStickUsed then
-		trace.Entity:onStunStickUsed(self.Owner)
+		trace.Entity:onStunStickUsed(self:GetOwner())
 		return
 	elseif IsValid(trace.Entity) and trace.Entity:GetClass() == "func_breakable_surf" then
 		trace.Entity:Fire("Shatter")
-		self.Owner:EmitSound(self.Hit[math.random(1,#self.Hit)])
+		self:GetOwner():EmitSound(self.Hit[math.random(1,#self.Hit)])
 		return
 	end
 
-	local ent = self.Owner:getEyeSightHitEntity(100, 15, fn.FAnd{fp{fn.Neq, self.Owner}, fc{IsValid, entMeta.GetPhysicsObject}})
+	local ent = self:GetOwner():getEyeSightHitEntity(100, 15, fn.FAnd{fp{fn.Neq, self:GetOwner()}, fc{IsValid, entMeta.GetPhysicsObject}})
 
 	if not IsValid(ent) then return end
 
 	if not ent:isDoor() then
-		ent:SetVelocity((ent:GetPos() - self.Owner:GetPos()) * 7)
+		ent:SetVelocity((ent:GetPos() - self:GetOwner():GetPos()) * 7)
 	end
 
 	if dmg > 0 then
-		ent:TakeDamage(dmg, self.Owner, self)
+		ent:TakeDamage(dmg, self:GetOwner(), self)
 	end
 
 	if ent:IsPlayer() or ent:IsNPC() or ent:IsVehicle() then
-		self.DoFlash(self, ent)
-		self.Owner:EmitSound(self.FleshHit[math.random(1,#self.FleshHit)])
+		self:DoFlash(ent)
+		self:GetOwner():EmitSound(self.FleshHit[math.random(1,#self.FleshHit)])
 	else
-		self.Owner:EmitSound(self.Hit[math.random(1,#self.Hit)])
-		if FPP and FPP.plyCanTouchEnt(self.Owner, ent, "EntityDamage") then
-			if ent.SeizeReward and not ent.beenSeized and not ent.burningup and self.Owner:isCP() and ent.Getowning_ent and self.Owner ~= ent:Getowning_ent() then
-				self.Owner:addMoney(ent.SeizeReward)
-				DarkRP.notify(self.Owner, 1, 4, DarkRP.getPhrase("you_received_x", DarkRP.formatMoney(ent.SeizeReward), DarkRP.getPhrase("bonus_destroying_entity")))
+		self:GetOwner():EmitSound(self.Hit[math.random(1,#self.Hit)])
+		if FPP and FPP.plyCanTouchEnt(self:GetOwner(), ent, "EntityDamage") then
+			if ent.SeizeReward and not ent.beenSeized and not ent.burningup and self:GetOwner():isCP() and ent.Getowning_ent and self:GetOwner() ~= ent:Getowning_ent() then
+				self:GetOwner():addMoney(ent.SeizeReward)
+				DarkRP.notify(self:GetOwner(), 1, 4, DarkRP.getPhrase("you_received_x", DarkRP.formatMoney(ent.SeizeReward), DarkRP.getPhrase("bonus_destroying_entity")))
 				ent.beenSeized = true
 			end
-			ent:TakeDamage(1000-dmg, self.Owner, self) -- for illegal entities
+			ent:TakeDamage(1000-dmg, self:GetOwner(), self) -- for illegal entities
 		end
 	end
 end
 
 function SWEP:PrimaryAttack()
+	BaseClass.PrimaryAttack(self)
+	self:SetNextSecondaryFire(self:GetNextPrimaryFire())
 	self:DoAttack(0)
 end
 
 function SWEP:SecondaryAttack()
+	BaseClass.PrimaryAttack(self)
+	self:SetNextSecondaryFire(self:GetNextPrimaryFire())
 	self:DoAttack(10)
 end
 
 function SWEP:Reload()
 	self:SetHoldType("melee")
-	timer.Destroy("rp_stunstick_threaten")
-	timer.Create("rp_stunstick_threaten", 1, 1, function()
-		if not IsValid(self) then return end
-		self:SetHoldType("normal")
-	end)
+	self:SetHoldTypeChangeTime(CurTime() + 1)
 
-	if not SERVER then return end
-
-	if self.LastReload and self.LastReload > CurTime() - 0.1 then self.LastReload = CurTime() return end
-	self.LastReload = CurTime()
-	self.Owner:EmitSound("weapons/stunstick/spark"..math.random(1,3)..".wav")
+	if self:GetLastReload() + 0.1 > CurTime() then self:SetLastReload(CurTime()) return end
+	self:SetLastReload(CurTime())
+	self:EmitSound("weapons/stunstick/spark"..math.random(1,3)..".wav")
 end

--- a/entities/weapons/stunstick/shared.lua
+++ b/entities/weapons/stunstick/shared.lua
@@ -4,6 +4,8 @@ if CLIENT then
 	SWEP.PrintName = "Stun Stick"
 	SWEP.Slot = 0
 	SWEP.SlotPos = 5
+
+	killicon.AddAlias("stunstick", "weapon_stunstick")
 end
 
 DEFINE_BASECLASS("stick_base")

--- a/entities/weapons/unarrest_stick/shared.lua
+++ b/entities/weapons/unarrest_stick/shared.lua
@@ -4,86 +4,16 @@ if CLIENT then
 	SWEP.PrintName = "Unarrest Baton"
 	SWEP.Slot = 1
 	SWEP.SlotPos = 3
-	SWEP.DrawAmmo = false
-	SWEP.DrawCrosshair = false
 end
 
-SWEP.Base = "weapon_cs_base2"
+DEFINE_BASECLASS("stick_base")
 
-SWEP.Author = "DarkRP Developers"
 SWEP.Instructions = "Left click to unarrest\nRight click to switch batons"
-SWEP.Contact = ""
-SWEP.Purpose = ""
-SWEP.IconLetter = ""
-
-SWEP.ViewModelFOV = 62
-SWEP.ViewModelFlip = false
-SWEP.AnimPrefix = "stunstick"
 
 SWEP.Spawnable = true
-SWEP.AdminOnly = true
 SWEP.Category = "DarkRP (Utility)"
 
-SWEP.NextStrike = 0
-
-SWEP.ViewModel = Model("models/weapons/v_stunbaton.mdl")
-SWEP.WorldModel = Model("models/weapons/w_stunbaton.mdl")
-
-SWEP.Sound = Sound("weapons/stunstick/stunstick_swing1.wav")
-
-SWEP.Primary.ClipSize = -1
-SWEP.Primary.DefaultClip = 0
-SWEP.Primary.Automatic = false
-SWEP.Primary.Ammo = ""
-
-SWEP.Secondary.ClipSize = -1
-SWEP.Secondary.DefaultClip = 0
-SWEP.Secondary.Automatic = false
-SWEP.Secondary.Ammo = ""
-
-function SWEP:Initialize()
-	self:SetHoldType("normal")
-end
-
-function SWEP:Deploy()
-	if SERVER then
-		self:SetColor(Color(0,255,0,255))
-		self:SetMaterial("models/shiny")
-		local vm = self.Owner:GetViewModel()
-		if not IsValid(vm) then return end
-		vm:ResetSequence(vm:LookupSequence("idle01"))
-	end
-	return true
-end
-
-function SWEP:PreDrawViewModel()
-	if SERVER or not IsValid(self.Owner) or not IsValid(self.Owner:GetViewModel()) then return end
-	self.Owner:GetViewModel():SetColor(Color(0,255,0,255))
-	self.Owner:GetViewModel():SetMaterial("models/shiny")
-end
-
-function SWEP:Holster()
-	if SERVER then
-		self:SetColor(Color(255,255,255,255))
-		self:SetMaterial("")
-		timer.Stop(self:GetClass() .. "_idle" .. self:EntIndex())
-	elseif CLIENT and IsValid(self.Owner) and IsValid(self.Owner:GetViewModel()) then
-		self.Owner:GetViewModel():SetColor(Color(255,255,255,255))
-		self.Owner:GetViewModel():SetMaterial("")
-	end
-	return true
-end
-
-function SWEP:OnRemove()
-	if SERVER then
-		self:SetColor(Color(255,255,255,255))
-		self:SetMaterial("")
-		timer.Stop(self:GetClass() .. "_idle" .. self:EntIndex())
-	elseif CLIENT and IsValid(self.Owner) and IsValid(self.Owner:GetViewModel()) then
-		self.Owner:GetViewModel():SetColor(Color(255,255,255,255))
-		self.Owner:GetViewModel():SetMaterial("")
-	end
-end
+SWEP.StickColor = Color(0, 255, 0)
 
 DarkRP.hookStub{
 	name = "canUnarrest",
@@ -118,75 +48,52 @@ DarkRP.hookStub{
 -- Default for canUnarrest hook
 local hookCanUnarrest = {canUnarrest = fp{fn.Id, true}}
 
+function SWEP:Deploy()
+	self.Switched = true
+	return BaseClass.Deploy(self)
+end
+
 function SWEP:PrimaryAttack()
-	if CurTime() < self.NextStrike then return end
-
-	self:SetHoldType("melee")
-	timer.Simple(0.3, function() if self:IsValid() then self:SetHoldType("normal") end end)
-
-	self.NextStrike = CurTime() + 0.51 -- Actual delay is set later
+	BaseClass.PrimaryAttack(self)
 
 	if CLIENT then return end
 
-	timer.Stop(self:GetClass() .. "_idle" .. self:EntIndex())
-	local vm = self.Owner:GetViewModel()
-	if IsValid(vm) then
-		vm:ResetSequence(vm:LookupSequence("idle01"))
-		timer.Simple(0, function()
-			if not IsValid(self) or not IsValid(self.Owner) or not IsValid(self.Owner:GetActiveWeapon()) or self.Owner:GetActiveWeapon() ~= self then return end
-			self.Owner:SetAnimation(PLAYER_ATTACK1)
-
-			if IsValid(self.Weapon) then
-				self.Weapon:EmitSound(self.Sound)
-			end
-
-			local vm = self.Owner:GetViewModel()
-			if not IsValid(vm) then return end
-			vm:ResetSequence(vm:LookupSequence("attackch"))
-			vm:SetPlaybackRate(1 + 1/3)
-			local duration = vm:SequenceDuration() / vm:GetPlaybackRate()
-			timer.Create(self:GetClass() .. "_idle" .. self:EntIndex(), duration, 1, function()
-				if not IsValid(self) or not IsValid(self.Owner) then return end
-				local vm = self.Owner:GetViewModel()
-				if not IsValid(vm) then return end
-				vm:ResetSequence(vm:LookupSequence("idle01"))
-			end)
-			self.NextStrike = CurTime() + duration
-		end)
-	end
-
-	self.Owner:LagCompensation(true)
-	local trace = util.QuickTrace(self.Owner:EyePos(), self.Owner:GetAimVector() * 90, {self.Owner})
-	self.Owner:LagCompensation(false)
+	self:GetOwner():LagCompensation(true)
+	local trace = util.QuickTrace(self:GetOwner():EyePos(), self:GetOwner():GetAimVector() * 90, {self:GetOwner()})
+	self:GetOwner():LagCompensation(false)
 	if IsValid(trace.Entity) and trace.Entity.onUnArrestStickUsed then
-		trace.Entity:onUnArrestStickUsed(self.Owner)
+		trace.Entity:onUnArrestStickUsed(self:GetOwner())
 		return
 	end
 
-	local ent = self.Owner:getEyeSightHitEntity(nil, nil, function(p) return p ~= self.Owner and p:IsPlayer() and p:Alive() end)
+	local ent = self:GetOwner():getEyeSightHitEntity(nil, nil, function(p) return p ~= self:GetOwner() and p:IsPlayer() and p:Alive() end)
 	if not ent then return end
 
-	if not IsValid(ent) or not ent:IsPlayer() or (self.Owner:EyePos():Distance(ent:GetPos()) > 90) or not ent:getDarkRPVar("Arrested") then
+	if not IsValid(ent) or not ent:IsPlayer() or (self:GetOwner():EyePos():Distance(ent:GetPos()) > 90) or not ent:getDarkRPVar("Arrested") then
 		return
 	end
 
-	local canUnarrest, message = hook.Call("canUnarrest", hookCanUnarrest, self.Owner, ent)
+	local canUnarrest, message = hook.Call("canUnarrest", hookCanUnarrest, self:GetOwner(), ent)
 	if not canUnarrest then
-		if message then DarkRP.notify(self.Owner, 1, 5, message) end
+		if message then DarkRP.notify(self:GetOwner(), 1, 5, message) end
 		return
 	end
 
-	ent:unArrest(self.Owner)
-	DarkRP.notify(ent, 0, 4, DarkRP.getPhrase("youre_unarrested_by", self.Owner:Nick()))
+	ent:unArrest(self:GetOwner())
+	DarkRP.notify(ent, 0, 4, DarkRP.getPhrase("youre_unarrested_by", self:GetOwner():Nick()))
 
-	if self.Owner.SteamName then
-		DarkRP.log(self.Owner:Nick().." ("..self.Owner:SteamID()..") unarrested "..ent:Nick(), Color(0, 255, 255))
+	if self:GetOwner().SteamName then
+		DarkRP.log(self:GetOwner():Nick().." ("..self:GetOwner():SteamID()..") unarrested "..ent:Nick(), Color(0, 255, 255))
 	end
 end
 
-function SWEP:SecondaryAttack()
-	if CLIENT then return end
-	if self.Owner:HasWeapon("arrest_stick") then
-		self.Owner:SelectWeapon("arrest_stick")
+function SWEP:StartCommand(ply, usrcmd)
+	if not IsValid(self) then return end
+	if usrcmd:KeyDown(IN_ATTACK2) then
+		if not self.Switched and self:GetOwner():HasWeapon("arrest_stick") then
+			usrcmd:SelectWeapon(self:GetOwner():GetWeapon("arrest_stick"))
+		end
+	else
+		self.Switched = false
 	end
 end

--- a/entities/weapons/weapon_cs_base2/shared.lua
+++ b/entities/weapons/weapon_cs_base2/shared.lua
@@ -263,8 +263,7 @@ Checks the objects before any action is taken
 This is to make sure that the entities haven't been removed
 ---------------------------------------------------------*/
 function SWEP:DrawWeaponSelection(x, y, wide, tall, alpha)
-	local iconletters = {"x", "w", "b", "k", "u", "f", "d", "l", "z", "c", "n"}
-	if self.IconLetter and table.HasValue(iconletters, self.IconLetter) then
+	if self.IconLetter and string.find(self.IconLetter, "^[0-9a-wA-Z]$") then
 		draw.DrawNonParsedSimpleText(self.IconLetter, "CSSelectIcons", x + wide/2, y + tall*0.2, Color(255, 210, 0, 255), TEXT_ALIGN_CENTER)
 
 		-- try to fool them into thinking they're playing a Tony Hawks game

--- a/entities/weapons/weapon_cs_base2/shared.lua
+++ b/entities/weapons/weapon_cs_base2/shared.lua
@@ -21,13 +21,15 @@ if CLIENT then
 		weight = 500,
 		antialias = true,
 		shadow = true,
-		font = "csd"})
+		font = "csd"
+	})
 	surface.CreateFont("CSSelectIcons", {
 		size = ScreenScale(60),
 		weight = 500,
 		antialias = true,
 		shadow = true,
-		font = "csd"})
+		font = "csd"
+	})
 end
 
 SWEP.Base = "weapon_base"
@@ -60,16 +62,13 @@ SWEP.Secondary.DefaultClip = -1
 SWEP.Secondary.Automatic = false
 SWEP.Secondary.Ammo = "none"
 
-SWEP.LastPrimaryAttack = 0
-
-SWEP.FireMode = "semi"
 SWEP.MultiMode = false
 
 /*---------------------------------------------------------
 ---------------------------------------------------------*/
 function SWEP:Initialize()
-	if CLIENT and IsValid(self.Owner) then
-		local vm = self.Owner:GetViewModel()
+	if CLIENT and IsValid(self:GetOwner()) then
+		local vm = self:GetOwner():GetViewModel()
 		self:ResetDarkRPBones(vm)
 	end
 
@@ -80,11 +79,23 @@ function SWEP:Initialize()
 		self:SetNPCFireRate(0.01)
 	end
 
-	self.Ironsights = false
+	self.dt.Ironsights = false
+	self.dt.TotalUsedMagCount = 0
+	self.dt.FireMode = self.Primary.Automatic and "auto" or "semi"
+end
 
-	if self.Primary.Automatic then
-		self.FireMode = "auto"
-	end
+function SWEP:SetupDataTables()
+	self:NetworkVar("Bool", 0, "Ironsights")
+	self:NetworkVar("Bool", 1, "Reloading")
+	self:NetworkVar("Float", 0, "LastPrimaryAttack")
+	self:NetworkVar("Float", 1, "ReloadEndTime")
+	self:NetworkVar("Float", 2, "BurstTime")
+	self:NetworkVar("Float", 3, "LastNonBurst")
+	self:NetworkVar("Int", 0, "BurstBulletNum")
+	self:NetworkVar("Int", 1, "TotalUsedMagCount")
+	self:NetworkVar("String", 0, "FireMode")
+	self:NetworkVar("Entity", 0, "LastOwner")
+	self:NetworkVarNotify("Ironsights", fc{self.IronsightsChanged, fp{fn.Id, self}, fp{select, 4}})
 end
 
 /*---------------------------------------------------------
@@ -93,36 +104,40 @@ Deploy
 function SWEP:Deploy()
 	self:SetHoldType("normal")
 
-	self.LASTOWNER = self.Owner
-
-	self:SetIronsights(self:GetIronsights())
+	self:IronsightsChanged(self:GetIronsights())
 
 	return true
 end
 
-function SWEP:Holster()
-	self.Ironsights = false
-	self.hasShot = false -- We do this here because SWEP:Deploy is currently unreliable clientside
+function SWEP:OwnerChanged()
+	if IsValid(self:GetOwner()) then self:SetLastOwner(self:GetOwner()) end
+end
 
-	if not IsValid(self.Owner) then return true end
+function SWEP:Holster()
+	self.dt.Ironsights = false
+	if CLIENT then self.hasShot = false end
+
+	if not IsValid(self:GetOwner()) then return true end
 	if CLIENT then
-		local vm = self.Owner:GetViewModel()
+		local vm = self:GetOwner():GetViewModel()
 		self:ResetDarkRPBones(vm)
-	else
-		hook.Call("UpdatePlayerSpeed", GAMEMODE, self.Owner)
 	end
+
+	hook.Call("UpdatePlayerSpeed", GAMEMODE, self:GetOwner())
 
 	return true
 end
 
 function SWEP:OnRemove()
-	self.Ironsights = false
+	self.dt.Ironsights = false
 
-	if CLIENT and IsValid(self.Owner) then
-		local vm = self.Owner:GetViewModel()
+	if CLIENT and IsValid(self:GetOwner()) then
+		local vm = self:GetOwner():GetViewModel()
 		self:ResetDarkRPBones(vm)
-	elseif SERVER and IsValid(self.LASTOWNER) then
-		hook.Call("UpdatePlayerSpeed", GAMEMODE, self.LASTOWNER)
+	end
+
+	if IsValid(self:GetLastOwner()) then
+		hook.Call("UpdatePlayerSpeed", GAMEMODE, self:GetLastOwner())
 	end
 end
 
@@ -130,41 +145,39 @@ end
 Reload does nothing
 ---------------------------------------------------------*/
 function SWEP:Reload()
-	if not self.Weapon:DefaultReload(ACT_VM_RELOAD) then return end
-	self.Reloading = true
+	if not self:DefaultReload(ACT_VM_RELOAD) then return end
+	self:SetReloading(true)
 	self:SetIronsights(false)
 	self:SetHoldType(self.HoldType)
-	self.Owner:SetAnimation(PLAYER_RELOAD)
-	timer.Simple(2, function()
-		if not IsValid(self) then return end
-		self.Reloading = false
-		self:SetHoldType("normal")
-		self.hasShot = false
-	end)
+	self:GetOwner():SetAnimation(PLAYER_RELOAD)
+	self:SetReloadEndTime(CurTime() + 2)
+	self:SetTotalUsedMagCount(self:GetTotalUsedMagCount() + 1)
 end
 
 /*---------------------------------------------------------
 PrimaryAttack
 ---------------------------------------------------------*/
-function SWEP:PrimaryAttack(partofburst)
-	if not partofburst and (self.LastNonBurst or 0) > CurTime() - 0.6 then return end
+function SWEP:PrimaryAttack()
+	self.Primary.Automatic = (self:GetFireMode() == "auto")
 
-	if self.Weapon.MultiMode and self.Owner:KeyDown(IN_USE) then
-		if self.FireMode == "semi" then
-			self.FireMode = "burst"
+	if self:GetBurstBulletNum() == 0 and (self:GetLastNonBurst() or 0) > CurTime() - 0.6 then return end
+
+	if self.MultiMode and self:GetOwner():KeyDown(IN_USE) then
+		if self:GetFireMode() == "semi" then
+			self:SetFireMode("burst")
 			self.Primary.Automatic = false
-			self.Owner:PrintMessage( HUD_PRINTCENTER, DarkRP.getPhrase("switched_burst"))
-		elseif self.FireMode == "burst" then
-			self.FireMode = "auto"
+			self:GetOwner():PrintMessage(HUD_PRINTCENTER, DarkRP.getPhrase("switched_burst"))
+		elseif self:GetFireMode() == "burst" then
+			self:SetFireMode("auto")
 			self.Primary.Automatic = true
-			self.Owner:PrintMessage(HUD_PRINTCENTER, DarkRP.getPhrase("switched_fully_auto"))
-		elseif self.FireMode == "auto" then
-			self.FireMode = "semi"
+			self:GetOwner():PrintMessage(HUD_PRINTCENTER, DarkRP.getPhrase("switched_fully_auto"))
+		elseif self:GetFireMode() == "auto" then
+			self:SetFireMode("semi")
 			self.Primary.Automatic = false
-			self.Owner:PrintMessage(HUD_PRINTCENTER, DarkRP.getPhrase("switched_semi_auto"))
+			self:GetOwner():PrintMessage(HUD_PRINTCENTER, DarkRP.getPhrase("switched_semi_auto"))
 		end
-		self.Weapon:SetNextPrimaryFire(CurTime() + 0.5)
-		self.Weapon:SetNextSecondaryFire(CurTime() + 0.5)
+		self:SetNextPrimaryFire(CurTime() + 0.5)
+		self:SetNextSecondaryFire(CurTime() + 0.5)
 		return
 	end
 
@@ -172,11 +185,11 @@ function SWEP:PrimaryAttack(partofburst)
 		self:SetHoldType(self.HoldType)
 	end
 
-	if self.FireMode ~= "burst" then
-		self.Weapon:SetNextPrimaryFire(CurTime() + self.Primary.Delay)
+	if self:GetFireMode() ~= "burst" then
+		self:SetNextPrimaryFire(CurTime() + self.Primary.Delay)
 	end
 
-	self.Weapon:SetNextSecondaryFire(CurTime() + self.Primary.Delay)
+	self:SetNextSecondaryFire(CurTime() + self.Primary.Delay)
 
 	if self:Clip1() <= 0 then
 		self:EmitSound("weapons/clipempty_rifle.wav")
@@ -185,29 +198,35 @@ function SWEP:PrimaryAttack(partofburst)
 	end
 
 	if not self:CanPrimaryAttack() then self:SetIronsights(false) return end
-	if not self.Ironsights and GAMEMODE.Config.ironshoot then return end
+	if not self:GetIronsights() and GAMEMODE.Config.ironshoot then return end
 	-- Play shoot sound
-	self.Weapon:EmitSound(self.Primary.Sound)
+	self:EmitSound(self.Primary.Sound)
 
 	-- Shoot the bullet
 	self:CSShootBullet(self.Primary.Damage, self.Primary.Recoil + 3, self.Primary.NumShots, self.Primary.Cone + .05)
 
-	if self.FireMode == "burst" and not partofburst then
-		timer.Simple(0.1, function() self:PrimaryAttack(true) end)
-		timer.Simple(0.2, function() self:PrimaryAttack(true) end)
-
-		self.LastNonBurst = CurTime()
+	if self:GetFireMode() == "burst" then
+		self:SetBurstBulletNum(self:GetBurstBulletNum() + 1)
+		if self:GetBurstBulletNum() == 1 then
+			self:SetLastNonBurst(CurTime())
+		end
+		if self:GetBurstBulletNum() == 3 then
+			self:SetBurstTime(0)
+			self:SetBurstBulletNum(0)
+		else
+			self:SetBurstTime(CurTime() + 0.1)
+		end
 	end
 
 	-- Remove 1 bullet from our clip
 	self:TakePrimaryAmmo(1)
 
-	if self.Owner:IsNPC() then return end
+	self:SetLastPrimaryAttack(CurTime())
+
+	if self:GetOwner():IsNPC() then return end
 
 	-- Punch the player's view
-	self.Owner:ViewPunch(Angle(math.Rand(-0.2,-0.1) * self.Primary.Recoil, math.Rand(-0.1,0.1) *self.Primary.Recoil, 0))
-
-	self.LastPrimaryAttack = CurTime()
+	self:GetOwner():ViewPunch(Angle(util.SharedRandom("DarkRP_CSBase"..self:EntIndex().."Mag"..self:GetTotalUsedMagCount().."p"..self:Clip1(), -1.2, -1.1) * self.Primary.Recoil, util.SharedRandom("DarkRP_CSBase"..self:EntIndex().."Mag"..self:GetTotalUsedMagCount().."y"..self:Clip1(), -1.1, 1.1) * self.Primary.Recoil, 0))
 end
 
 /*---------------------------------------------------------
@@ -215,35 +234,28 @@ Name: SWEP:PrimaryAttack()
 Desc: +attack1 has been pressed
 ---------------------------------------------------------*/
 function SWEP:CSShootBullet(dmg, recoil, numbul, cone)
-	if not IsValid(self.Owner) then return end
+	if not IsValid(self:GetOwner()) then return end
 	numbul = numbul or 1
 	cone = cone or 0.01
 
 	local bullet = {}
 	bullet.Num = numbul or 1
-	bullet.Src = self.Owner:GetShootPos()       -- Source
-	bullet.Dir = self.Owner:GetAimVector()      -- Dir of bullet
-	bullet.Spread = Vector(cone, cone, 0)     -- Aim Cone
-	bullet.Tracer = 4       -- Show a tracer on every x bullets
-	bullet.Force = 5        -- Amount of force to give to phys objects
+	bullet.Src = self:GetOwner():GetShootPos()	-- Source
+	bullet.Dir = (self:GetOwner():GetAimVector():Angle() + self:GetOwner():GetViewPunchAngles()):Forward() -- Dir of bullet
+	bullet.Spread = Vector(cone, cone, 0)		-- Aim Cone
+	bullet.Tracer = 4							-- Show a tracer on every x bullets
+	bullet.Force = 5							-- Amount of force to give tolju phys objects
 	bullet.Damage = dmg
 
-	self.Owner:FireBullets(bullet)
-	self.Weapon:SendWeaponAnim(ACT_VM_PRIMARYATTACK)      -- View model animation
-	self.Owner:MuzzleFlash()        -- Crappy muzzle light
-	self.Owner:SetAnimation(PLAYER_ATTACK1)       -- 3rd Person Animation
+	self:GetOwner():FireBullets(bullet)
+	self:SendWeaponAnim(ACT_VM_PRIMARYATTACK)      -- View model animation
+	self:GetOwner():MuzzleFlash()        -- Crappy muzzle light
+	self:GetOwner():SetAnimation(PLAYER_ATTACK1)       -- 3rd Person Animation
 
-	if self.Owner:IsNPC() then return end
-
-	// CUSTOM RECOIL!
-	if (game.SinglePlayer() and SERVER) or (not game.SinglePlayer() and CLIENT and IsFirstTimePredicted()) then
-		local eyeang = self.Owner:EyeAngles()
-		eyeang.pitch = eyeang.pitch - recoil
-		self.Owner:SetEyeAngles(eyeang)
-	end
+	if self:GetOwner():IsNPC() then return end
 
 	-- Part of workaround, different viewmodel position if shots have been fired
-	self.hasShot = true
+	if CLIENT then self.hasShot = true end
 end
 
 /*---------------------------------------------------------
@@ -259,26 +271,26 @@ function SWEP:DrawWeaponSelection(x, y, wide, tall, alpha)
 		draw.DrawNonParsedSimpleText(self.IconLetter, "CSSelectIcons", x + wide/2 + math.Rand(-4, 4), y + tall*0.2+ math.Rand(-14, 14), Color(255, 210, 0, math.Rand(10, 120)), TEXT_ALIGN_CENTER)
 		draw.DrawNonParsedSimpleText(self.IconLetter, "CSSelectIcons", x + wide/2 + math.Rand(-4, 4), y + tall*0.2+ math.Rand(-9, 9), Color(255, 210, 0, math.Rand(10, 120)), TEXT_ALIGN_CENTER)
 	else
-		// Set us up the texture
+		-- Set us up the texture
 		surface.SetDrawColor(255, 255, 255, alpha)
 		surface.SetTexture(self.WepSelectIcon)
 
-		// Lets get a sin wave to make it bounce
+		-- Lets get a sin wave to make it bounce
 		local fsin = 0
 
 		if self.BounceWeaponIcon then
 			fsin = math.sin(CurTime() * 10) * 5
 		end
 
-		// Borders
+		-- Borders
 		y = y + 10
 		x = x + 10
 		wide = wide - 20
 
-		// Draw that motherfucker
+		-- Draw that motherfucker
 		surface.DrawTexturedRect(x + (fsin), y - (fsin), wide-fsin*2 , (wide / 2) + (fsin))
 
-		// Draw weapon info box
+		-- Draw weapon info box
 		self:PrintWeaponInfo(x + wide + 20, y + tall * 0.95, alpha)
 	end
 end
@@ -294,7 +306,7 @@ Desc: Allows you to re-position the view model
 function SWEP:GetViewModelPosition(pos, ang)
 	if not self.IronSightsPos then return pos, ang end
 
-	local bIron = self.Ironsights
+	local bIron = self:GetIronsights()
 
 	if bIron ~= self.bLastIron then
 		self.bLastIron = bIron
@@ -375,42 +387,28 @@ end
 
 
 /*---------------------------------------------------------
-SetIronsights
+IronsightsChanged
 ---------------------------------------------------------*/
 
-function SWEP:SetIronsights(b)
-	if game.SinglePlayer() and SERVER then -- Make ironsights work on SP
-		self.Owner:SendLua("LocalPlayer():GetActiveWeapon().Ironsights = "..tostring(b))
-	end
-	self.Ironsights = b
-	if b then
-		self:SetHoldType(self.HoldType)
-		if SERVER and IsValid(self.Owner) then
-			hook.Call("UpdatePlayerSpeed", GAMEMODE, self.Owner)
-		end
-	else
-		self:SetHoldType("normal")
-		if SERVER and IsValid(self.Owner) then
-			hook.Call("UpdatePlayerSpeed", GAMEMODE, self.Owner)
-		end
+function SWEP:IronsightsChanged(b)
+	self:SetHoldType(b and self.HoldType or "normal")
+	self.dt.Ironsights = b -- for UpdatePlayerSpeed
+	if IsValid(self:GetOwner()) then
+		hook.Call("UpdatePlayerSpeed", GAMEMODE, self:GetOwner())
 	end
 end
 
-function SWEP:GetIronsights()
-	return self.Ironsights
-end
-
-SWEP.NextSecondaryAttack = 0
 /*---------------------------------------------------------
 SecondaryAttack
 ---------------------------------------------------------*/
 function SWEP:SecondaryAttack()
 	if not self.IronSightsPos then return end
 
-	if self.NextSecondaryAttack > CurTime() or self.reloading then return end
+	if self:GetReloading() then return end
 
-	self:SetIronsights(not self.Ironsights)
-	self.NextSecondaryAttack = CurTime() + 0.3
+	self:SetIronsights(not self:GetIronsights())
+
+	self:SetNextSecondaryFire(CurTime() + 0.3)
 end
 
 /*---------------------------------------------------------
@@ -418,17 +416,17 @@ onRestore
 	Loaded a saved game
 ---------------------------------------------------------*/
 function SWEP:OnRestore()
-	self.NextSecondaryAttack = 0
-	self.Ironsights = false
+	self:SetNextSecondaryFire(0)
+	self.dt.Ironsights = false
 end
 
 function SWEP:OnDrop()
 	self.PrimaryClipLeft = self:Clip1()
 	self.SecondaryClipLeft = self:Clip2()
 
-	if not self.LASTOWNER then return end
-	self.PrimaryAmmoLeft = self.LASTOWNER:GetAmmoCount(self:GetPrimaryAmmoType())
-	self.SecondaryAmmoLeft = self.LASTOWNER:GetAmmoCount(self:GetSecondaryAmmoType())
+	if not IsValid(self:GetLastOwner()) then return end
+	self.PrimaryAmmoLeft = self:GetLastOwner():GetAmmoCount(self:GetPrimaryAmmoType())
+	self.SecondaryAmmoLeft = self:GetLastOwner():GetAmmoCount(self:GetSecondaryAmmoType())
 	self:SetCollisionGroup(COLLISION_GROUP_INTERACTIVE_DEBRIS)
 end
 
@@ -443,14 +441,23 @@ function SWEP:Equip(NewOwner)
 end
 
 function SWEP:Think()
-	if self.Primary.ClipSize ~= -1 and not self.Reloading and not self.Ironsights and self.LastPrimaryAttack + 1 < CurTime() and self:GetHoldType() == self.HoldType then
+	if self.Primary.ClipSize ~= -1 and not self:GetReloading() and not self:GetIronsights() and self:GetLastPrimaryAttack() + 1 < CurTime() and self:GetHoldType() == self.HoldType then
 		self:SetHoldType("normal")
+	end
+	if self:GetReloadEndTime() ~= 0 and CurTime() >= self:GetReloadEndTime() then
+		self:SetReloadEndTime(0)
+		self:SetReloading(false)
+		self:SetHoldType("normal")
+		if CLIENT then self.hasShot = false end
+	end
+	if self:GetBurstTime() ~= 0 and CurTime() >= self:GetBurstTime() then
+		self:PrimaryAttack()
 	end
 end
 
 if CLIENT then
 	function SWEP:ViewModelDrawn(vm)
-		if self.DarkRPViewModelBoneManipulations and not self.Reloading then
+		if self.DarkRPViewModelBoneManipulations and not self:GetReloading() then
 			self:UpdateDarkRPBones(vm, self.DarkRPViewModelBoneManipulations)
 		else
 			self:ResetDarkRPBones(vm)
@@ -514,7 +521,7 @@ end
 
 hook.Add("UpdatePlayerSpeed", "DarkRP_WeaponSpeed", function(ply)
 	local wep = ply:GetActiveWeapon()
-	if not IsValid(wep) or not wep.Ironsights then return end
+	if not IsValid(wep) or not wep.GetIronsights or not wep:GetIronsights() then return end
 
 	GAMEMODE:SetPlayerSpeed(ply, GAMEMODE.Config.walkspeed / 3, GAMEMODE.Config.runspeed / 3)
 

--- a/entities/weapons/weapon_deagle2/shared.lua
+++ b/entities/weapons/weapon_deagle2/shared.lua
@@ -26,7 +26,7 @@ SWEP.AutoSwitchFrom = false
 SWEP.HoldType = "pistol"
 
 SWEP.Primary.Sound = Sound("Weapon_Deagle.Single")
-SWEP.Primary.Recoil = 1.1
+SWEP.Primary.Recoil = 5.1
 SWEP.Primary.Damage = 25
 SWEP.Primary.NumShots = 1
 SWEP.Primary.Cone = 0.01

--- a/entities/weapons/weapon_keypadchecker/shared.lua
+++ b/entities/weapons/weapon_keypadchecker/shared.lua
@@ -1,5 +1,6 @@
+AddCSLuaFile()
+
 if SERVER then
-	AddCSLuaFile("shared.lua")
 	AddCSLuaFile("cl_init.lua")
 
 	util.AddNetworkString("DarkRP_keypadData")
@@ -28,8 +29,6 @@ SWEP.IconLetter = ""
 
 SWEP.ViewModel = "models/weapons/c_pistol.mdl"
 SWEP.UseHands = true
-
-if not SERVER then return end
 
 /*
 	Gets which entities are controlled by which keyboard keys
@@ -133,33 +132,37 @@ end
 Send the info to the client
 ---------------------------------------------------------------------------*/
 function SWEP:PrimaryAttack()
-	local trace = self.Owner:GetEyeTrace()
+	self:SetNextPrimaryFire(CurTime() + 0.3)
+	if not SERVER then return end
+
+	local trace = self:GetOwner():GetEyeTrace()
 	local ent, class = trace.Entity, string.lower(trace.Entity:GetClass() or "")
 	local data
 
 	if class == "sent_keypad" then
 		data = get_sent_keypad_Info(ent)
-		DarkRP.notify(self.Owner, 1, 4, DarkRP.getPhrase("keypad_checker_controls_x_entities", #data / 2))
+		DarkRP.notify(self:GetOwner(), 1, 4, DarkRP.getPhrase("keypad_checker_controls_x_entities", #data / 2))
 	elseif class == "keypad" then
 		data = get_keypad_Info(ent)
-		DarkRP.notify(self.Owner, 1, 4, DarkRP.getPhrase("keypad_checker_controls_x_entities", #data / 2))
+		DarkRP.notify(self:GetOwner(), 1, 4, DarkRP.getPhrase("keypad_checker_controls_x_entities", #data / 2))
 	else
 		data = getEntityKeypad(ent)
-		DarkRP.notify(self.Owner, 1, 4, DarkRP.getPhrase("keypad_checker_controlled_by_x_keypads", #data))
+		DarkRP.notify(self:GetOwner(), 1, 4, DarkRP.getPhrase("keypad_checker_controlled_by_x_keypads", #data))
 	end
 
 	net.Start("DarkRP_keypadData")
 		net.WriteTable(data)
-	net.Send(self.Owner)
+	net.Send(self:GetOwner())
 end
 
 function SWEP:SecondaryAttack()
 end
 
+if not SERVER then return end
+
 /*---------------------------------------------------------------------------
 Registering numpad data
 ---------------------------------------------------------------------------*/
-if not SERVER then return end
 local oldNumpadUp = numpad.OnUp
 local oldNumpadDown = numpad.OnDown
 

--- a/entities/weapons/weapon_mp52/shared.lua
+++ b/entities/weapons/weapon_mp52/shared.lua
@@ -26,8 +26,8 @@ SWEP.AutoSwitchFrom = false
 SWEP.HoldType = "smg"
 
 SWEP.Primary.Sound = Sound("Weapon_MP5Navy.Single")
-SWEP.Primary.Recoil = 0.2
-SWEP.Primary.Damage = 20
+SWEP.Primary.Recoil = 0.5
+SWEP.Primary.Damage = 15
 SWEP.Primary.NumShots = 1
 SWEP.Primary.Cone = 0.005
 SWEP.Primary.ClipSize = 32

--- a/entities/weapons/weapon_pumpshotgun2/shared.lua
+++ b/entities/weapons/weapon_pumpshotgun2/shared.lua
@@ -10,7 +10,7 @@ if CLIENT then
 	killicon.AddFont("weapon_pumpshotgun2", "CSKillIcons", SWEP.IconLetter, Color(255, 80, 0, 255))
 end
 
-SWEP.Base = "weapon_cs_base2"
+DEFINE_BASECLASS("weapon_cs_base2")
 
 SWEP.Spawnable = true
 SWEP.AdminOnly = false
@@ -44,15 +44,27 @@ SWEP.Secondary.Ammo = "none"
 SWEP.IronSightsPos = Vector(-7.64, -8, 3.56)
 SWEP.IronSightsAng = Vector(-0.1, 0.02, 0)
 
+function SWEP:SetupDataTables()
+	BaseClass.SetupDataTables(self)
+	-- Float 0 = LastPrimaryAttack
+	-- Float 1 = ReloadEndTime
+	-- Float 2 = BurstTime
+	-- Float 3 = LastNonBurst
+	self:NetworkVar("Float", 4, "QueuedAttackTime")
+	-- Bool 0 = Ironsights
+	-- Bool 1 = Reloading
+	self:NetworkVar("Bool", 2, "AttackQueued")
+end
+
 function SWEP:Reload()
 	-- Already reloading
-	if self.Weapon.reloading then return end
+	if self:GetReloading() then return end
 
 	-- Start reloading if we can
-	if self.Weapon:Clip1() < self.Primary.ClipSize and self.Owner:GetAmmoCount(self.Primary.Ammo) > 0 then
-		self.Weapon.reloading = true
-		self.Weapon:SetVar("reloadtimer", CurTime() + 0.3)
-		self.Weapon:SendWeaponAnim(ACT_VM_RELOAD)
+	if self:Clip1() < self.Primary.ClipSize and self:GetOwner():GetAmmoCount(self.Primary.Ammo) > 0 then
+		self:SetReloading(true)
+		self:SetReloadEndTime(CurTime() + 0.3)
+		self:SendWeaponAnim(ACT_VM_RELOAD)
 		self:SetIronsights(false)
 		self:SetHoldType(self.HoldType)
 		self.Owner:SetAnimation(PLAYER_RELOAD)
@@ -61,49 +73,49 @@ function SWEP:Reload()
 end
 
 function SWEP:Think()
-	if self.Weapon.reloading then
-		if self.Weapon:GetVar("reloadtimer", 0) < CurTime() then
-			-- Finsished reload -
-			if self.Weapon:Clip1() >= self.Primary.ClipSize or self.Owner:GetAmmoCount(self.Primary.Ammo) <= 0 then
-				self.Weapon.reloading = false
-				return
-			end
+	if self:GetReloadEndTime() ~= 0 and CurTime() >= self:GetReloadEndTime() then
+		-- Finsished reload -
+		if self:Clip1() >= self.Primary.ClipSize or self:GetOwner():GetAmmoCount(self.Primary.Ammo) <= 0 then
+			self:SetReloading(false)
+			self:SetReloadEndTime(0)
+			return
+		end
 
-			if self.queueattack then
-				self.Weapon:SendWeaponAnim(ACT_SHOTGUN_RELOAD_FINISH)
-				self.Weapon.reloading = false
-				self.Weapon.queueattack = false
-				timer.Simple(0.8, function()
-					if not IsValid(self) then return end
-					self:PrimaryAttack()
-				end)
-				return
-			end
+		if self:GetAttackQueued() then
+			self:SendWeaponAnim(ACT_SHOTGUN_RELOAD_FINISH)
+			self:SetReloading(false)
+			self:SetReloadEndTime(0)
+			self:SetAttackQueued(false)
+			self:SetQueuedAttackTime(CurTime() + 0.8)
+			return
+		end
 
-			-- Next cycle
-			self.Weapon:SetVar("reloadtimer", CurTime() + 0.3)
-			self.Weapon:SendWeaponAnim(ACT_VM_RELOAD)
+		-- Next cycle
+		self:SetReloadEndTime(CurTime() + 0.3)
+		self:SendWeaponAnim(ACT_VM_RELOAD)
 
-			-- Add ammo
-			self.Owner:RemoveAmmo(1, self.Primary.Ammo, false)
-			self.Weapon:SetClip1(self.Weapon:Clip1() + 1)
+		-- Add ammo
+		self:GetOwner():RemoveAmmo(1, self.Primary.Ammo, false)
+		self:SetClip1(self:Clip1() + 1)
 
-			-- Finish filling, final pump
-			if self.Weapon:Clip1() >= self.Primary.ClipSize or self.Owner:GetAmmoCount(self.Primary.Ammo) <= 0 then
-				self.Weapon:SendWeaponAnim(ACT_SHOTGUN_RELOAD_FINISH)
-			end
+		-- Finish filling, final pump
+		if self:Clip1() >= self.Primary.ClipSize or self:GetOwner():GetAmmoCount(self.Primary.Ammo) <= 0 then
+			self:SendWeaponAnim(ACT_SHOTGUN_RELOAD_FINISH)
 		end
 	end
-	self.BaseClass.Think(self)
+	if self:GetQueuedAttackTime() ~= 0 and CurTime() >= self:GetQueuedAttackTime() then
+		self:SetQueuedAttackTime(0)
+		self:PrimaryAttack()
+	end
 end
 
 function SWEP:PrimaryAttack()
-	if self.queueattack then return end
+	if self:GetAttackQueued() then return end
 
-	if self.Weapon.reloading then
-		self.queueattack = true -- this way it doesn't interupt the reload animation
+	if self:GetReloading() then
+		self:SetAttackQueued(true) -- this way it doesn't interupt the reload animation
 		return
 	end
 
-	self.BaseClass.PrimaryAttack(self)
+	BaseClass.PrimaryAttack(self)
 end

--- a/gamemode/modules/base/cl_gamemode_functions.lua
+++ b/gamemode/modules/base/cl_gamemode_functions.lua
@@ -47,11 +47,6 @@ function GM:PlayerBindPress(ply, bind, pressed)
 	end
 end
 
-function GM:PlayerNoClip(ply)
-	-- Default action for noclip is to disallow it
-	return false
-end
-
 function GM:InitPostEntity()
 	hook.Call("teamChanged", GAMEMODE, GAMEMODE.DefaultTeam, GAMEMODE.DefaultTeam)
 end

--- a/gamemode/modules/base/sh_gamemode_functions.lua
+++ b/gamemode/modules/base/sh_gamemode_functions.lua
@@ -1,0 +1,14 @@
+function GM:PlayerNoClip(ply)
+	-- Default action for noclip is to disallow it
+	return false
+end
+
+function GM:UpdatePlayerSpeed(ply)
+	if ply:isArrested() then
+		GAMEMODE:SetPlayerSpeed(ply, GAMEMODE.Config.arrestspeed, GAMEMODE.Config.arrestspeed)
+	elseif ply:isCP() then
+		GAMEMODE:SetPlayerSpeed(ply, GAMEMODE.Config.walkspeed, GAMEMODE.Config.runspeedcp)
+	else
+		GAMEMODE:SetPlayerSpeed(ply, GAMEMODE.Config.walkspeed, GAMEMODE.Config.runspeed)
+	end
+end

--- a/gamemode/modules/base/sh_interface.lua
+++ b/gamemode/modules/base/sh_interface.lua
@@ -506,6 +506,20 @@ DarkRP.VECTOR.isInSight = DarkRP.stub{
 	metatable = DarkRP.VECTOR
 }
 
+DarkRP.hookStub{
+	name = "UpdatePlayerSpeed",
+	description = "Change a player's walking and running speed.",
+	parameters = {
+		{
+			name = "ply",
+			description = "The player for whom the speed changes.",
+			type = "Player"
+		}
+	},
+	returns = {
+	}
+}
+
 /*---------------------------------------------------------------------------
 Creating custom items
 ---------------------------------------------------------------------------*/

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -65,7 +65,7 @@ function GM:canDropWeapon(ply, weapon)
 	local team = ply:Team()
 
 	if not GAMEMODE.Config.dropspawnedweapons then
-	if RPExtraTeams[team] and RPExtraTeams[team].weapons and table.HasValue(RPExtraTeams[team].weapons, class) then return false end
+		if RPExtraTeams[team] and RPExtraTeams[team].weapons and table.HasValue(RPExtraTeams[team].weapons, class) then return false end
 	end
 
 	if self.Config.DisallowDrop[class] then return false end
@@ -87,16 +87,6 @@ end
 
 function GM:canSeeLogMessage(ply, message, colour)
 	return ply:hasDarkRPPrivilege("rp_viewlog") or ply:IsAdmin()
-end
-
-function GM:UpdatePlayerSpeed(ply)
-	if ply:isArrested() then
-		GAMEMODE:SetPlayerSpeed(ply, GAMEMODE.Config.arrestspeed, GAMEMODE.Config.arrestspeed)
-	elseif ply:isCP() then
-		GAMEMODE:SetPlayerSpeed(ply, GAMEMODE.Config.walkspeed, GAMEMODE.Config.runspeedcp)
-	else
-		GAMEMODE:SetPlayerSpeed(ply, GAMEMODE.Config.walkspeed, GAMEMODE.Config.runspeed)
-	end
 end
 
 /*---------------------------------------------------------
@@ -914,11 +904,5 @@ end
 timer.Create("RP_DecalCleaner", GM.Config.decaltimer, 0, ClearDecals)
 
 function GM:PlayerSpray()
-
 	return not GAMEMODE.Config.allowsprays
-end
-
-function GM:PlayerNoClip(ply)
-	-- Default action for noclip is to disallow it
-	return false
 end

--- a/gamemode/modules/base/sv_interface.lua
+++ b/gamemode/modules/base/sv_interface.lua
@@ -254,7 +254,7 @@ DarkRP.notify = DarkRP.stub{
 			optional = false
 		},
 		{
-			name = "MsgType",
+			name = "msgType",
 			description = "The type of the message.",
 			type = "number",
 			optional = false
@@ -648,20 +648,6 @@ DarkRP.PLAYER.getPreferredModel = DarkRP.stub{
 		}
 	},
 	metatable = DarkRP.PLAYER
-}
-
-DarkRP.hookStub{
-	name = "UpdatePlayerSpeed",
-	description = "Change a player's walking and running speed.",
-	parameters = {
-		{
-			name = "ply",
-			description = "The player for whom the speed changes.",
-			type = "Player"
-		}
-	},
-	returns = {
-	}
 }
 
 DarkRP.hookStub{


### PR DESCRIPTION
* Lots of prediction fixes.
  - The UpdatePlayerSpeed, canDoorRam, canLockpick and lockpickTime hooks are now shared.
  - The recoil is now less jerky and comes back down after a short period.
  - The only prediction error now is when door ramming a vehicle with a driver as Vehicle:GetDriver() unfortunately only exists serverside.
* Refactored arrest, unarrest and stunsticks to a common stick_base.
  - A lot less code duplication now.
* Added stunstick killicon.
* Relaxed SWEP.IconLetter restrictions to any valid character in the font.
  - Used to be restricted to weapons that exist by default in DarkRP.
  - Now is expanded to [0-9a-wA-Z].
  - Lowercase x-z are not valid characters in the font.
* Increased Deagle and MP5 recoil; decreased MP5 damage.
  - The Deagle had next to no recoil because of the large delay between shots. This didn't matter too much before since the recoil did not come back down but since it does now then this is in need of an increase.
  - The MP5 had its next-to-zero recoil increased slightly. The damage was decreased slightly as it's still one of the most accurate weapons in DarkRP.
* Simplified ls_sniper HUD code.
  - A lot less code duplication.