### PR TITLE
Added wanted time override

### DIFF
--- a/gamemode/modules/police/sv_init.lua
+++ b/gamemode/modules/police/sv_init.lua
@@ -46,14 +46,14 @@ function plyMeta:requestWarrant(suspect, actor, reason)
 	DarkRP.createQuestion(question, suspect:EntIndex() .. "warrant", self, 40, finishWarrantRequest, actor, suspect, reason)
 end
 
-function plyMeta:wanted(actor, reason)
+function plyMeta:wanted(actor, reason, time)
 	local suppressMsg = hook.Call("playerWanted", DarkRP.hooks, self, actor, reason)
 
 	self:setDarkRPVar("wanted", true)
 	self:setDarkRPVar("wantedReason", reason)
 
 
-	timer.Create(self:UniqueID() .. " wantedtimer", GAMEMODE.Config.wantedtime, 1, function()
+	timer.Create(self:UniqueID() .. " wantedtimer", time or GAMEMODE.Config.wantedtime, 1, function()
 		if not IsValid(self) then return end
 		self:unWanted()
 	end)

--- a/gamemode/modules/police/sv_interface.lua
+++ b/gamemode/modules/police/sv_interface.lua
@@ -121,6 +121,12 @@ DarkRP.PLAYER.wanted = DarkRP.stub{
 			description = "The reason for the wanted status.",
 			type = "string",
 			optional = false
+		},
+		{
+			name = "time",
+			description = "The time in seconds for which the player should be wanted.",
+			type = "number",
+			optional = true
 		}
 	},
 	returns = {


### PR DESCRIPTION
This allows overriding the default wanted time with a custom one.

I was in the situation where I had to either repeatedly call :wanted or manually fiddle with the timer, and I'd rather not fiddle with the internals here.