### PR TITLE
Converted all usermessages to netmessages

### DIFF
--- a/entities/entities/darkrp_laws/cl_init.lua
+++ b/entities/entities/darkrp_laws/cl_init.lua
@@ -36,15 +36,15 @@ local function addLaw(inLaw)
 	Laws[#Laws + 1] = law
 end
 
-local function umAddLaw(um)
-	local law = um:ReadString()
+local function netAddLaw()
+	local law = net.ReadString()
 	timer.Simple(0, fn.Curry(addLaw, 2)(law))
 	hook.Run("addLaw", #Laws + 1, law)
 end
-usermessage.Hook("DRP_AddLaw", umAddLaw)
+net.Receive("DRP_AddLaw", netAddLaw)
 
-local function umRemoveLaw(um)
-	local i = um:ReadShort()
+local function netRemoveLaw()
+	local i = net.ReadUInt(16)
 
 	hook.Run("removeLaw", i, Laws[i])
 
@@ -54,14 +54,14 @@ local function umRemoveLaw(um)
 	end
 	Laws[i] = nil
 end
-usermessage.Hook("DRP_RemoveLaw", umRemoveLaw)
+net.Receive("DRP_RemoveLaw", netRemoveLaw)
 
-local function umResetLaws(um)
+local function netResetLaws()
 	Laws = {}
 	fn.Foldl(function(val,v) addLaw(v) end, nil, GAMEMODE.Config.DefaultLaws)
 	hook.Run("resetLaws")
 end
-usermessage.Hook("DRP_ResetLaws", umResetLaws)
+net.Receive("DRP_ResetLaws", netResetLaws)
 
 function DarkRP.getLaws()
 	return Laws

--- a/entities/entities/darkrp_laws/init.lua
+++ b/entities/entities/darkrp_laws/init.lua
@@ -57,9 +57,9 @@ local function addLaw(ply, args)
 
 	local num = table.insert(Laws, args)
 
-	umsg.Start("DRP_AddLaw")
-		umsg.String(args)
-	umsg.End()
+	net.Start("DRP_AddLaw")
+		net.WriteString(args)
+	net.Broadcast()
 
 	hook.Run("addLaw", num, args)
 
@@ -93,9 +93,9 @@ local function removeLaw(ply, args)
 
 	table.remove(Laws, i)
 
-	umsg.Start("DRP_RemoveLaw")
-		umsg.Short(i)
-	umsg.End()
+	net.Start("DRP_RemoveLaw")
+		net.WriteUInt(i, 16)
+	net.Broadcast()
 
 	hook.Run("removeLaw", i, law)
 
@@ -108,8 +108,8 @@ DarkRP.defineChatCommand("removeLaw", removeLaw)
 function DarkRP.resetLaws()
 	Laws = table.Copy(FixedLaws)
 
-	umsg.Start("DRP_ResetLaws")
-	umsg.End()
+	net.Start("DRP_ResetLaws")
+	net.Broadcast()
 end
 
 local function resetLaws(ply, args)
@@ -183,9 +183,9 @@ hook.Add("PlayerInitialSpawn", "SendLaws", function(ply)
 	for i, law in pairs(Laws) do
 		if FixedLaws[i] then continue end
 
-		umsg.Start("DRP_AddLaw", ply)
-			umsg.String(law)
-		umsg.End()
+		net.Start("DRP_AddLaw")
+			net.WriteString(law)
+		net.Send(ply)
 	end
 end)
 

--- a/entities/entities/drug/cl_init.lua
+++ b/entities/entities/drug/cl_init.lua
@@ -32,8 +32,8 @@ end
 function ENT:Think()
 end
 
-local function drugEffects(um)
-	local toggle = um:ReadBool()
+local function drugEffects()
+	local toggle = net.ReadBool()
 
 	if toggle then
 		hook.Add("RenderScreenspaceEffects", "drugged", function()
@@ -45,4 +45,4 @@ local function drugEffects(um)
 		hook.Remove("RenderScreenspaceEffects", "drugged")
 	end
 end
-usermessage.Hook("DrugEffects", drugEffects)
+net.Receive("DrugEffects", drugEffects)

--- a/entities/entities/drug/init.lua
+++ b/entities/entities/drug/init.lua
@@ -9,7 +9,9 @@ local function UnDrugPlayer(ply)
 
 	timer.Remove(IDSteam.."DruggedHealth")
 
-	SendUserMessage("DrugEffects", ply, false)
+	net.Start("DrugEffects")
+		net.WriteBool(false)
+	net.Send(ply)
 
 	ply:SetJumpPower(190)
 	hook.Call("UpdatePlayerSpeed", GAMEMODE, ply)
@@ -22,7 +24,9 @@ hook.Add("PlayerDeath", "UndrugPlayers", function(ply) if ply.isDrugged then UnD
 local function DrugPlayer(ply)
 	if not IsValid(ply) then return end
 
-	SendUserMessage("DrugEffects", ply, true)
+	net.Start("DrugEffects")
+		net.WriteBool(true)
+	net.Send(ply)
 
 	ply:SetJumpPower(300)
 	ply.isDrugged = true

--- a/entities/entities/food/init.lua
+++ b/entities/entities/food/init.lua
@@ -31,8 +31,8 @@ end
 
 function ENT:Use(activator,caller)
 	caller:setSelfDarkRPVar("Energy", math.Clamp((caller:getDarkRPVar("Energy") or 0) + 100, 0, 100))
-	umsg.Start("AteFoodIcon", caller)
-	umsg.End()
+	net.Start("AteFoodIcon")
+	net.Send(caller)
 
 	self:Remove()
 end

--- a/entities/entities/letter/cl_init.lua
+++ b/entities/entities/letter/cl_init.lua
@@ -7,30 +7,30 @@ function ENT:Draw()
 	self:DrawModel()
 end
 
-local function KillLetter(msg)
+local function KillLetter()
 	hook.Remove("HUDPaint", "ShowLetter")
 	frame:Remove()
 end
-usermessage.Hook("KillLetter", KillLetter)
+net.Receive("KillLetter", KillLetter)
 
 
-local function ShowLetter(msg)
+local function ShowLetter()
 	if frame then
 		frame:Remove()
 	end
 
 	local LetterMsg = ""
-	local Letter = msg:ReadEntity()
-	local LetterType = msg:ReadShort()
-	local LetterPos = msg:ReadVector()
-	local sectionCount = msg:ReadShort()
+	local Letter = net.ReadEntity()
+	local LetterType = net.ReadUInt(16)
+	local LetterPos = net.ReadVector()
+	local sectionCount = net.ReadUInt(16)
 	local LetterY = ScrH() / 2 - 300
 	local LetterAlpha = 255
 
 	Letter:CallOnRemove("Kill letter HUD on remove", KillLetter)
 
 	for k=1, sectionCount do
-		LetterMsg = LetterMsg .. msg:ReadString()
+		LetterMsg = LetterMsg .. net.ReadString()
 	end
 
 	frame = vgui.Create("DFrame")
@@ -74,4 +74,4 @@ local function ShowLetter(msg)
 		end
 	end)
 end
-usermessage.Hook("ShowLetter", ShowLetter)
+net.Receive("ShowLetter", ShowLetter)

--- a/entities/entities/letter/init.lua
+++ b/entities/entities/letter/init.lua
@@ -29,17 +29,16 @@ end
 
 function ENT:Use(ply)
 	if not ply:KeyDown(IN_ATTACK) then
-		umsg.Start("ShowLetter", ply)
-			umsg.Entity(self)
-			umsg.Short(self.type)
-			umsg.Vector(self:GetPos())
-			local numParts = self.numPts
-			umsg.Short(numParts)
-			for a,b in pairs(self.Parts) do umsg.String(b) end
-		umsg.End()
+		net.Start("ShowLetter")
+			net.WriteEntity(self)
+			net.WriteUInt(self.type, 16)
+			net.WriteVector(self:GetPos())
+			net.WriteUInt(self.numPts, 16)
+			for a,b in pairs(self.Parts) do net.WriteString(b) end
+		net.Send(ply)
 	else
-		umsg.Start("KillLetter", ply)
-		umsg.End()
+		net.Start("KillLetter")
+		net.Send(ply)
 	end
 end
 

--- a/entities/entities/spawned_food/init.lua
+++ b/entities/entities/spawned_food/init.lua
@@ -19,8 +19,8 @@ end
 
 function ENT:Use(activator,caller)
 	activator:setSelfDarkRPVar("Energy", math.Clamp((activator:getDarkRPVar("Energy") or 100) + (self:GetTable().FoodEnergy or 1), 0, 100))
-	umsg.Start("AteFoodIcon", activator)
-	umsg.End()
+	net.Start("AteFoodIcon")
+	net.Send(activator)
 	self:Remove()
 	activator:EmitSound("vo/sandwicheat09.wav", 100, 100)
 end

--- a/entities/weapons/gmod_tool/stools/shareprops.lua
+++ b/entities/weapons/gmod_tool/stools/shareprops.lua
@@ -29,21 +29,21 @@ function TOOL:LeftClick(trace)
 	local Damage = trace.Entity.ShareEntityDamage1 or false
 	local Toolgun = trace.Entity.ShareToolgun1 or false
 
-	-- This big usermessage will be too big if you select 63 players, since that will not happen I can't be arsed to solve it
-	umsg.Start("FPP_ShareSettings", ply)
-		umsg.Entity(trace.Entity)
-		umsg.Bool(Physgun)
-		umsg.Bool(GravGun)
-		umsg.Bool(PlayerUse)
-		umsg.Bool(Damage)
-		umsg.Bool(Toolgun)
+	-- Test size with netmessages
+	net.Start("FPP_ShareSettings")
+		net.WriteEntity(trace.Entity)
+		net.WriteBool(Physgun)
+		net.WriteBool(GravGun)
+		net.WriteBool(PlayerUse)
+		net.WriteBool(Damage)
+		net.WriteBool(Toolgun)
 		if trace.Entity.AllowedPlayers then
-			umsg.Long(#trace.Entity.AllowedPlayers)
+			net.WriteUInt(#trace.Entity.AllowedPlayers, 32)
 			for k,v in pairs(trace.Entity.AllowedPlayers) do
-				umsg.Entity(v)
+				net.WriteEntity(v)
 			end
 		end
-	umsg.End()
+	net.Send(ply)
 	return true
 end
 

--- a/entities/weapons/keys/cl_menu.lua
+++ b/entities/weapons/keys/cl_menu.lua
@@ -97,7 +97,7 @@ DarkRP.hookStub{
 }
 
 local KeyFrameVisible = false
-function DarkRP.openKeysMenu(um)
+function DarkRP.openKeysMenu()
 	if KeyFrameVisible then return end
 
 	local ent = LocalPlayer():GetEyeTrace().Entity
@@ -222,4 +222,4 @@ function DarkRP.openKeysMenu(um)
 	Frame:Center()
 	Frame:SetSkin(GAMEMODE.Config.DarkRPSkin)
 end
-usermessage.Hook("KeysMenu", DarkRP.openKeysMenu)
+net.Receive("KeysMenu", DarkRP.openKeysMenu)

--- a/entities/weapons/keys/shared.lua
+++ b/entities/weapons/keys/shared.lua
@@ -76,23 +76,20 @@ local function lockUnlockAnimation(ply, snd)
 	ply:EmitSound("npc/metropolice/gear" .. math.floor(math.Rand(1,7)) .. ".wav")
 	timer.Simple(0.9, function() if IsValid(ply) then ply:EmitSound(snd) end end)
 
-	local RP = RecipientFilter()
-	RP:AddAllPlayers()
-
-	umsg.Start("anim_keys", RP)
-		umsg.Entity(ply)
-		umsg.String("usekeys")
-	umsg.End()
+	net.Start("anim_keys")
+		net.WriteEntity(ply)
+		net.WriteString("usekeys")
+	net.Broadcast()
 
 	ply:AnimRestartGesture(GESTURE_SLOT_ATTACK_AND_RELOAD, ACT_GMOD_GESTURE_ITEM_PLACE, true)
 end
 
 local function doKnock(ply, sound)
 	ply:EmitSound(sound, 100, math.random(90, 110))
-	umsg.Start("anim_keys", RP)
-		umsg.Entity(ply)
-		umsg.String("knocking")
-	umsg.End()
+	net.Start("anim_keys")
+		net.WriteEntity(ply)
+		net.WriteString("knocking")
+	net.Broadcast()
 
 	ply:AnimRestartGesture(GESTURE_SLOT_ATTACK_AND_RELOAD, ACT_HL2MP_GESTURE_RANGE_ATTACK_FIST, true)
 end
@@ -142,7 +139,7 @@ function SWEP:Reload()
 		return
 	end
 	if SERVER then
-		umsg.Start("KeysMenu", self:GetOwner())
-		umsg.End()
+		net.Start("KeysMenu")
+		net.Send(self:GetOwner())
 	end
 end

--- a/entities/weapons/weapon_cs_base2/sv_commands.lua
+++ b/entities/weapons/weapon_cs_base2/sv_commands.lua
@@ -51,12 +51,9 @@ local function DropWeapon(ply)
 		return ""
 	end
 
-	local RP = RecipientFilter()
-	RP:AddAllPlayers()
-
-	umsg.Start("anim_dropitem", RP)
-		umsg.Entity(ply)
-	umsg.End()
+	net.Start("anim_dropitem")
+		net.WriteEntity(ply)
+	net.Broadcast()
 	ply.anim_DroppingItem = true
 
 	timer.Simple(1, function()

--- a/gamemode/modules/afk/sv_afk.lua
+++ b/gamemode/modules/afk/sv_afk.lua
@@ -19,7 +19,9 @@ local function SetAFK(ply)
 	local rpname = ply:getDarkRPVar("rpname")
 	ply:setSelfDarkRPVar("AFK", not ply:getDarkRPVar("AFK"))
 
-	SendUserMessage("blackScreen", ply, ply:getDarkRPVar("AFK"))
+	net.Start("blackScreen")
+		net.WriteBool(ply:getDarkRPVar("AFK"))
+	net.Send(ply)
 
 	if ply:getDarkRPVar("AFK") then
 		DarkRP.retrieveSalary(ply, function(amount) ply.OldSalary = amount end)

--- a/gamemode/modules/animations/sh_animations.lua
+++ b/gamemode/modules/animations/sh_animations.lua
@@ -66,13 +66,9 @@ hook.Add("CalcMainActivity", "darkrp_animations", function(ply, velocity) -- Usi
 		ply.ThrewPoop = true
 		ply:AnimRestartGesture(GESTURE_SLOT_ATTACK_AND_RELOAD, ACT_GMOD_GESTURE_ITEM_THROW, true)
 
-
-		local RP = RecipientFilter()
-		RP:AddAllPlayers()
-
-		umsg.Start("anim_throwpoop", RP)
-			umsg.Entity(ply)
-		umsg.End()
+		net.Start("anim_throwpoop")
+			net.WriteEntity(ply)
+		net.Broadcast()
 	elseif ply.ThrewPoop and not ply:KeyDown(IN_ATTACK) then
 		ply.ThrewPoop = nil
 	end
@@ -84,12 +80,9 @@ hook.Add("CalcMainActivity", "darkrp_animations", function(ply, velocity) -- Usi
 			ply.SaidHi = true
 			ply:AnimRestartGesture(GESTURE_SLOT_ATTACK_AND_RELOAD, ACT_SIGNAL_GROUP, true)
 
-			local RP = RecipientFilter()
-			RP:AddAllPlayers()
-
-			umsg.Start("anim_sayhi", RP)
-				umsg.Entity(ply)
-			umsg.End()
+			net.Start("anim_sayhi")
+				net.WriteEntity(ply)
+			net.Broadcast()
 		end
 	elseif ply.SaidHi and not ply:KeyDown(IN_ATTACK) then
 		ply.SaidHi = nil
@@ -102,67 +95,64 @@ if SERVER then
 		local Gesture = tonumber(args[1] or 0)
 		if not Anims[Gesture] then return end
 
-		local RP = RecipientFilter()
-		RP:AddAllPlayers()
-
-		umsg.Start("_DarkRP_CustomAnim", RP)
-		umsg.Entity(ply)
-		umsg.Short(Gesture)
-		umsg.End()
+		net.Start("_DarkRP_CustomAnim")
+			net.WriteEntity(ply)
+			net.WriteUInt(Gesture, 16)
+		net.Broadcast()
 	end
 	concommand.Add("_DarkRP_DoAnimation", CustomAnim)
 	return
 end
 
-local function DropItem(um)
-	local ply = um:ReadEntity()
+local function DropItem()
+	local ply = net.ReadEntity()
 	if not IsValid(ply) then return end
 
 	ply.anim_DroppingItem = true
 end
-usermessage.Hook("anim_dropitem", DropItem)
+net.Receive("anim_dropitem", DropItem)
 
-local function GiveItem(um)
-	local ply = um:ReadEntity()
+local function GiveItem()
+	local ply = net.ReadEntity()
 	if not IsValid(ply) then return end
 
 	ply.anim_GivingItem = true
 end
-usermessage.Hook("anim_giveitem", GiveItem)
+net.Receive("anim_giveitem", GiveItem)
 
-local function ThrowPoop(um)
-	local ply = um:ReadEntity()
+local function ThrowPoop()
+	local ply = net.ReadEntity()
 	if not IsValid(ply) then return end
 
 	ply.ThrewPoop = true
 end
-usermessage.Hook("anim_throwpoop", ThrowPoop)
+net.Receive("anim_throwpoop", ThrowPoop)
 
-local function PhysgunHi(um)
-	local ply = um:ReadEntity()
+local function PhysgunHi()
+	local ply = net.ReadEntity()
 	if not IsValid(ply) then return end
 
 	ply.SaidHi = true
 end
-usermessage.Hook("anim_sayhi", PhysgunHi)
+net.Receive("anim_sayhi", PhysgunHi)
 
-local function KeysAnims(um)
-	local ply = um:ReadEntity()
+local function KeysAnims()
+	local ply = net.ReadEntity()
 	if not IsValid(ply) then return end
-	local Type = um:ReadString()
+	local Type = net.ReadString()
 	ply[Type] = true
 end
-usermessage.Hook("anim_keys", KeysAnims)
+net.Receive("anim_keys", KeysAnims)
 
 
-local function CustomAnimation(um)
-	local ply = um:ReadEntity()
-	local act = um:ReadShort()
+local function CustomAnimation()
+	local ply = net.ReadEntity()
+	local act = net.ReadUInt(16)
 
 	if not IsValid(ply) then return end
 	ply:AnimRestartGesture(GESTURE_SLOT_CUSTOM, act, true)
 end
-usermessage.Hook("_DarkRP_CustomAnim", CustomAnimation)
+net.Receive("_DarkRP_CustomAnim", CustomAnimation)
 
 local AnimFrame
 local function AnimationMenu()

--- a/gamemode/modules/base/cl_entityvars.lua
+++ b/gamemode/modules/base/cl_entityvars.lua
@@ -27,7 +27,7 @@ end
 
 /*---------------------------------------------------------------------------
 Retrieve a player var.
-Read the usermessage and attempt to set the DarkRP var
+Read the net message and attempt to set the DarkRP var
 ---------------------------------------------------------------------------*/
 local function doRetrieve()
 	local userID = net.ReadUInt(16)

--- a/gamemode/modules/base/cl_gamemode_functions.lua
+++ b/gamemode/modules/base/cl_gamemode_functions.lua
@@ -54,11 +54,11 @@ end
 function GM:teamChanged(before, after)
 end
 
-local function OnChangedTeam(um)
-	local oldTeam, newTeam = um:ReadShort(), um:ReadShort()
+local function OnChangedTeam()
+	local oldTeam, newTeam = net.ReadUInt(16), net.ReadUInt(16)
 	hook.Call("teamChanged", GAMEMODE, oldTeam, newTeam) -- backwards compatibility
 	hook.Call("OnPlayerChangedTeam", GAMEMODE, LocalPlayer(), oldTeam, newTeam)
 end
-usermessage.Hook("OnChangedTeam", OnChangedTeam)
+net.Receive("OnChangedTeam", OnChangedTeam)
 
 timer.Simple(0, function() GAMEMODE.ShowTeam = DarkRP.openKeysMenu end)

--- a/gamemode/modules/base/cl_util.lua
+++ b/gamemode/modules/base/cl_util.lua
@@ -3,8 +3,8 @@ local plyMeta = FindMetaTable("Player")
 /*---------------------------------------------------------------------------
 Show a black screen
 ---------------------------------------------------------------------------*/
-local function blackScreen(um)
-	local toggle = um:ReadBool()
+local function blackScreen()
+	local toggle = net.ReadBool()
 	if toggle then
 		local black = Color(0, 0, 0)
 		local w, h = ScrW(), ScrH()
@@ -16,7 +16,7 @@ local function blackScreen(um)
 		hook.Remove("HUDPaintBackground", "BlackScreen")
 	end
 end
-usermessage.Hook("blackScreen", blackScreen)
+net.Receive("blackScreen", blackScreen)
 
 /*---------------------------------------------------------------------------
 Wrap strings to not become wider than the given amount of pixels

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -390,7 +390,9 @@ function GM:PlayerDeath(ply, weapon, killer)
 	end
 
 	if GAMEMODE.Config.deathblack then
-		SendUserMessage("blackScreen", ply, true)
+		net.Start("blackScreen")
+			net.WriteBool(true)
+		net.Send(ply)
 	end
 
 	if weapon:IsVehicle() and weapon:GetDriver():IsPlayer() then killer = weapon:GetDriver() end
@@ -621,7 +623,9 @@ function GM:PlayerSpawn(ply)
 	ply:UnSpectate()
 
 	-- Kill any colormod
-	SendUserMessage("blackScreen", ply, false)
+	net.Start("blackScreen")
+		net.WriteBool(false)
+	net.Send(ply)
 
 	if GAMEMODE.Config.babygod and not ply.IsSleeping and not ply.Babygod then
 		timer.Destroy(ply:EntIndex() .. "babygod")

--- a/gamemode/modules/base/sv_util.lua
+++ b/gamemode/modules/base/sv_util.lua
@@ -1,17 +1,17 @@
 function DarkRP.notify(ply, msgtype, len, msg)
-	umsg.Start("_Notify", ply)
-		umsg.String(msg)
-		umsg.Short(msgtype)
-		umsg.Long(len)
-	umsg.End()
+	net.Start("_Notify")
+		net.WriteString(msg)
+		net.WriteUInt(msgtype, 16)
+		net.WriteUInt(len, 32)
+	net.Send(ply)
 end
 
 function DarkRP.notifyAll(msgtype, len, msg)
-	umsg.Start("_Notify")
-		umsg.String(msg)
-		umsg.Short(msgtype)
-		umsg.Long(len)
-	umsg.End()
+	net.Start("_Notify")
+		net.WriteString(msg)
+		net.WriteUInt(msgtype, 16)
+		net.WriteUInt(len, 32)
+	net.Broadcast()
 end
 
 function DarkRP.printMessageAll(msgtype, msg)

--- a/gamemode/modules/chat/cl_chat.lua
+++ b/gamemode/modules/chat/cl_chat.lua
@@ -79,9 +79,9 @@ People who have contributed (ordered by commits, with at least two commits)
 	TypicalRookie
 ]]
 
-local function credits(um)
+local function credits()
 	chat.AddNonParsedText(Color(255,0,0,255), "[", Color(50,50,50,255), GAMEMODE.Name, Color(255,0,0,255), "] ", Color(255, 255, 255, 255), DarkRP.getPhrase("credits_see_console"))
 
 	MsgC(Color(255,0,0,255), DarkRP.getPhrase("credits_for", GAMEMODE.Name), Color(255,255,255,255), creds)
 end
-usermessage.Hook("DarkRP_Credits", credits)
+net.Receive("DarkRP_Credits", credits)

--- a/gamemode/modules/chat/sv_chatcommands.lua
+++ b/gamemode/modules/chat/sv_chatcommands.lua
@@ -223,14 +223,13 @@ local function GetDarkRPAuthors(ply, args)
 	CreditsWait = false
 	timer.Simple(60, function() CreditsWait = true end)--so people don't spam it
 
-	local rf = RecipientFilter()
-	rf:AddPlayer(target)
+	local players = {target}
 	if ply ~= target then
-		rf:AddPlayer(ply)
+		table.insert(players, nil, ply)
 	end
 
-	umsg.Start("DarkRP_Credits", rf)
-	umsg.End()
+	net.Start("DarkRP_Credits")
+	net.Send(players)
 
 	return ""
 end

--- a/gamemode/modules/fadmin/fadmin/access/cl_init.lua
+++ b/gamemode/modules/fadmin/fadmin/access/cl_init.lua
@@ -7,17 +7,17 @@ local function RetrievePRIVS(len)
 end
 net.Receive("FADMIN_SendGroups", RetrievePRIVS)
 
-local function addPriv(um)
-	local group = um:ReadString()
+local function addPriv()
+	local group = net.ReadString()
 	FAdmin.Access.Groups[group] = FAdmin.Access.Groups[group] or {}
-	FAdmin.Access.Groups[group].PRIVS[um:ReadString()] = true
+	FAdmin.Access.Groups[group].PRIVS[net.ReadString()] = true
 end
-usermessage.Hook("FAdmin_AddPriv", addPriv)
+net.Receive("FAdmin_AddPriv", addPriv)
 
-local function removePriv(um)
-	FAdmin.Access.Groups[um:ReadString()].PRIVS[um:ReadString()] = nil
+local function removePriv()
+	FAdmin.Access.Groups[net.ReadString()].PRIVS[net.ReadString()] = nil
 end
-usermessage.Hook("FAdmin_RemovePriv", removePriv)
+net.Receive("FAdmin_RemovePriv", removePriv)
 
 local function addGroupUI(ply, func)
 	Derma_StringRequest("Set name",

--- a/gamemode/modules/fadmin/fadmin/access/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/access/sv_init.lua
@@ -139,7 +139,11 @@ local function AddPrivilege(ply, cmd, args)
 	FAdmin.Access.Groups[group].PRIVS[priv] = true
 
 	MySQLite.query("REPLACE INTO FADMIN_PRIVILEGES VALUES(" .. MySQLite.SQLStr(group) .. ", " .. MySQLite.SQLStr(priv) .. ");")
-	SendUserMessage("FAdmin_AddPriv", player.GetAll(), group, priv)
+	net.Start("FAdmin_AddPriv")
+		net.WriteString(group)
+		net.WriteString(priv)
+	net.Send(player:GetAll())
+
 	FAdmin.Messages.SendMessage(ply, 4, "Privilege Added!")
 
 	return true, group, priv
@@ -157,7 +161,11 @@ local function RemovePrivilege(ply, cmd, args)
 	FAdmin.Access.Groups[group].PRIVS[priv] = nil
 
 	MySQLite.query("DELETE FROM FADMIN_PRIVILEGES WHERE NAME = " .. MySQLite.SQLStr(group) .. " AND PRIVILEGE = " .. MySQLite.SQLStr(priv) .. ";")
-	SendUserMessage("FAdmin_RemovePriv", player.GetAll(), group, priv)
+	net.Start("FAdmin_RemovePriv")
+		net.WriteString(group)
+		net.WriteString(priv)
+	net.Send(player:GetAll())
+
 	FAdmin.Messages.SendMessage(ply, 4, "Privilege Removed!")
 
 	return true, group, priv

--- a/gamemode/modules/fadmin/fadmin/cleanup/cl_init.lua
+++ b/gamemode/modules/fadmin/fadmin/cleanup/cl_init.lua
@@ -12,7 +12,7 @@ FAdmin.StartHooks["CleanUp"] = function()
 		RunConsoleCommand("_FAdmin", "StopSounds")
 	end)
 
-	usermessage.Hook("FAdmin_StopSounds", function()
+	net.Receive("FAdmin_StopSounds", function()
 		RunConsoleCommand("stopsound") -- bypass for ConCommand blocking it
 	end)
 

--- a/gamemode/modules/fadmin/fadmin/cleanup/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/cleanup/sv_init.lua
@@ -12,8 +12,8 @@ end
 local function StopSounds(ply, cmd, args)
 	if not FAdmin.Access.PlayerHasPrivilege(ply, "CleanUp") then FAdmin.Messages.SendMessage(ply, 5, "No access!") return false end
 
-	umsg.Start("FAdmin_StopSounds")
-	umsg.End()
+	net.Start("FAdmin_StopSounds")
+	net.Broadcast()
 
 	FAdmin.Messages.ActionMessage(ply, player.GetAll(), "You have stopped all sounds", "All sounds have been stopped", "Stopped all sounds")
 

--- a/gamemode/modules/fadmin/fadmin/messaging/cl_init.lua
+++ b/gamemode/modules/fadmin/fadmin/messaging/cl_init.lua
@@ -28,7 +28,7 @@ function FAdmin.Messages.AddMessage( MsgType, Message )
 	LocalPlayer():EmitSound("npc/turret_floor/click1.wav", 30, 100)
 end
 
-usermessage.Hook("FAdmin_SendMessage", function(u) FAdmin.Messages.AddMessage(u:ReadShort(), u:ReadString()) end)
+net.Receive("FAdmin_SendMessage", function() FAdmin.Messages.AddMessage(net.ReadUInt(16), net.ReadString()) end)
 
 
 local function DrawNotice( self, k, v, i )
@@ -114,7 +114,7 @@ local function HUDPaint()
 end
 hook.Add("HUDPaint", "FAdmin_MessagePaint", HUDPaint)
 
-local function ConsoleMessage(um)
-	MsgC(Color(255,0,0,255), "(FAdmin) ", Color(200,0,200,255), um:ReadString() .. "\n")
+local function ConsoleMessage()
+	MsgC(Color(255,0,0,255), "(FAdmin) ", Color(200,0,200,255), net.ReadString() .. "\n")
 end
-usermessage.Hook("FAdmin_ConsoleMessage", ConsoleMessage)
+net.Receive("FAdmin_ConsoleMessage", ConsoleMessage)

--- a/gamemode/modules/fadmin/fadmin/messaging/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/messaging/sv_init.lua
@@ -5,28 +5,28 @@ function FAdmin.Messages.SendMessage(ply, MsgType, text)
 		return
 	end
 
-	umsg.Start("FAdmin_SendMessage", ply)
-		umsg.Short(MsgType)
-		umsg.String(text)
-	umsg.End()
+	net.Start("FAdmin_SendMessage")
+		net.WriteUInt(MsgType, 16)
+		net.WriteString(text)
+	net.Send(ply)
 	ply:PrintMessage(HUD_PRINTCONSOLE, text)
 end
 
 function FAdmin.Messages.SendMessageAll(text, MsgType)
 	FAdmin.Log("FAdmin message to everyone: "..text)
-	umsg.Start("FAdmin_SendMessage")
-		umsg.Short(MsgType)
-		umsg.String(text)
-	umsg.End()
+	net.Start("FAdmin_SendMessage")
+		net.WriteUInt(MsgType, 16)
+		net.WriteString(text)
+	net.Broadcast()
 	for _,ply in pairs(player.GetAll()) do
 		ply:PrintMessage(HUD_PRINTCONSOLE, text)
 	end
 end
 
 function FAdmin.Messages.ConsoleNotify(ply, message)
-	umsg.Start("FAdmin_ConsoleMessage", ply)
-		umsg.String(message)
-	umsg.End()
+	net.Start("FAdmin_ConsoleMessage")
+		net.WriteString(message)
+	net.Send(ply)
 end
 
 function FAdmin.Messages.ActionMessage(ply, target, messageToPly, MessageToTarget, LogMSG)

--- a/gamemode/modules/fadmin/fadmin/playeractions/kickban/cl_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/kickban/cl_init.lua
@@ -2,40 +2,40 @@
 WHEN GETTING KICKED
 */
 local KickText = ""
-usermessage.Hook("FAdmin_kick_start", function()
+net.Receive("FAdmin_kick_start", function()
 	hook.Add("HUDPaint", "FAdmin_kick", function()
 		draw.RoundedBox(0,0,0, ScrW(), ScrH(), Color(0,0,0,255))
 		draw.DrawNonParsedText("You are getting kicked\nReason: "..KickText.."\nLeaving voluntarily is also an option.", "HUDNumber5", ScrW()/2, ScrH()/2, Color(255,0,0,255), TEXT_ALIGN_CENTER)
 	end)
 end)
 
-usermessage.Hook("FAdmin_kick_cancel", function()
+net.Receive("FAdmin_kick_cancel", function()
 	hook.Remove("HUDPaint", "FAdmin_kick")
 	FAdmin.Messages.AddMessage(4, "Kick was canceled by admin")
 end)
 
-usermessage.Hook("FAdmin_kick_update", function(um)
-	KickText = um:ReadString()
+net.Receive("FAdmin_kick_update", function()
+	KickText = net.ReadString()
 end)
 
 local BanText = "No reason"
 local BanTimeText = "permanent"
 
-usermessage.Hook("FAdmin_ban_start", function()
+net.Receive("FAdmin_ban_start", function()
 	hook.Add("HUDPaint", "FAdmin_ban", function()
 		draw.RoundedBox(0,0,0, ScrW(), ScrH(), Color(0,0,0,255))
 		draw.DrawNonParsedText("You are getting banned\nReason: "..BanText.."\nTime: ".." "..BanTimeText.."\nLeaving voluntarily or rejoining will not prevent banning.", "HUDNumber5", ScrW()/2, ScrH()/2, Color(0,0,255,255), TEXT_ALIGN_CENTER)
 	end)
 end)
 
-usermessage.Hook("FAdmin_ban_cancel", function()
+net.Receive("FAdmin_ban_cancel", function()
 	hook.Remove("HUDPaint", "FAdmin_ban")
 	FAdmin.Messages.AddMessage(4, "Ban was canceled by admin")
 end)
 
-usermessage.Hook("FAdmin_ban_update", function(um)
-	BanTimeText = FAdmin.PlayerActions.ConvertBanTime(um:ReadLong())
-	BanText = um:ReadString()
+net.Receive("FAdmin_ban_update", function()
+	BanTimeText = FAdmin.PlayerActions.ConvertBanTime(net.ReadUInt(32))
+	BanText = net.ReadString()
 end)
 
 /*---------------------------------------------------------------------------

--- a/gamemode/modules/fadmin/fadmin/playeractions/spectate/cl_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/spectate/cl_init.lua
@@ -259,9 +259,9 @@ end
 specEnt
 Spectate a player
 ---------------------------------------------------------------------------*/
-local function startSpectate(um)
-	isRoaming = um:ReadBool()
-	specEnt = um:ReadEntity()
+local function startSpectate()
+	isRoaming = net.ReadBool()
+	specEnt = net.ReadEntity()
 
 	if isRoaming then
 		startFreeRoam()
@@ -282,7 +282,7 @@ local function startSpectate(um)
 		RunConsoleCommand("_FAdmin_SpectatePosUpdate", roamPos.x, roamPos.y, roamPos.z)
 	end)
 end
-usermessage.Hook("FAdminSpectate", startSpectate)
+net.Receive("FAdminSpectate", startSpectate)
 
 /*---------------------------------------------------------------------------
 stopSpectating

--- a/gamemode/modules/fadmin/fadmin/playeractions/spectate/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/spectate/sv_init.lua
@@ -12,10 +12,10 @@ local function Spectate(ply, cmd, args)
 
 	ply:ExitVehicle()
 
-	umsg.Start("FAdminSpectate", ply)
-		umsg.Bool(target == nil) -- Is the player roaming?
-		umsg.Entity(ply.FAdminSpectatingEnt)
-	umsg.End()
+	net.Start("FAdminSpectate")
+		net.WriteBool(target == nil) -- Is the player roaming?
+		net.WriteEntity(ply.FAdminSpectatingEnt)
+	net.Send(ply)
 
 	hook.Add("PlayerSay", ply, OnPlayerSay)
 

--- a/gamemode/modules/fpp/pp/client/buddies.lua
+++ b/gamemode/modules/fpp/pp/client/buddies.lua
@@ -72,8 +72,8 @@ function FPP.SaveBuddy(SteamID, Name, Type, value)
 	end
 end
 
-function FPP.NewBuddy(um)
-	local ply = um:ReadEntity()
+function FPP.NewBuddy()
+	local ply = net.ReadEntity()
 
 	if not IsValid(ply) or not ply:IsPlayer() then return end
 	local SteamID = ply:SteamID()
@@ -91,4 +91,4 @@ function FPP.NewBuddy(um)
 		FPP.Buddies[SteamID].name = ply:Nick()
 	end
 end
-usermessage.Hook("FPP_CheckBuddy", FPP.NewBuddy)
+net.Receive("FPP_CheckBuddy", FPP.NewBuddy)

--- a/gamemode/modules/fpp/pp/client/hud.lua
+++ b/gamemode/modules/fpp/pp/client/hud.lua
@@ -61,7 +61,7 @@ function FPP.AddNotify( str, type )
 	LocalPlayer():EmitSound("npc/turret_floor/click1.wav", 10, 100)
 end
 
-usermessage.Hook("FPP_Notify", function(u) FPP.AddNotify(u:ReadString(), u:ReadBool()) end)
+net.Receive("FPP_Notify", function() FPP.AddNotify(net.ReadString(), net.ReadBool()) end)
 
 local function DrawNotice( self, k, v, i )
 

--- a/gamemode/modules/fpp/pp/client/menu.lua
+++ b/gamemode/modules/fpp/pp/client/menu.lua
@@ -602,8 +602,8 @@ function FPP.AdminMenu(Panel)
 	AdminPanel:Dock(FILL)
 end
 
-RetrieveBlockedModels = function(um)
-	local model = um:ReadString()
+RetrieveBlockedModels = function()
+	local model = net.ReadString()
 	if not ShowBlockedModels then return end
 
 	local Icon = vgui.Create("SpawnIcon", ShowBlockedModels.pan)
@@ -620,19 +620,16 @@ RetrieveBlockedModels = function(um)
 	end
 	ShowBlockedModels.pan:AddItem(Icon)
 end
-usermessage.Hook("FPP_BlockedModel", RetrieveBlockedModels)
+net.Receive("FPP_BlockedModel", RetrieveBlockedModels)
 
-RetrieveRestrictedTool = function(um)
-	local tool, admin, Teams = um, 0, {}--Settings when it's not a usermessage
-	if type(um) ~= "table" then
-		tool = um:ReadString()
-		admin = um:ReadLong()
-		Teams = um:ReadString()
-		if Teams ~= "nil" then
-			Teams = string.Explode(";", Teams)
-		else
-			Teams = {}
-		end
+RetrieveRestrictedTool = function()
+	local tool = net.ReadString()
+	local admin = net.ReadUInt(32)
+	local Teams = net.ReadString()
+	if Teams ~= "nil" then
+		Teams = string.Explode(";", Teams)
+	else
+		Teams = {}
 	end
 
 	local frame = vgui.Create("DFrame")
@@ -802,7 +799,7 @@ RetrieveRestrictedTool = function(um)
 	end
 
 end
-usermessage.Hook("FPP_RestrictedToolList", RetrieveRestrictedTool)
+net.Receive("FPP_RestrictedToolList", RetrieveRestrictedTool)
 
 EditGroupTools = function(groupname)
 	if not FPP.Groups[groupname] then return end
@@ -899,16 +896,16 @@ EditGroupTools = function(groupname)
 	end
 end
 
-local function retrieveblocked(um)
-	local Type = string.lower(um:ReadString())
+local function retrieveblocked()
+	local Type = string.lower(net.ReadString())
 	if not BlockedLists[Type] then return end
-	local text = um:ReadString()
+	local text = net.ReadString()
 	local line = BlockedLists[Type]:AddLine(text)
 	line.text = text
 	BlockedLists[Type]:SetTall(18 + #BlockedLists[Type]:GetLines() * 17)
 	//BlockedLists[Type]:GetParent():GetParent():GetParent():GetParent():InvalidateLayout()
 end
-usermessage.Hook("FPP_blockedlist", retrieveblocked)
+net.Receive("FPP_blockedlist", retrieveblocked)
 
 local BuddiesPanel
 function FPP.BuddiesMenu(Panel)
@@ -1095,13 +1092,13 @@ local function UpdateMenus()
 end
 hook.Add("SpawnMenuOpen", "FPPMenus", UpdateMenus)
 
-function FPP.SharedMenu(um)
-	local ent = um:ReadEntity()
+function FPP.SharedMenu()
+	local ent = net.ReadEntity()
 	if not IsValid(ent) then frame:Close() return end
 	local frame = vgui.Create("DFrame")
 	frame:SetTitle("Share "..ent:GetClass())
 	frame:MakePopup()
-	frame:SetVisible( true )
+	frame:SetVisible(true)
 
 	local count = 1.5
 	local row = 1
@@ -1135,18 +1132,18 @@ function FPP.SharedMenu(um)
 		end
 		box:SizeToContents()
 	end
-	AddChk("Physgun", "SharePhysgun1", um:ReadBool())
-	AddChk("Gravgun", "ShareGravgun1", um:ReadBool())
-	AddChk("Use", "SharePlayerUse1", um:ReadBool())
-	AddChk("Damage", "ShareEntityDamage1", um:ReadBool())
-	AddChk("Toolgun", "ShareToolgun1", um:ReadBool())
+	AddChk("Physgun", "SharePhysgun1", net.ReadBool())
+	AddChk("Gravgun", "ShareGravgun1", net.ReadBool())
+	AddChk("Use", "SharePlayerUse1", net.ReadBool())
+	AddChk("Damage", "ShareEntityDamage1", net.ReadBool())
+	AddChk("Toolgun", "ShareToolgun1", net.ReadBool())
 
-	local long = um:ReadLong()
+	local long = net.ReadUInt(32)
 	local SharedWith = {}
 
 	if long > 0 then
 		for i=1, long do
-			table.insert(SharedWith, um:ReadEntity())
+			table.insert(SharedWith, net.ReadEntity())
 		end
 	end
 
@@ -1169,7 +1166,7 @@ function FPP.SharedMenu(um)
 	frame:SetSize(math.Min(math.Max(165 + (row - 1) * 165, 165), ScrW()), height)
 	frame:Center()
 end
-usermessage.Hook("FPP_ShareSettings", FPP.SharedMenu)
+net.Receive("FPP_ShareSettings", FPP.SharedMenu)
 
 properties.Add("addFPPBlocked",
 {

--- a/gamemode/modules/fpp/pp/server/core.lua
+++ b/gamemode/modules/fpp/pp/server/core.lua
@@ -571,15 +571,16 @@ hook.Add("PlayerDisconnected", "FPP.PlayerDisconnect", FPP.PlayerDisconnect)
 
 -- PlayerInitialspawn, the props he had left before will now be theirs again
 function FPP.PlayerInitialSpawn(ply)
-	local RP = RecipientFilter()
 
 	timer.Simple(5, function()
 		if not IsValid(ply) then return end
-		RP:AddAllPlayers()
-		RP:RemovePlayer(ply)
-		umsg.Start("FPP_CheckBuddy", RP)--Message everyone that a new player has joined
-			umsg.Entity(ply)
-		umsg.End()
+
+		local all = player.GetAll()
+		table.RemoveByValue(all, ply)
+
+		net.Start("FPP_CheckBuddy", RP)--Message everyone that a new player has joined
+			net.WriteEntity(ply)
+		net.Send(all)
 	end)
 
 	local entities = {}
@@ -592,10 +593,10 @@ function FPP.PlayerInitialSpawn(ply)
 		end
 	end
 
-	local plys = {}
-	for k,v in pairs(player.GetAll()) do if v ~= ply then table.insert(plys, v) end end
+	local players = player.GetAll()
+	table.RemoveByValue(players, ply)
 
-	FPP.recalculateCanTouch(plys, entities)
+	FPP.recalculateCanTouch(players, entities)
 	timer.Simple(0, function() -- wait until the player's usergroup is initialized
 		if not IsValid(ply) then return end
 		FPP.recalculateCanTouch({ply}, ents.GetAll())

--- a/gamemode/modules/hud/cl_hud.lua
+++ b/gamemode/modules/hud/cl_hud.lua
@@ -192,9 +192,9 @@ end
 
 local Arrested = function() end
 
-usermessage.Hook("GotArrested", function(msg)
+net.Receive("GotArrested", function()
 	local StartArrested = CurTime()
-	local ArrestedUntil = msg:ReadFloat()
+	local ArrestedUntil = net.ReadFloat()
 
 	Arrested = function()
 		if CurTime() - StartArrested <= ArrestedUntil and localplayer:getDarkRPVar("Arrested") then
@@ -207,9 +207,9 @@ end)
 
 local AdminTell = function() end
 
-usermessage.Hook("AdminTell", function(msg)
+net.Receive("AdminTell", function()
 	timer.Destroy("DarkRP_AdminTell")
-	local Message = msg:ReadString()
+	local Message = net.ReadString()
 
 	AdminTell = function()
 		draw.RoundedBox(4, 10, 10, Scrw - 20, 110, colors.darkblack)
@@ -226,7 +226,7 @@ end)
 Drawing the HUD elements such as Health etc.
 ---------------------------------------------------------------------------*/
 local function DrawHUD()
-	localplayer = localplayer and IsValid(localplayer) and localplayer or LocalPlayer()
+	localplayer = IsValid(localplayer) and localplayer or LocalPlayer()
 	if not IsValid(localplayer) then return end
 
 	local shouldDraw = hook.Call("HUDShouldDraw", GAMEMODE, "DarkRP_HUD")
@@ -362,15 +362,15 @@ end
 /*---------------------------------------------------------------------------
 Display notifications
 ---------------------------------------------------------------------------*/
-local function DisplayNotify(msg)
-	local txt = msg:ReadString()
-	GAMEMODE:AddNotify(txt, msg:ReadShort(), msg:ReadLong())
+local function DisplayNotify()
+	local txt = net.ReadString()
+	GAMEMODE:AddNotify(txt, net.ReadUInt(16), net.ReadUInt(32))
 	surface.PlaySound("buttons/lightswitch2.wav")
 
 	-- Log to client console
 	MsgC(Color(255, 20, 20, 255), "[DarkRP] ", Color(200, 200, 200, 255), txt, "\n")
 end
-usermessage.Hook("_Notify", DisplayNotify)
+net.Receive("_Notify", DisplayNotify)
 
 /*---------------------------------------------------------------------------
 Remove some elements from the HUD in favour of the DarkRP HUD

--- a/gamemode/modules/hud/sv_admintell.lua
+++ b/gamemode/modules/hud/sv_admintell.lua
@@ -21,9 +21,9 @@ local function ccTell(ply, cmd, args)
 			msg = msg .. args[n] .. " "
 		end
 
-		umsg.Start("AdminTell", target)
-			umsg.String(msg)
-		umsg.End()
+		net.Start("AdminTell")
+			net.WriteString(msg)
+		net.Send(target)
 
 		if ply:EntIndex() == 0 then
 			DarkRP.log("Console did rp_tell \""..msg .. "\" on "..target:SteamName(), Color(30, 30, 30))
@@ -53,9 +53,9 @@ local function ccTellAll(ply, cmd, args)
 		msg = msg .. args[n] .. " "
 	end
 
-	umsg.Start("AdminTell")
-		umsg.String(msg)
-	umsg.End()
+	net.Start("AdminTell")
+		net.WriteString(msg)
+	net.Broadcast()
 
 	if ply:EntIndex() == 0 then
 		DarkRP.log("Console did rp_tellall \""..msg .. "\"", Color(30, 30, 30))

--- a/gamemode/modules/hungermod/cl_init.lua
+++ b/gamemode/modules/hungermod/cl_init.lua
@@ -95,8 +95,8 @@ local function HMHUD()
 end
 hook.Add("HUDDrawTargetID", "HMHUD", HMHUD) --HUDDrawTargetID is called after DarkRP HUD is drawn in HUDPaint
 
-local function AteFoodIcon(msg)
+local function AteFoodIcon()
 	FoodAteAlpha = 1
 	FoodAteY = ScrH() - 8
 end
-usermessage.Hook("AteFoodIcon", AteFoodIcon)
+net.Receive("AteFoodIcon", AteFoodIcon)

--- a/gamemode/modules/jobs/sv_jobs.lua
+++ b/gamemode/modules/jobs/sv_jobs.lua
@@ -144,10 +144,10 @@ function meta:changeTeam(t, force)
 		self:KillSilent()
 	end
 
-	umsg.Start("OnChangedTeam", self)
-		umsg.Short(prevTeam)
-		umsg.Short(t)
-	umsg.End()
+	net.Start("OnChangedTeam")
+		net.WriteUInt(prevTeam, 16)
+		net.WriteUInt(t, 16)
+	net.Send(self)
 	return true
 end
 

--- a/gamemode/modules/logging/cl_init.lua
+++ b/gamemode/modules/logging/cl_init.lua
@@ -1,9 +1,9 @@
 /*---------------------------------------------------------------------------
 Log a message to console
 ---------------------------------------------------------------------------*/
-local function AdminLog(um)
-	local colour = Color(um:ReadShort(), um:ReadShort(), um:ReadShort())
-	local text = um:ReadString() .. "\n"
+local function AdminLog()
+	local colour = Color(net.ReadUInt(16), net.ReadUInt(16), net.ReadUInt(16))
+	local text = net.ReadString() .. "\n"
 	MsgC(Color(255,0,0), "[" .. GAMEMODE.Name .. "] ", colour, DarkRP.deLocalise(text))
 end
-usermessage.Hook("DRPLogMsg", AdminLog)
+net.Receive("DRPLogMsg", AdminLog)

--- a/gamemode/modules/logging/sv_logging.lua
+++ b/gamemode/modules/logging/sv_logging.lua
@@ -1,18 +1,18 @@
 local function AdminLog(message, colour)
-	local RF = RecipientFilter()
+	local players = {}
 	for k,v in pairs(player.GetAll()) do
 		local canHear = hook.Call("canSeeLogMessage", GAMEMODE, v, message, colour)
 
 		if canHear then
-			RF:AddPlayer(v)
+			table.insert(players, v)
 		end
 	end
-	umsg.Start("DRPLogMsg", RF)
-		umsg.Short(colour.r)
-		umsg.Short(colour.g)
-		umsg.Short(colour.b) -- Alpha is not needed
-		umsg.String(message)
-	umsg.End()
+	net.Start("DRPLogMsg")
+		net.WriteUInt(colour.r, 16)
+		net.WriteUInt(colour.g, 16)
+		net.WriteUInt(colour.b, 16)
+		net.WriteString(message)
+	net.Send(players)
 end
 
 local DarkRPFile

--- a/gamemode/modules/money/sv_money.lua
+++ b/gamemode/modules/money/sv_money.lua
@@ -80,12 +80,9 @@ local function GiveMoney(ply, args)
 			return ""
 		end
 
-		local RP = RecipientFilter()
-		RP:AddAllPlayers()
-
-		umsg.Start("anim_giveitem", RP)
-			umsg.Entity(ply)
-		umsg.End()
+		net.Start("anim_giveitem")
+			net.WriteEntity(ply)
+		net.Broadcast()
 		ply.anim_GivingItem = true
 
 		timer.Simple(1.2, function()
@@ -143,12 +140,10 @@ local function DropMoney(ply, args)
 	end
 
 	ply:addMoney(-amount)
-	local RP = RecipientFilter()
-	RP:AddAllPlayers()
 
-	umsg.Start("anim_dropitem", RP)
-		umsg.Entity(ply)
-	umsg.End()
+	net.Start("anim_dropitem")
+		net.WriteEntity(ply)
+	net.Broadcast()
 	ply.anim_DroppingItem = true
 
 	timer.Simple(1, function()
@@ -196,9 +191,9 @@ local function CreateCheque(ply, args)
 		ply:addMoney(-amount)
 	end
 
-	umsg.Start("anim_dropitem", RecipientFilter():AddAllPlayers())
-		umsg.Entity(ply)
-	umsg.End()
+	net.Start("anim_dropitem")
+		net.WriteEntity(ply)
+	net.Broadcast()
 	ply.anim_DroppingItem = true
 
 	timer.Simple(1, function()

--- a/gamemode/modules/playerscale/cl_playerscale.lua
+++ b/gamemode/modules/playerscale/cl_playerscale.lua
@@ -1,9 +1,11 @@
-local function doScale(um)
-	local ply = um:ReadEntity()
-	local scale = um:ReadFloat()
-
+local function doScale()
+	local ply = net.ReadEntity()
+	
 	if not IsValid(ply) then return end
+	
+	local scale = net.ReadFloat()
+	
 	ply:SetModelScale(scale, 1)
 	ply:SetHull(Vector(-16, -16, 0), Vector(16, 16, 72 * scale))
 end
-usermessage.Hook("darkrp_playerscale", doScale)
+net.Receive("darkrp_playerscale", doScale)

--- a/gamemode/modules/playerscale/sv_playerscale.lua
+++ b/gamemode/modules/playerscale/sv_playerscale.lua
@@ -2,10 +2,10 @@ local function setScale(ply, scale)
 	ply:SetModelScale(scale, 0)
 
 	ply:SetHull(Vector(-16, -16, 0), Vector(16, 16, 72 * scale))
-	umsg.Start("darkrp_playerscale")
-		umsg.Entity(ply)
-		umsg.Float(scale)
-	umsg.End()
+	net.Start("darkrp_playerscale")
+		net.WriteEntity(ply)
+		net.WriteFloat(scale)
+	net.Broadcast()
 end
 
 local function onLoadout(ply)

--- a/gamemode/modules/police/sv_init.lua
+++ b/gamemode/modules/police/sv_init.lua
@@ -312,9 +312,9 @@ function DarkRP.hooks:playerArrested(ply, time, arrester)
 		if IsValid(ply) then ply:unArrest() end
 		arrestedPlayers[steamID] = nil
 	end)
-	umsg.Start("GotArrested", ply)
-		umsg.Float(time)
-	umsg.End()
+	net.Start("GotArrested")
+		net.WriteFloat(time)
+	net.Send(ply)
 end
 
 function DarkRP.hooks:playerUnArrested(ply, actor)

--- a/gamemode/modules/sleep/sv_sleep.lua
+++ b/gamemode/modules/sleep/sv_sleep.lua
@@ -67,7 +67,9 @@ function DarkRP.toggleSleep(player, command)
 					player:Lock()
 				end
 
-				SendUserMessage("blackScreen", player, false)
+				net.Start("blackScreen")
+					net.WriteBool(false)
+				net.Send(player)
 
 				if command == true then
 					player:arrest()
@@ -125,7 +127,9 @@ function DarkRP.toggleSleep(player, command)
 				--Make sure noone can pick it up:
 				ragdoll:CPPISetOwner(player)
 
-				SendUserMessage("blackScreen", player, true)
+				net.Start("blackScreen")
+					net.WriteBool(true)
+				net.Send(player)
 
 				player.SleepSound = CreateSound(ragdoll, "npc/ichthyosaur/water_breath.wav")
 				player.SleepSound:PlayEx(0.10, 100)

--- a/gamemode/modules/voting/cl_voting.lua
+++ b/gamemode/modules/voting/cl_voting.lua
@@ -1,12 +1,12 @@
 local QuestionVGUI = {}
 local PanelNum = 0
 local VoteVGUI = {}
-local function MsgDoVote(msg)
+local function MsgDoVote()
 	local _, chatY = chat.GetChatBoxPos()
 
-	local question = msg:ReadString()
-	local voteid = msg:ReadShort()
-	local timeleft = msg:ReadFloat()
+	local question = net.ReadString()
+	local voteid = net.ReadUInt(16)
+	local timeleft = net.ReadFloat()
 	if timeleft == 0 then
 		timeleft = 100
 	end
@@ -99,22 +99,21 @@ local function MsgDoVote(msg)
 	VoteVGUI[voteid .. "vote"] = panel
 	panel:SetSkin(GAMEMODE.Config.DarkRPSkin)
 end
-usermessage.Hook("DoVote", MsgDoVote)
+net.Receive("DoVote", MsgDoVote)
 
-local function KillVoteVGUI(msg)
-	local id = msg:ReadShort()
+local function KillVoteVGUI()
+	local id = net.ReadUInt(16)
 
 	if VoteVGUI[id .. "vote"] and VoteVGUI[id .. "vote"]:IsValid() then
 		VoteVGUI[id.."vote"]:Close()
-
 	end
 end
-usermessage.Hook("KillVoteVGUI", KillVoteVGUI)
+net.Receive("KillVoteVGUI", KillVoteVGUI)
 
-local function MsgDoQuestion(msg)
-	local question = msg:ReadString()
-	local quesid = msg:ReadString()
-	local timeleft = msg:ReadFloat()
+local function MsgDoQuestion()
+	local question = net.ReadString()
+	local quesid = net.ReadString()
+	local timeleft = net.ReadFloat()
 	if timeleft == 0 then
 		timeleft = 100
 	end
@@ -193,16 +192,16 @@ local function MsgDoQuestion(msg)
 
 	panel:SetSkin(GAMEMODE.Config.DarkRPSkin)
 end
-usermessage.Hook("DoQuestion", MsgDoQuestion)
+net.Receive("DoQuestion", MsgDoQuestion)
 
-local function KillQuestionVGUI(msg)
-	local id = msg:ReadString()
+local function KillQuestionVGUI()
+	local id = net.ReadString()
 
 	if QuestionVGUI[id .. "ques"] and QuestionVGUI[id .. "ques"]:IsValid() then
 		QuestionVGUI[id .. "ques"]:Close()
 	end
 end
-usermessage.Hook("KillQuestionVGUI", KillQuestionVGUI)
+net.Receive("KillQuestionVGUI", KillQuestionVGUI)
 
 local function DoVoteAnswerQuestion(ply, cmd, args)
 	if not args[1] then return end

--- a/gamemode/modules/voting/sv_questions.lua
+++ b/gamemode/modules/voting/sv_questions.lua
@@ -39,19 +39,19 @@ function DarkRP.createQuestion(question, quesid, ent, delay, callback, fromPly, 
 
 	Questions[quesid] = newques
 
-	umsg.Start("DoQuestion", ent)
-		umsg.String(question)
-		umsg.String(quesid)
-		umsg.Float(delay)
-	umsg.End()
+	net.Start("DoQuestion")
+		net.WriteString(question)
+		net.WriteString(quesid)
+		net.WriteFloat(delay)
+	net.Send(ent)
 
 	timer.Create(quesid .. "timer", delay, 1, function() handleQuestionEnd(quesid) end)
 end
 
 function DarkRP.destroyQuestion(id)
-	umsg.Start("KillQuestionVGUI", Questions[id].Ent)
-		umsg.String(Questions[id].ID)
-	umsg.End()
+	net.Start("KillQuestionVGUI")
+		net.WriteString(Questions[id].ID)
+	net.Send(Questions[id].Ent)
 
 	Questions[id] = nil
 end


### PR DESCRIPTION
*Phew*

All these changes were rote conversion and are untested. I call out to
all server owners to test these changes and report back any
errors/functionality problems.

Falco, I noticed on FPP_ShareSettings, you left a comment saying you had
issues with the usermessage being too large on servers with >60 people.
I would test the changes you wanted to make with net messages since they
have an increased query size.

Also, I noticed some weird functionality on player hulls. You broadcasted the hull change clientside of a single player, then, set the hull size of that one player on every client. Was this intentional?

Lastly, I left the VOTE:getFilter() function there for legacy purposes, but changed it to return a table instead.