### PR TITLE
Updated blacklisted items for pocket

### DIFF
--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -400,6 +400,17 @@ GM.Config.PocketBlacklist = {
 	["money_printer"] = true,
 	["gunlab"] = true,
 	["prop_dynamic"] = true,
+	["spawned_money"] = true,
+	["prop_vehicle_prisoner_pod"] = true,
+	["keypad_wire"] = true,
+	["gmod_button"] = true,
+	["gmod_rtcameraprop"] = true,
+	["gmod_cameraprop"] = true,
+	["gmod_dynamite"] = true,
+	["gmod_thruster"] = true,
+	["gmod_light"] = true,
+	["gmod_lamp"] = true,
+	["gmod_emitter"] = true,
 }
 
 -- These weapons are classed as 'legal' in the weapon checker and are not stripped when confiscating weapons.


### PR DESCRIPTION
Some gmod tools and chairs with wire-keypad now blacklisted for pocket. Money entity also blocked due to money dupe