### PR TITLE
Fixed repetitive error when updating via auto refresh.

### DIFF
--- a/gamemode/modules/base/cl_entityvars.lua
+++ b/gamemode/modules/base/cl_entityvars.lua
@@ -58,6 +58,8 @@ Initialize the DarkRPVars at the start of the game
 local function InitializeDarkRPVars(len)
 	local plyCount = net.ReadUInt(8)
 
+	if ( !DarkRPVar ) then return end
+
 	for i = 1, plyCount, 1 do
 		local userID = net.ReadUInt(16)
 		local varCount = net.ReadUInt(DarkRP.DARKRP_ID_BITS + 2)


### PR DESCRIPTION
- Fixed this occuring after a auto refresh due to the timer.Simple on the client.

[ERROR] gamemodes/darkrp/gamemode/modules/base/sh_entityvars.lua:80: attempt to index local 'DarkRPVar' (a nil value)
  1. readNetDarkRPVar - gamemodes/darkrp/gamemode/modules/base/sh_entityvars.lua:80
   2. func - gamemodes/darkrp/gamemode/modules/base/cl_entityvars.lua:66
    3. unknown - lua/includes/modules/net.lua:32