### PR TITLE
Create playerBoughtAmmo hook

### DIFF
--- a/gamemode/modules/base/sv_interface.lua
+++ b/gamemode/modules/base/sv_interface.lua
@@ -851,6 +851,35 @@ DarkRP.hookStub{
 }
 
 DarkRP.hookStub{
+	name = "playerBoughtAmmo",
+	description = "Called when a player buys some ammo.",
+	parameters = {
+		{
+			name = "ply",
+			description = "The player.",
+			type = "Player"
+		},
+		{
+			name = "ammoTable",
+			description = "The table (from the AmmoTypes table).",
+			type = "table"
+		},
+		{
+			name = "ent",
+			description = "The spawned ammo entity.",
+			type = "Weapon"
+		},
+		{
+			name = "price",
+			description = "The eventual price.",
+			type = "number"
+		}
+	},
+	returns = {
+	}
+}
+
+DarkRP.hookStub{
 	name = "canDemote",
 	description = "Whether a player can demote another player.",
 	parameters = {

--- a/gamemode/modules/base/sv_purchasing.lua
+++ b/gamemode/modules/base/sv_purchasing.lua
@@ -402,6 +402,8 @@ local function BuyAmmo(ply, args)
 	ammo.nodupe = true
 	ammo.amountGiven, ammo.ammoType = found.amountGiven, found.ammoType
 	ammo:Spawn()
+	
+	hook.Call("playerBoughtAmmo", nil, ply, found, ammo, cost)
 
 	return ""
 end


### PR DESCRIPTION
Everything else has it, so why not ammo?
Arguments: Player, Ammo Table, Ammo Entity, Cost

For some reason the branch was created on my fprp fork, but nothing else changed.