### PR TITLE
Possible fix for the rare case of sticks not resetting its view model colour; fixed colour affecting whole arm; added stunstick spark effect

### DIFF
--- a/entities/weapons/stick_base/shared.lua
+++ b/entities/weapons/stick_base/shared.lua
@@ -42,6 +42,10 @@ function SWEP:Initialize()
 
 	CreateMaterial("darkrp/"..self:GetClass(), "VertexLitGeneric", {
 		["$basetexture"] = "models/debug/debugwhite",
+		["$surfaceprop"] = "metal",
+		["$envmap"] = "env_cubemap",
+		["$envmaptint"] = "[ .5 .5 .5 ]",
+		["$selfillum"] = 0,
 		["$model"] = 1
 	}):SetVector("$color2", self.StickColor:ToVector())
 end

--- a/entities/weapons/stick_base/shared.lua
+++ b/entities/weapons/stick_base/shared.lua
@@ -74,10 +74,16 @@ function SWEP:Deploy()
 	return true
 end
 
-function SWEP:PreDrawViewModel()
-	if SERVER or not IsValid(self:GetOwner()) or not IsValid(self:GetOwner():GetViewModel()) then return end
-	self:GetOwner():GetViewModel():SetColor(self.StickColor)
-	self:GetOwner():GetViewModel():SetMaterial("models/shiny")
+function SWEP:PreDrawViewModel(vm)
+	if not IsValid(vm) then return end
+	local colVec = self.StickColor:ToVector()
+	render.SetColorModulation(colVec.x, colVec.y, colVec.z)
+	vm:SetMaterial("models/shiny")
+end
+
+function SWEP:ViewModelDrawn(vm)
+	if not IsValid(vm) then return end
+	vm:SetMaterial("")
 end
 
 function SWEP:ResetStick(force)
@@ -86,9 +92,6 @@ function SWEP:ResetStick(force)
 	if SERVER then
 		self:SetColor(Color(255, 255, 255))
 		self:SetMaterial("")
-	elseif IsValid(self:GetOwner()) and IsValid(self:GetOwner():GetViewModel()) then
-		self:GetOwner():GetViewModel():SetColor(Color(255, 255, 255))
-		self:GetOwner():GetViewModel():SetMaterial("")
 	end
 	self:SetSeqIdling(false)
 	self:SetSeqIdleTime(0)

--- a/entities/weapons/stick_base/shared.lua
+++ b/entities/weapons/stick_base/shared.lua
@@ -37,6 +37,13 @@ SWEP.Secondary.Ammo = ""
 
 function SWEP:Initialize()
 	self:SetHoldType("normal")
+
+	if SERVER then return end
+
+	CreateMaterial("darkrp/"..self:GetClass(), "VertexLitGeneric", {
+		["$basetexture"] = "models/debug/debugwhite",
+		["$model"] = 1
+	}):SetVector("$color2", self.StickColor:ToVector())
 end
 
 function SWEP:SetupDataTables()
@@ -64,8 +71,7 @@ function SWEP:Deploy()
 	if SERVER then
 		self:HookStartCommand()
 		if not game.SinglePlayer() then self:CallOnClient("HookStartCommand") end
-		self:SetColor(self.StickColor)
-		self:SetMaterial("models/shiny")
+		self:SetMaterial("!darkrp/"..self:GetClass())
 	end
 	local vm = self:GetOwner():GetViewModel()
 	if not IsValid(vm) then return true end
@@ -76,22 +82,21 @@ end
 
 function SWEP:PreDrawViewModel(vm)
 	if not IsValid(vm) then return end
-	local colVec = self.StickColor:ToVector()
-	render.SetColorModulation(colVec.x, colVec.y, colVec.z)
-	vm:SetMaterial("models/shiny")
+	for i = 9, 15 do
+		vm:SetSubMaterial(i, "!darkrp/"..self:GetClass())
+	end
 end
 
 function SWEP:ViewModelDrawn(vm)
 	if not IsValid(vm) then return end
-	vm:SetMaterial("")
+	vm:SetSubMaterial() -- clear sub-materials
 end
 
 function SWEP:ResetStick(force)
 	if game.SinglePlayer() then force = true end
 	if not IsValid(self:GetOwner()) or (not force and (not IsValid(self:GetOwner():GetActiveWeapon()) or self:GetOwner():GetActiveWeapon():GetClass() ~= self:GetClass())) then return end
 	if SERVER then
-		self:SetColor(Color(255, 255, 255))
-		self:SetMaterial("")
+		self:SetMaterial() -- clear material
 	end
 	self:SetSeqIdling(false)
 	self:SetSeqIdleTime(0)

--- a/entities/weapons/stunstick/shared.lua
+++ b/entities/weapons/stunstick/shared.lua
@@ -10,7 +10,7 @@ end
 
 DEFINE_BASECLASS("stick_base")
 
-SWEP.Instructions = "Left click to discipline\nRight click to kill\nReload to threaten"
+SWEP.Instructions = "Left click to discipline\nRight click to kill\nHold reload to threaten"
 
 SWEP.Spawnable = true
 SWEP.Category = "DarkRP (Utility)"
@@ -87,7 +87,7 @@ end
 
 function SWEP:DrawWorldModel()
 	self:DrawModel()
-	if CurTime() <= self:GetLastReload() + 1 then
+	if CurTime() <= self:GetLastReload() + 0.1 then
 		local attachment = self:GetOwner():GetAttachment(self:GetOwner():LookupAttachment("anim_attachment_rh"))
 		local pos = attachment.Pos + (attachment.Ang:Up() * 16) + (attachment.Ang:Right() * -3) + attachment.Ang:Forward() * 4
 		cam.Start3D(EyePos(), EyeAngles())
@@ -157,7 +157,7 @@ end
 
 function SWEP:Reload()
 	self:SetHoldType("melee")
-	self:SetHoldTypeChangeTime(CurTime() + 1)
+	self:SetHoldTypeChangeTime(CurTime() + 0.1)
 
 	if self:GetLastReload() + 0.1 > CurTime() then self:SetLastReload(CurTime()) return end
 	self:SetLastReload(CurTime())


### PR DESCRIPTION
Still couldn't reproduce it but this will make what should be impossible even more impossible.

Instead of calling SetColor on the view model, it now sets the colour of the render using render.SetColorModulation. This only applies to the current frame so it should be impossible for it to carry over to other weapons. The shiny material is also now reset on ViewModelDrawn rather than in Holster so that we are handling everything on a per frame basis.