### PR TITLE
A workaround for sleep module

### DIFF
--- a/gamemode/modules/sleep/sv_sleep.lua
+++ b/gamemode/modules/sleep/sv_sleep.lua
@@ -36,7 +36,7 @@ function DarkRP.toggleSleep(player, command)
 					model = "models/player/corpse1.mdl"
 				end
 				player:SetModel(model)
-				player:SetAngles(Angle(0, ragdoll:GetPhysicsObjectNum(10):GetAngles().Yaw, 0))
+				player:SetAngles(Angle(0, ragdoll:GetPhysicsObjectNum(10) and ragdoll:GetPhysicsObjectNum(10):GetAngles().Yaw or 0, 0))
 				player:UnSpectate()
 				player:StripWeapons()
 				ragdoll:Remove()


### PR DESCRIPTION
Fixes
[ERROR] gamemodes/darkrp/gamemode/modules/sleep/sv_sleep.lua:39: attempt to index a nil value
  1. callback - gamemodes/darkrp/gamemode/modules/sleep/sv_sleep.lua:39
   2. RP_PlayerChat - gamemodes/darkrp/gamemode/modules/chat/sv_chat.lua:33
    3. unknown - gamemodes/darkrp/gamemode/modules/chat/sv_chat.lua:97

If playermodel has no physics (like error)