### PR TITLE
Fixed error that pops up when lua autorefreshing.

### DIFF
--- a/gamemode/modules/base/sh_entityvars.lua
+++ b/gamemode/modules/base/sh_entityvars.lua
@@ -71,7 +71,7 @@ function DarkRP.readNetDarkRPVar()
 	local DarkRPVarId = net.ReadUInt(DARKRP_ID_BITS)
 	local DarkRPVar = DarkRPVarById[DarkRPVarId]
 
-	if DarkRPVarId == UNKNOWN_DARKRPVAR then
+	if DarkRPVarId == UNKNOWN_DARKRPVAR or !DarkRPVar then
 		local name, value = readUnknown()
 
 		return name, value


### PR DESCRIPTION
`[ERROR] gamemodes/darkrp/gamemode/modules/base/sh_entityvars.lua:80: attempt to index global 'DarkRPVar' (a nil value)
  1. readNetDarkRPVar - gamemodes/darkrp/gamemode/modules/base/sh_entityvars.lua:80
   2. func - gamemodes/darkrp/gamemode/modules/base/cl_entityvars.lua:34
    3. unknown - lua/includes/modules/net.lua:32