### PR TITLE
Everything else

### DIFF
--- a/entities/entities/letter/init.lua
+++ b/entities/entities/letter/init.lua
@@ -62,7 +62,7 @@ end)
 
 local function removeLetters(ply, cmd, args)
 	if ply:EntIndex() ~= 0 and not ply:hasDarkRPPrivilege("rp_commands") then
-		ply:PrintMessage(2, DarkRP.getPhrase("need_admin", "rp_removeletters"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_admin", "rp_removeletters"))
 		return
 	end
 

--- a/gamemode/libraries/modificationloader.lua
+++ b/gamemode/libraries/modificationloader.lua
@@ -140,5 +140,5 @@ function GM:DarkRPFinishedLoading()
 	loadLanguages()
 	loadModules()
 	loadCustomDarkRPItems()
-	hook.Run("loadCustomDarkRPItems", GAMEMODE)
+	hook.Call("loadCustomDarkRPItems", GAMEMODE)
 end

--- a/gamemode/modules/base/cl_entityvars.lua
+++ b/gamemode/modules/base/cl_entityvars.lua
@@ -89,16 +89,3 @@ timer.Create("DarkRPCheckifitcamethrough", 15, 0, function()
 
 	timer.Destroy("DarkRPCheckifitcamethrough")
 end)
-
-/*---------------------------------------------------------------------------
-RP name override
----------------------------------------------------------------------------*/
-pmeta.SteamName = pmeta.SteamName or pmeta.Name
-function pmeta:Name()
-	if not self:IsValid() then DarkRP.error("Attempt to call Name/Nick/GetName on a non-existing player!", 2) end
-	return GAMEMODE.Config.allowrpnames and self:getDarkRPVar("rpname")
-		or self:SteamName()
-end
-
-pmeta.GetName = pmeta.Name
-pmeta.Nick = pmeta.Name

--- a/gamemode/modules/base/cl_fonts.lua
+++ b/gamemode/modules/base/cl_fonts.lua
@@ -4,19 +4,22 @@ The fonts that DarkRP uses
 ---------------------------------------------------------------------------*/
 -----------------------------------------------------------------------------]]
 local function loadFonts()
-	surface.CreateFont ("DarkRPHUD1", {
-		size = 16,
+	local tahoma = system.IsLinux() and "DejaVu Sans" or "Tahoma"
+	local tahomaSize = system.IsLinux() and fp{fn.Flip(fn.Add), 1} or fn.Id
+
+	surface.CreateFont("DarkRPHUD1", {
+		size = tahomaSize(16),
 		weight = 600,
 		antialias = true,
 		shadow = true,
-		font = "DejaVu Sans"})
+		font = tahoma})
 
-	surface.CreateFont ("DarkRPHUD2", {
+	surface.CreateFont("DarkRPHUD2", {
 		size = 23,
 		weight = 400,
 		antialias = true,
 		shadow = false,
-		font = "coolvetica"})
+		font = "Coolvetica"})
 
 	surface.CreateFont("Trebuchet18", {
 		size = 18,
@@ -25,22 +28,8 @@ local function loadFonts()
 		shadow = false,
 		font = "Trebuchet MS"})
 
-	surface.CreateFont("Trebuchet19", {
-		size = 19,
-		weight = 500,
-		antialias = true,
-		shadow = false,
-		font = "Trebuchet MS"})
-
 	surface.CreateFont("Trebuchet20", {
 		size = 20,
-		weight = 500,
-		antialias = true,
-		shadow = false,
-		font = "Trebuchet MS"})
-
-	surface.CreateFont("Trebuchet22", {
-		size = 22,
 		weight = 500,
 		antialias = true,
 		shadow = false,
@@ -54,11 +43,11 @@ local function loadFonts()
 		font = "Trebuchet MS"})
 
 	surface.CreateFont("TabLarge", {
-		size = 17,
+		size = tahomaSize(15),
 		weight = 700,
 		antialias = true,
 		shadow = false,
-		font = "Trebuchet MS"})
+		font = tahoma})
 
 	surface.CreateFont("UiBold", {
 		size = 16,
@@ -79,44 +68,43 @@ local function loadFonts()
 		weight = 500,
 		antialias = true,
 		shadow = false,
-		font = "coolvetica"})
+		font = "Coolvetica"})
 
 	surface.CreateFont("ScoreboardSubtitle", {
 		size = 22,
 		weight = 500,
 		antialias = true,
 		shadow = false,
-		font = "coolvetica"})
+		font = "Coolvetica"})
 
 	surface.CreateFont("ScoreboardPlayerName", {
 		size = 19,
 		weight = 500,
 		antialias = true,
 		shadow = false,
-		font = "coolvetica"})
+		font = "Coolvetica"})
 
 	surface.CreateFont("ScoreboardPlayerName2", {
 		size = 15,
 		weight = 500,
 		antialias = true,
 		shadow = false,
-		font = "coolvetica"})
+		font = "Coolvetica"})
 
 	surface.CreateFont("ScoreboardPlayerNameBig", {
 		size = 22,
 		weight = 500,
 		antialias = true,
 		shadow = false,
-		font = "coolvetica"})
+		font = "Coolvetica"})
 
 	surface.CreateFont("AckBarWriting", {
 		size = 20,
 		weight = 500,
 		antialias = true,
 		shadow = false,
-		font = "akbar"})
+		font = "Akbar"})
 end
 loadFonts()
 -- Load twice because apparently once is not enough
 hook.Add("InitPostEntity", "DarkRP_LoadFonts", loadFonts)
-

--- a/gamemode/modules/base/sh_createitems.lua
+++ b/gamemode/modules/base/sh_createitems.lua
@@ -458,31 +458,27 @@ local function addTeamCommands(CTeam, max)
 
 	concommand.Add("rp_"..CTeam.command, function(ply, cmd, args)
 		if ply:EntIndex() ~= 0 and not ply:IsAdmin() then
-			ply:PrintMessage(2, DarkRP.getPhrase("need_admin", cmd))
+			ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_admin", cmd))
 			return
 		end
 
 		if CTeam.admin > 1 and not ply:IsSuperAdmin() and ply:EntIndex() ~= 0 then
-			ply:PrintMessage(2, DarkRP.getPhrase("need_sadmin", cmd))
+			ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_sadmin", cmd))
 			return
 		end
 
 		if CTeam.vote then
 			if CTeam.admin >= 1 and ply:EntIndex() ~= 0 and not ply:IsSuperAdmin() then
-				ply:PrintMessage(2, DarkRP.getPhrase("need_sadmin", cmd))
+				ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_sadmin", cmd))
 				return
 			elseif CTeam.admin > 1 and ply:IsSuperAdmin() and ply:EntIndex() ~= 0 then
-				ply:PrintMessage(2, DarkRP.getPhrase("need_to_make_vote", CTeam.name))
+				ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_to_make_vote", CTeam.name))
 				return
 			end
 		end
 
 		if not args or not args[1] then
-			if ply:EntIndex() == 0 then
-				print(DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-			else
-				ply:PrintMessage(2, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-			end
+			DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
 			return
 		end
 
@@ -496,13 +492,9 @@ local function addTeamCommands(CTeam, max)
 			else
 				nick = "Console"
 			end
-			target:PrintMessage(2, DarkRP.getPhrase("x_made_you_a_y", nick, CTeam.name))
+			DarkRP.notify(target, 0, 4, DarkRP.getPhrase("x_made_you_a_y", nick, CTeam.name))
 		else
-			if (ply:EntIndex() == 0) then
-				print(DarkRP.getPhrase("could_not_find", tostring(args[1])))
-			else
-				ply:PrintMessage(2, DarkRP.getPhrase("could_not_find", tostring(args[1])))
-			end
+			DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
 		end
 	end)
 end

--- a/gamemode/modules/base/sh_entityvars.lua
+++ b/gamemode/modules/base/sh_entityvars.lua
@@ -97,3 +97,16 @@ DarkRP.registerDarkRPVar("Arrested",      net.WriteBit, fc{tobool, net.ReadBit})
 DarkRP.registerDarkRPVar("wanted",        net.WriteBit, fc{tobool, net.ReadBit})
 DarkRP.registerDarkRPVar("wantedReason",  net.WriteString, net.ReadString)
 DarkRP.registerDarkRPVar("agenda",        net.WriteString, net.ReadString)
+
+/*---------------------------------------------------------------------------
+RP name override
+---------------------------------------------------------------------------*/
+local pmeta = FindMetaTable("Player")
+pmeta.SteamName = pmeta.SteamName or pmeta.Name
+function pmeta:Name()
+	if not self:IsValid() then DarkRP.error("Attempt to call Name/Nick/GetName on a non-existing player!", SERVER and 1 or 2) end
+	return GAMEMODE.Config.allowrpnames and self:getDarkRPVar("rpname")
+		or self:SteamName()
+end
+pmeta.GetName = pmeta.Name
+pmeta.Nick = pmeta.Name

--- a/gamemode/modules/base/sv_entityvars.lua
+++ b/gamemode/modules/base/sv_entityvars.lua
@@ -167,19 +167,6 @@ DarkRP.defineChatCommand("name", RPName)
 DarkRP.defineChatCommand("nick", RPName)
 
 /*---------------------------------------------------------------------------
-Nickname override to show RP name
----------------------------------------------------------------------------*/
-meta.SteamName = meta.SteamName or meta.Name
-function meta:Name()
-	-- Error level is 1 because this file is somehow left out of the trace.
-	if not self:IsValid() then return DarkRP.error("Attempt to call Name/Nick/GetName on a non-existing player!", 1) end
-	return GAMEMODE.Config.allowrpnames and self.DarkRPVars and self:getDarkRPVar("rpname")
-		or self:SteamName()
-end
-meta.Nick = meta.Name
-meta.GetName = meta.Name
-
-/*---------------------------------------------------------------------------
 Setting the RP name
 ---------------------------------------------------------------------------*/
 function meta:setRPName(name, firstRun)

--- a/gamemode/modules/base/sv_entityvars.lua
+++ b/gamemode/modules/base/sv_entityvars.lua
@@ -102,16 +102,12 @@ Admin DarkRPVar commands
 ---------------------------------------------------------------------------*/
 local function setRPName(ply, cmd, args)
 	if not args[2] or string.len(args[2]) < 2 or string.len(args[2]) > 30 then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), "<2/>30"))
-		else
-			ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), "<2/>30"))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), "<2/>30"))
 		return
 	end
 
 	if ply:EntIndex() ~= 0 and not ply:IsAdmin() then
-		ply:PrintMessage(2, DarkRP.getPhrase("need_admin", "rp_setname"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_admin", "rp_setname"))
 		return
 	end
 
@@ -123,25 +119,22 @@ local function setRPName(ply, cmd, args)
 		DarkRP.storeRPName(target, args[2])
 		target:setDarkRPVar("rpname", args[2])
 
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("you_set_x_name", oldname, args[2]))
+
+		local nick = ""
 		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("you_set_x_name", oldname, args[2]))
 			nick = "Console"
 		else
-			ply:PrintMessage(2, DarkRP.getPhrase("you_set_x_name", oldname, args[2]))
 			nick = ply:Nick()
 		end
-		target:PrintMessage(2, DarkRP.getPhrase("x_set_your_name", nick, args[2]))
+		DarkRP.notify(target, 0, 4, DarkRP.getPhrase("x_set_your_name", nick, args[2]))
 		if ply:EntIndex() == 0 then
 			DarkRP.log("Console set " .. target:SteamName() .. "'s name to " .. args[2], Color(30, 30, 30))
 		else
 			DarkRP.log(ply:Nick() .. " (" .. ply:SteamID() .. ") set " .. target:SteamName() .. "'s name to " .. args[2], Color(30, 30, 30))
 		end
 	else
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
 	end
 end
 concommand.Add("rp_setname", setRPName)
@@ -153,7 +146,7 @@ local function RPName(ply, args)
 	end
 
 	if not GAMEMODE.Config.allowrpnames then
-		DarkRP.notify(ply, 1, 6,  DarkRP.getPhrase("disabled", "RPname", ""))
+		DarkRP.notify(ply, 1, 6, DarkRP.getPhrase("disabled", "RPname", ""))
 		return ""
 	end
 

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -413,9 +413,7 @@ function GM:PlayerDeath(ply, weapon, killer)
 	if ply:isArrested() and not GAMEMODE.Config.respawninjail  then
 		-- If the player died in jail, make sure they can't respawn until their jail sentance is over
 		ply.NextSpawnTime = CurTime() + math.ceil(GAMEMODE.Config.jailtimer - (CurTime() - ply.LastJailed)) + 1
-		for a, b in pairs(player.GetAll()) do
-			b:PrintMessage(HUD_PRINTCENTER, DarkRP.getPhrase("died_in_jail", ply:Nick()))
-		end
+		DarkRP.printMessageAll(HUD_PRINTCENTER, DarkRP.getPhrase("died_in_jail", ply:Nick()))
 		DarkRP.notify(ply, 4, 4, DarkRP.getPhrase("dead_in_jail"))
 	else
 		-- Normal death, respawning.

--- a/gamemode/modules/base/sv_interface.lua
+++ b/gamemode/modules/base/sv_interface.lua
@@ -327,6 +327,28 @@ DarkRP.printMessageAll = DarkRP.stub{
 	metatable = DarkRP
 }
 
+DarkRP.printConsoleMessage = DarkRP.stub{
+	name = "printConsoleMessage",
+	description = "Prints a message to a given player's console. This function also handles server consoles too (EntIndex = 0).",
+	parameters = {
+		{
+			name = "ply",
+			description = "The player to send the console message to.",
+			type = "Player",
+			optional = false
+		},
+		{
+			name = "msg",
+			description = "The actual message.",
+			type = "string",
+			optional = false
+		}
+	},
+	returns = {
+	},
+	metatable = DarkRP
+}
+
 DarkRP.talkToRange = DarkRP.stub{
 	name = "talkToRange",
 	description = "Send a chat message to people close to a player.",

--- a/gamemode/modules/base/sv_util.lua
+++ b/gamemode/modules/base/sv_util.lua
@@ -64,16 +64,14 @@ function DarkRP.talkToPerson(receiver, col1, text1, col2, text2, sender)
 		net.WriteUInt(col1.b, 8)
 		net.WriteString(text1)
 
-		if sender then
-			net.WriteEntity(sender)
-		end
+		sender = sender or Entity(0)
+		net.WriteEntity(sender)
 
-		if col2 and text2 then
-			net.WriteUInt(col2.r, 8)
-			net.WriteUInt(col2.g, 8)
-			net.WriteUInt(col2.b, 8)
-			net.WriteString(text2)
-		end
+		col2 = col2 or Color(0, 0, 0)
+		net.WriteUInt(col2.r, 8)
+		net.WriteUInt(col2.g, 8)
+		net.WriteUInt(col2.b, 8)
+		net.WriteString(text2 or "")
 	net.Send(receiver)
 end
 

--- a/gamemode/modules/base/sv_util.lua
+++ b/gamemode/modules/base/sv_util.lua
@@ -21,6 +21,14 @@ function DarkRP.printMessageAll(msgtype, msg)
 	end
 end
 
+function DarkRP.printConsoleMessage(ply, msg)
+	if ply:EntIndex() == 0 then
+		print(msg)
+	else
+		ply:PrintMessage(HUD_PRINTCONSOLE, msg)
+	end
+end
+
 util.AddNetworkString("DarkRP_Chat")
 
 function DarkRP.talkToRange(ply, PlayerName, Message, size)
@@ -134,40 +142,22 @@ end
 
 local function LookPersonUp(ply, cmd, args)
 	if not args[1] then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("invalid_x", "argument", ""))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("invalid_x", "argument", ""))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", "argument", ""))
 		return
 	end
 	local P = DarkRP.findPlayer(args[1])
 	if not IsValid(P) then
-		if ply:EntIndex() ~= 0 then
-			ply:PrintMessage(2, DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		else
-			print(DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
 		return
 	end
-	if ply:EntIndex() ~= 0 then
-		ply:PrintMessage(2, DarkRP.getPhrase("name", P:Nick()))
-		ply:PrintMessage(2, "Steam ".. DarkRP.getPhrase("name", P:SteamName()))
-		ply:PrintMessage(2, "Steam ID: "..P:SteamID())
-		ply:PrintMessage(2, DarkRP.getPhrase("job", team.GetName(P:Team())))
-		ply:PrintMessage(2, DarkRP.getPhrase("kills", P:Frags()))
-		ply:PrintMessage(2, DarkRP.getPhrase("deaths", P:Deaths()))
-		if ply:IsAdmin() then
-			ply:PrintMessage(2, DarkRP.getPhrase("wallet", DarkRP.formatMoney(P:getDarkRPVar("money")), ""))
-		end
-	else
-		print(DarkRP.getPhrase("name", P:Nick()))
-		print("Steam ".. DarkRP.getPhrase("name", P:SteamName()))
-		print("Steam ID: "..P:SteamID())
-		print(DarkRP.getPhrase("job", team.GetName(P:Team())))
-		print(DarkRP.getPhrase("kills", P:Frags()))
-		print(DarkRP.getPhrase("deaths", P:Deaths()))
-		print(DarkRP.getPhrase("wallet", DarkRP.formatMoney(P:getDarkRPVar("money")), ""))
+	DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("name", P:Nick()))
+	DarkRP.printConsoleMessage(ply, "Steam ".. DarkRP.getPhrase("name", P:SteamName()))
+	DarkRP.printConsoleMessage(ply, "Steam ID: "..P:SteamID())
+	DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("job", team.GetName(P:Team())))
+	DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("kills", P:Frags()))
+	DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("deaths", P:Deaths()))
+	if ply:EntIndex() == 0 or ply:IsAdmin() then
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("wallet", DarkRP.formatMoney(P:getDarkRPVar("money")), ""))
 	end
 end
 concommand.Add("rp_lookup", LookPersonUp)

--- a/gamemode/modules/doorsystem/sv_dooradministration.lua
+++ b/gamemode/modules/doorsystem/sv_dooradministration.lua
@@ -5,14 +5,14 @@ local function ccDoorOwn(ply, cmd, args)
 	end
 
 	if not ply:hasDarkRPPrivilege("rp_commands") then
-		ply:PrintMessage(2, DarkRP.getPhrase("need_admin", "rp_own"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_admin", "rp_own"))
 		return
 	end
 
 	local trace = ply:GetEyeTrace()
 
 	if not IsValid(trace.Entity) or not trace.Entity:isKeysOwnable() or ply:EyePos():Distance(trace.Entity:GetPos()) > 200 then
-		ply:PrintMessage(2, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("door_or_vehicle")))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("door_or_vehicle")))
 		return
 	end
 
@@ -30,14 +30,14 @@ local function ccDoorUnOwn(ply, cmd, args)
 	end
 
 	if not ply:hasDarkRPPrivilege("rp_commands") then
-		ply:PrintMessage(2, DarkRP.getPhrase("need_admin", "rp_unown"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_admin", "rp_unown"))
 		return
 	end
 
 	local trace = ply:GetEyeTrace()
 
 	if not IsValid(trace.Entity) or not trace.Entity:isKeysOwnable() or ply:EyePos():Distance(trace.Entity:GetPos()) > 200 then
-		ply:PrintMessage(2, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("door_or_vehicle")))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("door_or_vehicle")))
 		return
 	end
 
@@ -48,33 +48,20 @@ end
 concommand.Add("rp_unown", ccDoorUnOwn)
 
 local function unownAll(ply, cmd, args)
-	if ply:EntIndex() == 0 then
-		print(DarkRP.getPhrase("cmd_cant_be_run_server_console"))
-		return
-	end
-
 	if ply:EntIndex() ~= 0 and not ply:hasDarkRPPrivilege("rp_commands") then
-		ply:PrintMessage(2, DarkRP.getPhrase("need_admin", "rp_unown"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_admin", "rp_unown"))
 		return
 	end
 
 	if not args or not args[1] then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
 		return
 	end
 
 	local target = DarkRP.findPlayer(args[1])
-	
+
 	if not IsValid(target) then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
 		return
 	end
 	target:keysUnOwnAll()
@@ -94,19 +81,19 @@ local function ccAddOwner(ply, cmd, args)
 	end
 
 	if not ply:hasDarkRPPrivilege("rp_commands") then
-		ply:PrintMessage(2, DarkRP.getPhrase("need_admin", "rp_addowner"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_admin", "rp_addowner"))
 		return
 	end
 
 	if not args or not args[1] then
-		ply:PrintMessage(2, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
 		return
 	end
 
 	local trace = ply:GetEyeTrace()
 
 	if not IsValid(trace.Entity) or not trace.Entity:isKeysOwnable() or ply:EyePos():Distance(trace.Entity:GetPos()) > 200 then
-		ply:PrintMessage(2, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("door_or_vehicle")))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("door_or_vehicle")))
 		return
 	end
 
@@ -117,14 +104,14 @@ local function ccAddOwner(ply, cmd, args)
 			if not trace.Entity:isKeysOwnedBy(target) and not trace.Entity:isKeysAllowedToOwn(target) then
 				trace.Entity:addKeysAllowedToOwn(target)
 			else
-				ply:PrintMessage(2, DarkRP.getPhrase("rp_addowner_already_owns_door", target))
+				ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("rp_addowner_already_owns_door", target))
 			end
 		else
 			trace.Entity:keysOwn(target)
 		end
 		DarkRP.log(ply:Nick().." ("..ply:SteamID()..") force-added a door owner with rp_addowner", Color(30, 30, 30))
 	else
-		ply:PrintMessage(2, DarkRP.getPhrase("could_not_find", tostring(args[1])))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("could_not_find", tostring(args[1])))
 	end
 end
 concommand.Add("rp_addowner", ccAddOwner)
@@ -136,19 +123,19 @@ local function ccRemoveOwner(ply, cmd, args)
 	end
 
 	if not ply:hasDarkRPPrivilege("rp_commands") then
-		ply:PrintMessage(2,  DarkRP.getPhrase("need_admin", "rp_removeowner"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_admin", "rp_removeowner"))
 		return
 	end
 
 	if not args or not args[1] then
-		ply:PrintMessage(2, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
 		return
 	end
 
 	local trace = ply:GetEyeTrace()
 
 	if not IsValid(trace.Entity) or not trace.Entity:isKeysOwnable() or ply:EyePos():Distance(trace.Entity:GetPos()) > 200 then
-		ply:PrintMessage(2, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("door_or_vehicle")))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("door_or_vehicle")))
 		return
 	end
 
@@ -164,7 +151,7 @@ local function ccRemoveOwner(ply, cmd, args)
 		end
 		DarkRP.log(ply:Nick().." ("..ply:SteamID()..") force-removed a door owner with rp_removeowner", Color(30, 30, 30))
 	else
-		ply:PrintMessage(2, DarkRP.getPhrase("could_not_find", tostring(args[1])))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("could_not_find", tostring(args[1])))
 	end
 end
 concommand.Add("rp_removeowner", ccRemoveOwner)
@@ -176,18 +163,18 @@ local function ccLock(ply, cmd, args)
 	end
 
 	if not ply:hasDarkRPPrivilege("rp_commands") then
-		ply:PrintMessage(2,  DarkRP.getPhrase("need_admin", "rp_lock"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_admin", "rp_lock"))
 		return
 	end
 
 	local trace = ply:GetEyeTrace()
 
 	if not IsValid(trace.Entity) or not trace.Entity:isKeysOwnable() or ply:EyePos():Distance(trace.Entity:GetPos()) > 200 then
-		ply:PrintMessage(2, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("door_or_vehicle")))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("door_or_vehicle")))
 		return
 	end
 
-	ply:PrintMessage(2, DarkRP.getPhrase("locked"))
+	ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("locked"))
 
 	trace.Entity:keysLock()
 
@@ -204,18 +191,18 @@ local function ccUnLock(ply, cmd, args)
 	end
 
 	if not ply:hasDarkRPPrivilege("rp_commands") then
-		ply:PrintMessage(2,  DarkRP.getPhrase("need_admin", "rp_unlock"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_admin", "rp_unlock"))
 		return
 	end
 
 	local trace = ply:GetEyeTrace()
 
 	if not IsValid(trace.Entity) or not trace.Entity:isKeysOwnable() or ply:EyePos():Distance(trace.Entity:GetPos()) > 200 then
-		ply:PrintMessage(2, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("door_or_vehicle")))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("door_or_vehicle")))
 		return
 	end
 
-	ply:PrintMessage(2, DarkRP.getPhrase("unlocked"))
+	ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("unlocked"))
 	trace.Entity:keysUnLock()
 
 	if not trace.Entity:CreatedByMap() then return end

--- a/gamemode/modules/f1menu/cl_htmlcontrols.lua
+++ b/gamemode/modules/f1menu/cl_htmlcontrols.lua
@@ -1,9 +1,9 @@
-surface.CreateFont ("F1AddressBar", {
+surface.CreateFont("F1AddressBar", {
 		size = 14,
 		weight = 400,
 		antialias = true,
 		shadow = false,
-		font = "coolvetica"})
+		font = "Coolvetica"})
 
 local PANEL = {}
 

--- a/gamemode/modules/f1menu/cl_titlelabel.lua
+++ b/gamemode/modules/f1menu/cl_titlelabel.lua
@@ -3,7 +3,7 @@ surface.CreateFont("F1MenuTitle", {
 		weight = 500,
 		antialias = true,
 		shadow = false,
-		font = "coolvetica"})
+		font = "Coolvetica"})
 
 local PANEL = {}
 

--- a/gamemode/modules/hud/sv_admintell.lua
+++ b/gamemode/modules/hud/sv_admintell.lua
@@ -3,16 +3,12 @@ Messages
 ---------------------------------------------------------------------------*/
 local function ccTell(ply, cmd, args)
 	if not args or not args[1] then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
 		return
 	end
 
 	if ply:EntIndex() ~= 0 and not ply:hasDarkRPPrivilege("rp_commands") then
-		ply:PrintMessage(2, DarkRP.getPhrase("need_admin", "rp_tell"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_admin", "rp_tell"))
 		return
 	end
 
@@ -35,27 +31,19 @@ local function ccTell(ply, cmd, args)
 			DarkRP.log(ply:Nick().." ("..ply:SteamID()..") did rp_tell \""..msg .. "\" on "..target:SteamName(), Color(30, 30, 30))
 		end
 	else
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
 	end
 end
 concommand.Add("rp_tell", ccTell)
 
 local function ccTellAll(ply, cmd, args)
 	if not args or not args[1] then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
 		return
 	end
 
 	if ply:EntIndex() ~= 0 and not ply:hasDarkRPPrivilege("rp_commands") then
-		ply:PrintMessage(2, DarkRP.getPhrase("need_admin", "rp_tellall"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_admin", "rp_tellall"))
 		return
 	end
 

--- a/gamemode/modules/jobs/sv_jobs.lua
+++ b/gamemode/modules/jobs/sv_jobs.lua
@@ -189,7 +189,6 @@ function meta:changeAllowed(t)
 	if self.bannedfrom[group] then return false else return true end
 end
 
-
 function GM:canChangeJob(ply, args)
 	if ply:isArrested() then return false end
 	if ply.LastJob and 10 - (CurTime() - ply.LastJob) >= 0 then return false, DarkRP.getPhrase("have_to_wait", math.ceil(10 - (CurTime() - ply.LastJob)), "/job") end
@@ -371,11 +370,7 @@ local function DoTeamBan(ply, args, cmdargs)
 	end
 
 	if cmdargs and not cmdargs[2] then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("rp_teamban_hint"))
-		else
-			ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("rp_teamban_hint"))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("rp_teamban_hint"))
 		return
 	end
 
@@ -385,11 +380,8 @@ local function DoTeamBan(ply, args, cmdargs)
 
 	local target = DarkRP.findPlayer(ent)
 	if not target or not IsValid(target) then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("could_not_find", ent or ""))
-			return
-		elseif cmdargs then
-			ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("could_not_find", ent or ""))
+		if cmdargs then
+			DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", ent or ""))
 			return
 		else
 			DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", ent or ""))
@@ -407,11 +399,8 @@ local function DoTeamBan(ply, args, cmdargs)
 	end
 
 	if not found then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("could_not_find", Team or ""))
-			return
-		elseif cmdargs then
-			ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("could_not_find", Team or ""))
+		if cmdargs then
+			DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", Team or ""))
 			return
 		else
 			DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", Team or ""))
@@ -449,11 +438,7 @@ local function DoTeamUnBan(ply, args, cmdargs)
 	local Team = args
 	if cmdargs then
 		if not cmdargs[2] then
-			if ply:EntIndex() == 0 then
-				print(DarkRP.getPhrase("rp_teamunban_hint"))
-			else
-				ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("rp_teamunban_hint"))
-			end
+			DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("rp_teamunban_hint"))
 			return
 		end
 		ent = cmdargs[1]
@@ -466,11 +451,8 @@ local function DoTeamUnBan(ply, args, cmdargs)
 
 	local target = DarkRP.findPlayer(ent)
 	if not target or not IsValid(target) then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("could_not_find", ent or ""))
-			return
-		elseif cmdargs then
-			ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("could_not_find", ent or ""))
+		if cmdargs then
+			DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", ent or ""))
 			return
 		else
 			DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", ent or ""))
@@ -492,11 +474,8 @@ local function DoTeamUnBan(ply, args, cmdargs)
 	end
 
 	if not found then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("could_not_find", Team or ""))
-			return
-		elseif cmdargs then
-			ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("could_not_find", Team or ""))
+		if cmdargs then
+			DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", Team or ""))
 			return
 		else
 			DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", Team or ""))

--- a/gamemode/modules/money/sv_money.lua
+++ b/gamemode/modules/money/sv_money.lua
@@ -227,22 +227,18 @@ DarkRP.defineChatCommand("check", CreateCheque, 0.3) -- for those of you who can
 
 local function ccSetMoney(ply, cmd, args)
 	if not tonumber(args[2]) then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		else
-			ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
 		return
 	end
 	if ply:EntIndex() ~= 0 and not ply:IsSuperAdmin() then
-		ply:PrintMessage(2, DarkRP.getPhrase("need_sadmin", "rp_setmoney"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_sadmin", "rp_setmoney"))
 		return
 	end
 
 	local target = DarkRP.findPlayer(args[1])
 
 	if not target then
-		DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("invalid_x", "argument", "target"))
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
 		return
 	end
 
@@ -253,93 +249,68 @@ local function ccSetMoney(ply, cmd, args)
 	end
 
 	if target then
-		local nick = ""
 		DarkRP.storeMoney(target, amount)
 		target:setDarkRPVar("money", amount)
 
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("you_set_x_money", target:Nick(), DarkRP.formatMoney(amount), ""))
+
+		local nick = ""
 		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("you_set_x_money", target:Nick(), DarkRP.formatMoney(amount), ""))
 			nick = "Console"
 		else
-			ply:PrintMessage(2, DarkRP.getPhrase("you_set_x_money", target:Nick(), DarkRP.formatMoney(amount), ""))
 			nick = ply:Nick()
 		end
-		target:PrintMessage(2, DarkRP.getPhrase("x_set_your_money", nick, DarkRP.formatMoney(amount), ""))
+		DarkRP.notify(target, 0, 4, DarkRP.getPhrase("x_set_your_money", nick, DarkRP.formatMoney(amount), ""))
 		if ply:EntIndex() == 0 then
 			DarkRP.log("Console set " .. target:SteamName() .. "'s money to " .. DarkRP.formatMoney(amount), Color(30, 30, 30))
 		else
 			DarkRP.log(ply:Nick() .. " (" .. ply:SteamID() .. ") set " .. target:SteamName() .. "'s money to " ..  DarkRP.formatMoney(amount), Color(30, 30, 30))
 		end
 	else
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("could_not_find", args[1]))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("could_not_find", args[1]))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
 	end
 end
 concommand.Add("rp_setmoney", ccSetMoney, function() return {"rp_setmoney   <ply>   <amount>   [+/-]"} end)
 
 local function ccSetSalary(ply, cmd, args)
 	if not tonumber(args[2]) then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		else
-			ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
 		return
 	end
 	if ply:EntIndex() ~= 0 and not ply:IsSuperAdmin() then
-		ply:PrintMessage(2, DarkRP.getPhrase("need_sadmin", "rp_setsalary"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_sadmin", "rp_setsalary"))
 		return
 	end
 
 	local amount = math.floor(tonumber(args[2]))
 
-	if amount < 0 then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), args[2]))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), args[2]))
-		end
-		return
-	end
-
-	if amount > 150 then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), args[2].." (<150)"))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), args[2].." (<150)"))
-		end
+	if amount < 0 or amount > 150 then
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), tostring(args[2]).." (0-150)"))
 		return
 	end
 
 	local target = DarkRP.findPlayer(args[1])
 
 	if target then
-		local nick = ""
 		DarkRP.storeSalary(target, amount)
 		target:setSelfDarkRPVar("salary", amount)
 
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("you_set_x_salary", target:Nick(), DarkRP.formatMoney(amount), ""))
+
+		local nick = ""
 		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("you_set_x_salary", target:Nick(), DarkRP.formatMoney(amount), ""))
 			nick = "Console"
 		else
-			ply:PrintMessage(2, DarkRP.getPhrase("you_set_x_salary", target:Nick(), DarkRP.formatMoney(amount), ""))
 			nick = ply:Nick()
 		end
-		target:PrintMessage(2, DarkRP.getPhrase("x_set_your_salary", nick, DarkRP.formatMoney(amount), ""))
+		DarkRP.notify(target, 0, 4, DarkRP.getPhrase("x_set_your_salary", nick, DarkRP.formatMoney(amount), ""))
 		if ply:EntIndex() == 0 then
 			DarkRP.log("Console set " .. target:SteamName() .. "'s salary to " .. DarkRP.formatMoney(amount), Color(30, 30, 30))
 		else
 			DarkRP.log(ply:Nick() .. " (" .. ply:SteamID() .. ") set " .. target:SteamName() .. "'s salary to " .. DarkRP.formatMoney(amount), Color(30, 30, 30))
 		end
 	else
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
 		return
 	end
 end

--- a/gamemode/modules/police/sv_commands.lua
+++ b/gamemode/modules/police/sv_commands.lua
@@ -293,16 +293,12 @@ DarkRP.defineChatCommand("givelicense", GiveLicense)
 
 local function rp_GiveLicense(ply, cmd, args)
 	if ply:EntIndex() ~= 0 and not ply:IsSuperAdmin() then
-		ply:PrintMessage(2, DarkRP.getPhrase("need_sadmin", "rp_givelicense"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_sadmin", "rp_givelicense"))
 		return
 	end
 
 	if not args or not args[1] then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
 		return
 	end
 
@@ -322,35 +318,23 @@ local function rp_GiveLicense(ply, cmd, args)
 
 		DarkRP.notify(target, 0, 4, DarkRP.getPhrase("gunlicense_granted", nick, target:Nick()))
 		if ply ~= target then
-			if ply:EntIndex() == 0 then
-				print(DarkRP.getPhrase("gunlicense_granted", nick, target:Nick()))
-			else
-				ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("gunlicense_granted", nick, target:Nick()))
-			end
+			DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("gunlicense_granted", nick, target:Nick()))
 		end
 		DarkRP.log(nick.." ("..steamID..") force-gave "..target:Nick().." a gun license", Color(30, 30, 30))
 	else
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
 	end
 end
 concommand.Add("rp_givelicense", rp_GiveLicense)
 
 local function rp_RevokeLicense(ply, cmd, args)
 	if ply:EntIndex() ~= 0 and not ply:IsSuperAdmin() then
-		ply:PrintMessage(2, DarkRP.getPhrase("need_sadmin", "rp_revokelicense"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_sadmin", "rp_revokelicense"))
 		return
 	end
 
 	if not args or not args[1] then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
 		return
 	end
 
@@ -370,19 +354,11 @@ local function rp_RevokeLicense(ply, cmd, args)
 
 		DarkRP.notify(target, 1, 4, DarkRP.getPhrase("gunlicense_denied", nick, target:Nick()))
 		if ply ~= target then
-			if ply:EntIndex() == 0 then
-				print(DarkRP.getPhrase("gunlicense_denied", nick, target:Nick()))
-			else
-				ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("gunlicense_granted", nick, target:Nick()))
-			end
+			DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("gunlicense_denied", nick, target:Nick()))
 		end
 		DarkRP.log(nick.." ("..steamID..") force-removed "..target:Nick().."'s gun license", Color(30, 30, 30))
 	else
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
 	end
 end
 concommand.Add("rp_revokelicense", rp_RevokeLicense)

--- a/gamemode/modules/police/sv_init.lua
+++ b/gamemode/modules/police/sv_init.lua
@@ -205,37 +205,24 @@ Admin commands
 ---------------------------------------------------------------------------*/
 local function ccArrest(ply, cmd, args)
 	if ply:EntIndex() ~= 0 and not ply:hasDarkRPPrivilege("rp_commands") then
-		ply:PrintMessage(2, DarkRP.getPhrase("need_admin", "rp_arrest"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_admin", "rp_arrest"))
 		return
 	end
 
 	if not args or not args[1] then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
 		return
 	end
 
 	if DarkRP.jailPosCount() == 0 then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("no_jail_pos"))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("no_jail_pos"))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("no_jail_pos"))
 		return
 	end
 
 	local targets = DarkRP.findPlayers(args[1])
 
 	if not targets then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		end
-
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
 		return
 	end
 
@@ -258,28 +245,19 @@ concommand.Add("rp_arrest", ccArrest)
 
 local function ccUnarrest(ply, cmd, args)
 	if ply:EntIndex() ~= 0 and not ply:hasDarkRPPrivilege("rp_commands") then
-		ply:PrintMessage(2, DarkRP.getPhrase("need_admin", "rp_unarrest"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_admin", "rp_unarrest"))
 		return
 	end
 
 	if not args or not args[1] then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
 		return
 	end
 
 	local targets = DarkRP.findPlayers(args[1])
 
 	if not targets then
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("could_not_find", tostring(args[1])))
-		end
-
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
 		return
 	end
 

--- a/gamemode/modules/voting/sv_votes.lua
+++ b/gamemode/modules/voting/sv_votes.lua
@@ -2,7 +2,10 @@ local Vote = {}
 local Votes = {}
 
 local function ccDoVote(ply, cmd, args)
-	if ply:EntIndex() == 0 then return end
+	if ply:EntIndex() == 0 then
+		print(DarkRP.getPhrase("cmd_cant_be_run_server_console"))
+		return
+	end
 
 	local vote = Votes[tonumber(args[1] or 0)]
 
@@ -139,7 +142,7 @@ end
 
 local function CancelVote(ply, cmd, args)
 	if ply:EntIndex() ~= 0 and not ply:hasDarkRPPrivilege("rp_commands") then
-		ply:PrintMessage(2, DarkRP.getPhrase("need_admin", "rp_cancelvote"))
+		ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_admin", "rp_cancelvote"))
 		return
 	end
 
@@ -151,11 +154,7 @@ local function CancelVote(ply, cmd, args)
 			print(DarkRP.getPhrase("x_cancelled_vote", "Console"))
 		end
 	else
-		if ply:EntIndex() == 0 then
-			print(DarkRP.getPhrase("cant_cancel_vote"))
-		else
-			ply:PrintMessage(2, DarkRP.getPhrase("cant_cancel_vote"))
-		end
+		DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("cant_cancel_vote"))
 	end
 end
 concommand.Add("rp_cancelvote", CancelVote)

--- a/gamemode/modules/workarounds/sh_workarounds.lua
+++ b/gamemode/modules/workarounds/sh_workarounds.lua
@@ -179,16 +179,3 @@ hook.Add("CanTool", "DoorExploit", function(ply, trace, tool)
 		return false
 	end
 end)
-
-/*---------------------------------------------------------------------------
-ply:UniqueID calculates the CRC of "gm_"..ply:SteamID().."_gm"
-That calculation is slow
----------------------------------------------------------------------------*/
-local plyMeta = FindMetaTable("Player")
-local oldUID = plyMeta.UniqueID
-function plyMeta:UniqueID()
-	if not self:IsValid() then DarkRP.error("Attempt to get UniqueID of non-existing player", 2) end
-	self.UIDCache = self.UIDCache or oldUID(self)
-
-	return self.UIDCache
-end


### PR DESCRIPTION
* Added DarkRP.printConsoleMessage(ply, msg).
  - Less code duplication
* Fixed some fonts on certain operating systems.
  - OS X is currently case sensitive in fonts (should be fixed whenever FreeType arrives in GMod).
  - DejaVu Sans does not ship by default in Windows and OS X.
    * Unfortunately surface.IsValidFont does not exist so a Linux check will have to suffice.
    * Tahoma is used instead on Windows and OS X as it is fairly similar.
  - Couple of unused fonts (Trebuchet19 and Trebuchet22) were removed.
* Fixed GAMEMODE.DefaultTeam validation check.
  - Regression in d594a09 caused GM:loadCustomDarkRPItems() to never run since gmod.GetGamemode() (which hook.Run uses) would still return nil.
* Fixed DarkRP.talkToPerson outputting trailing garbage with nil text2 argument.
  - Explicitly calling net.WriteString to an empty string fixed this.
* Removed UniqueID workaround.
  - The sv_lan check is now cached properly in the engine (CRC was already cached).
* Simplified some code.