### PR TITLE
bonePos or attachment (Final Stunstick fix)

### DIFF
--- a/entities/weapons/stunstick/shared.lua
+++ b/entities/weapons/stunstick/shared.lua
@@ -88,12 +88,19 @@ end
 function SWEP:DrawWorldModel()
 	self:DrawModel()
 	if CurTime() <= self:GetLastReload() + 0.1 then
-		local attachment = self:GetOwner():GetAttachment(self:GetOwner():LookupAttachment("anim_attachment_rh"))
-		local pos = attachment.Pos + (attachment.Ang:Up() * 16) + (attachment.Ang:Right() * -3) + attachment.Ang:Forward() * 4
-		cam.Start3D(EyePos(), EyeAngles())
+		local bonePos, boneAng = self:GetOwner():LookupBone("ValveBiped.Bip01_R_Hand") and self:GetOwner():GetBonePosition(self:GetOwner():LookupBone("ValveBiped.Bip01_R_Hand")) 
+		local attachment = self:GetOwner():LookupAttachment("anim_attachment_rh") and self:GetOwner():GetAttachment(self:GetOwner():LookupAttachment("anim_attachment_rh"))
+		if bonePos then
+			local pos = bonePos + (boneAng:Up() * -16) + (boneAng:Right() * 3) + (boneAng:Forward() * 6.5)
 			render.SetMaterial(Material("sprites/light_glow02_add"))
 			render.DrawSprite(pos, 32, 32, Color(255, 255, 255))
-		cam.End3D()
+		elseif attachment then 
+			local pos = attachment.Pos + (attachment.Ang:Up() * 16) + (attachment.Ang:Right() * -3) + attachment.Ang:Forward() * 4
+			cam.Start3D(EyePos(), EyeAngles())
+				render.SetMaterial(Material("sprites/light_glow02_add"))
+				render.DrawSprite(pos, 32, 32, Color(255, 255, 255))
+			cam.End3D()
+		end
 	end
 end
 

--- a/entities/weapons/stunstick/shared.lua
+++ b/entities/weapons/stunstick/shared.lua
@@ -6,6 +6,7 @@ if CLIENT then
 	SWEP.SlotPos = 5
 
 	killicon.AddAlias("stunstick", "weapon_stunstick")
+	SWEP.RenderGroup = RENDERGROUP_BOTH
 end
 
 DEFINE_BASECLASS("stick_base")


### PR DESCRIPTION
If model is ERROR or custom it will create error
```
[ERROR] gamemodes/darkrp/entities/weapons/stunstick/shared.lua:92: bad argument #1 to 'GetBonePosition' (number expected, got no value)
  1. GetBonePosition - [C]:-1
   2. unknown - gamemodes/darkrp/entities/weapons/stunstick/shared.lua:92
```
It totally fixes it