### PR TITLE
Wiki fixes

### DIFF
--- a/entities/weapons/keys/cl_menu.lua
+++ b/entities/weapons/keys/cl_menu.lua
@@ -93,7 +93,8 @@ DarkRP.hookStub{
 		}
 	},
 	returns = {
-	}
+	},
+	realm = "Client"
 }
 
 local KeyFrameVisible = false

--- a/gamemode/modules/base/sv_interface.lua
+++ b/gamemode/modules/base/sv_interface.lua
@@ -1066,6 +1066,11 @@ DarkRP.hookStub{
 			name = "amount",
 			description = "The amount of money given to the player.",
 			type = "number"
+		},
+		{
+			name = "wallet",
+			description = "How much money the player had before receiving the money.",
+			type = "number"
 		}
 	},
 	returns = {


### PR DESCRIPTION
* Fixed onKeysMenuChanged hook stub having implicit Shared realm.
  - I assume this is why the hook was missing from the wiki (Shared realm is handled serverside but the file is clientside).
* Added missing playerWalletChanged parameter to docs.