### PR TITLE
Blind fix for #1981

### DIFF
--- a/entities/weapons/arrest_stick/shared.lua
+++ b/entities/weapons/arrest_stick/shared.lua
@@ -129,9 +129,8 @@ function SWEP:PrimaryAttack()
 	end
 end
 
-function SWEP:StartCommand(ply, usrcmd)
-	if not IsValid(self) or not IsValid(self:GetOwner()) then return end
-	if not IsValid(self:GetOwner():GetActiveWeapon()) or self:GetOwner():GetActiveWeapon():EntIndex() ~= self:EntIndex() then return end
+function SWEP:startDarkRPCommand(usrcmd)
+	if game.SinglePlayer() and CLIENT then return end
 	if usrcmd:KeyDown(IN_ATTACK2) then
 		if not self.Switched and self:GetOwner():HasWeapon("unarrest_stick") then
 			usrcmd:SelectWeapon(self:GetOwner():GetWeapon("unarrest_stick"))

--- a/entities/weapons/stick_base/shared.lua
+++ b/entities/weapons/stick_base/shared.lua
@@ -63,20 +63,9 @@ function SWEP:SetupDataTables()
 	self:NetworkVar("Float", 5, "HoldTypeChangeTime")
 end
 
-function SWEP:StartCommand()
-end
-
-function SWEP:HookStartCommand()
-	hook.Add("StartCommand", "DarkRP_"..self:GetClass().."_StartCommand", fp{self.StartCommand, self})
-end
-
 function SWEP:Deploy()
 	BaseClass.Deploy(self)
-	if SERVER then
-		self:HookStartCommand()
-		if not game.SinglePlayer() then self:CallOnClient("HookStartCommand") end
-		self:SetMaterial("!darkrp/"..self:GetClass())
-	end
+	if SERVER then self:SetMaterial("!darkrp/"..self:GetClass()) end
 	local vm = self:GetOwner():GetViewModel()
 	if not IsValid(vm) then return true end
 	self:PreDrawViewModel()
@@ -105,7 +94,6 @@ function SWEP:ResetStick(force)
 	self:SetSeqIdling(false)
 	self:SetSeqIdleTime(0)
 	self:SetHoldTypeChangeTime(0)
-	hook.Remove("StartCommand", "DarkRP_"..self:GetClass().."_StartCommand")
 end
 
 function SWEP:Holster()

--- a/entities/weapons/unarrest_stick/shared.lua
+++ b/entities/weapons/unarrest_stick/shared.lua
@@ -87,9 +87,8 @@ function SWEP:PrimaryAttack()
 	end
 end
 
-function SWEP:StartCommand(ply, usrcmd)
-	if not IsValid(self) or not IsValid(self:GetOwner()) then return end
-	if not IsValid(self:GetOwner():GetActiveWeapon()) or self:GetOwner():GetActiveWeapon():EntIndex() ~= self:EntIndex() then return end
+function SWEP:startDarkRPCommand(usrcmd)
+	if game.SinglePlayer() and CLIENT then return end
 	if usrcmd:KeyDown(IN_ATTACK2) then
 		if not self.Switched and self:GetOwner():HasWeapon("arrest_stick") then
 			usrcmd:SelectWeapon(self:GetOwner():GetWeapon("arrest_stick"))

--- a/gamemode/modules/base/sh_gamemode_functions.lua
+++ b/gamemode/modules/base/sh_gamemode_functions.lua
@@ -12,3 +12,11 @@ function GM:UpdatePlayerSpeed(ply)
 		GAMEMODE:SetPlayerSpeed(ply, GAMEMODE.Config.walkspeed, GAMEMODE.Config.runspeed)
 	end
 end
+
+function GM:StartCommand(ply, usrcmd)
+	-- Used in arrest_stick and unarrest_stick but addons can use it too!
+	local wep = ply:GetActiveWeapon()
+	if IsValid(wep) and isfunction(wep.startDarkRPCommand) then
+		wep:startDarkRPCommand(usrcmd)
+	end
+end


### PR DESCRIPTION
Still can't reproduce it so I'm just going to assume both SWEP:Holster and EntIndex is broken and just call SWEP:StartCommand (now SWEP:startDarkRPCommand) in an entirely different way.

This is how the base gamemode does it. This also opens up to addons wanting to use StartCommand in their SWEPs too - all they need to do now is use the startDarkRPCommand SWEP hook. Don't know if it's worth documenting anywhere or not.