### PR TITLE
Update sv_spawnpos.lua

### DIFF
--- a/gamemode/modules/positions/sv_spawnpos.lua
+++ b/gamemode/modules/positions/sv_spawnpos.lua
@@ -4,7 +4,8 @@ local function SetSpawnPos(ply, args)
 		return ""
 	end
 
-	local pos = string.Explode(" ", tostring(ply:GetPos()))
+	local pos = ply:GetPos()
+	local tablePos = { pos.x, pos.y, pos.z }
 	local t
 
 	for k,v in pairs(RPExtraTeams) do
@@ -15,7 +16,7 @@ local function SetSpawnPos(ply, args)
 	end
 
 	if t then
-		DarkRP.storeTeamSpawnPos(t, pos)
+		DarkRP.storeTeamSpawnPos(t, tablePos)
 	else
 		DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", tostring(args)))
 	end
@@ -30,7 +31,8 @@ local function AddSpawnPos(ply, args)
 		return ""
 	end
 
-	local pos = string.Explode(" ", tostring(ply:GetPos()))
+	local pos = ply:GetPos()
+	local tablePos = { pos.x, pos.y, pos.z } 
 	local t
 
 	for k,v in pairs(RPExtraTeams) do
@@ -41,7 +43,7 @@ local function AddSpawnPos(ply, args)
 	end
 
 	if t then
-		DarkRP.addTeamSpawnPos(t, pos)
+		DarkRP.addTeamSpawnPos(t, tablePos)
 	else
 		DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", tostring(args)))
 	end


### PR DESCRIPTION
Removes Vector.__tostring requirement so that the Vector tostring method can be changed without causing DarkRP to break.