### PR TITLE
Properly fixed #1957

### DIFF
--- a/entities/weapons/stunstick/shared.lua
+++ b/entities/weapons/stunstick/shared.lua
@@ -4,6 +4,7 @@ if CLIENT then
 	SWEP.PrintName = "Stun Stick"
 	SWEP.Slot = 0
 	SWEP.SlotPos = 5
+	SWEP.RenderGroup = RENDERGROUP_BOTH
 
 	killicon.AddAlias("stunstick", "weapon_stunstick")
 end
@@ -85,16 +86,16 @@ function SWEP:PostDrawViewModel(vm)
 	end
 end
 
-function SWEP:DrawWorldModel()
-	self:DrawModel()
+function SWEP:DrawWorldModelTranslucent()
 	if CurTime() <= self:GetLastReload() + 0.1 then
-		local attachment = self:GetOwner():GetAttachment(self:GetOwner():LookupAttachment("anim_attachment_rh"))
-		local pos = attachment.Pos + (attachment.Ang:Up() * 16) + (attachment.Ang:Right() * -3) + attachment.Ang:Forward() * 4
-		cam.Start3D(EyePos(), EyeAngles())
+		local bonePos, boneAng = self:GetOwner():GetBonePosition(self:GetOwner():LookupBone("ValveBiped.Bip01_R_Hand"))
+		if bonePos then
+			local pos = bonePos + (boneAng:Up() * -16) + (boneAng:Right() * 3) + (boneAng:Forward() * 6.5)
 			render.SetMaterial(Material("sprites/light_glow02_add"))
 			render.DrawSprite(pos, 32, 32, Color(255, 255, 255))
-		cam.End3D()
+		end
 	end
+	self:DrawModel()
 end
 
 local entMeta = FindMetaTable("Entity")


### PR DESCRIPTION
Instead of hiding the problem like #1958 did, this actually fixes the problem by relying on the Bip01_R_Hand bone which every (working) player model should have. The previously used anim_attachment_rh attachment seems to not be required in a player model and thus some don't have it as #1957 has revealed. Also added a nil check in case someone decides that it's a good idea to set the player model to something that isn't a player model.