### PR TITLE
Privileged command fixes

### DIFF
--- a/gamemode/modules/base/sh_createitems.lua
+++ b/gamemode/modules/base/sh_createitems.lua
@@ -446,7 +446,6 @@ local function addTeamCommands(CTeam, max)
             end
 
             ply:changeTeam(k)
-            return
         end
         DarkRP.defineChatCommand(CTeam.command, function(ply)
             CAMI.PlayerHasAccess(ply, "DarkRP_GetJob_" .. CTeam.command, fp{onJobCommand, ply})

--- a/gamemode/modules/base/sv_entityvars.lua
+++ b/gamemode/modules/base/sv_entityvars.lua
@@ -104,7 +104,7 @@ local function setRPName(ply, arg)
     local args = string.Explode(" ", arg)
 
     if not args[2] or string.len(args[2]) < 2 or string.len(args[2]) > 30 then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), "<2/>30"))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), "<2/>30"))
         return
     end
 
@@ -114,12 +114,13 @@ local function setRPName(ply, arg)
 
     if target then
         local oldname = target:Nick()
-        local nick = ""
+
         DarkRP.storeRPName(target, name)
         target:setDarkRPVar("rpname", name)
 
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("you_set_x_name", oldname, name))
+        DarkRP.notify(ply, 0, 4, DarkRP.getPhrase("you_set_x_name", oldname, name))
 
+        local nick = ""
         if ply:EntIndex() == 0 then
             nick = "Console"
         else
@@ -132,14 +133,14 @@ local function setRPName(ply, arg)
             DarkRP.log(ply:Nick() .. " (" .. ply:SteamID() .. ") set " .. target:SteamName() .. "'s name to " .. name, Color(30, 30, 30))
         end
     else
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", args[1]))
     end
 end
 DarkRP.definePrivilegedChatCommand("forcerpname", "DarkRP_AdminCommands", setRPName)
 
 local function RPName(ply, args)
     if ply.LastNameChange and ply.LastNameChange > (CurTime() - 5) then
-        DarkRP.notify( ply, 1, 4, DarkRP.getPhrase("have_to_wait",  math.ceil(5 - (CurTime() - ply.LastNameChange)), "/rpname"))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("have_to_wait",  math.ceil(5 - (CurTime() - ply.LastNameChange)), "/rpname"))
         return ""
     end
 

--- a/gamemode/modules/base/sv_util.lua
+++ b/gamemode/modules/base/sv_util.lua
@@ -1,4 +1,9 @@
 function DarkRP.notify(ply, msgtype, len, msg)
+    if not IsValid(ply) then
+        -- Dedicated erver console
+        print(msg)
+    end
+
     umsg.Start("_Notify", ply)
         umsg.String(msg)
         umsg.Short(msgtype)

--- a/gamemode/modules/doorsystem/sv_dooradministration.lua
+++ b/gamemode/modules/doorsystem/sv_dooradministration.lua
@@ -19,15 +19,10 @@ end
 DarkRP.definePrivilegedChatCommand("forceunown", "DarkRP_SetDoorOwner", ccDoorUnOwn)
 
 local function unownAll(ply, args)
-    if not args or not args then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-        return
-    end
-
     local target = DarkRP.findPlayer(args)
 
     if not IsValid(target) then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", args))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", args))
         return
     end
     target:keysUnOwnAll()
@@ -58,7 +53,7 @@ local function ccAddOwner(ply, args)
     local target = DarkRP.findPlayer(args)
 
     if not target then
-        ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("could_not_find", args))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", args))
         return
     end
 
@@ -66,7 +61,7 @@ local function ccAddOwner(ply, args)
         if not trace.Entity:isKeysOwnedBy(target) and not trace.Entity:isKeysAllowedToOwn(target) then
             trace.Entity:addKeysAllowedToOwn(target)
         else
-            ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("rp_addowner_already_owns_door", target))
+            DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("rp_addowner_already_owns_door", target))
         end
     end
     trace.Entity:keysOwn(target)
@@ -92,7 +87,7 @@ local function ccRemoveOwner(ply, args)
     local target = DarkRP.findPlayer(args)
 
     if not target then
-        ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("could_not_find", args))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", args))
         return
     end
 
@@ -124,7 +119,7 @@ local function ccLock(ply, args)
         return
     end
 
-    ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("locked"))
+    DarkRP.notify(ply, 0, 4, DarkRP.getPhrase("locked"))
 
     trace.Entity:keysLock()
 
@@ -154,7 +149,7 @@ local function ccUnLock(ply, args)
         return
     end
 
-    ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("unlocked"))
+    DarkRP.notify(ply, 0, 4, DarkRP.getPhrase("unlocked"))
     trace.Entity:keysUnLock()
 
     if not trace.Entity:CreatedByMap() then return end
@@ -164,8 +159,8 @@ local function ccUnLock(ply, args)
         MySQLite.SQLStr(trace.Entity:getKeysTitle() or ""),
         trace.Entity:getKeysNonOwnable() and 1 or 0
         ))
-    DarkRP.log(ply:Nick() .. " (" .. ply:SteamID() .. ") force-unlocked a door with forcelock (unlocked door is saved)", Color(30, 30, 30))
 
+    DarkRP.log(ply:Nick() .. " (" .. ply:SteamID() .. ") force-unlocked a door with forcelock (unlocked door is saved)", Color(30, 30, 30))
     DarkRP.notify(ply, 0, 4, "Forcefully unlocked")
 end
 DarkRP.definePrivilegedChatCommand("forceunlock", "DarkRP_ChangeDoorSettings", ccUnLock)

--- a/gamemode/modules/doorsystem/sv_dooradministration.lua
+++ b/gamemode/modules/doorsystem/sv_dooradministration.lua
@@ -63,6 +63,7 @@ local function ccAddOwner(ply, args)
         else
             DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("rp_addowner_already_owns_door", target))
         end
+        return
     end
     trace.Entity:keysOwn(target)
 

--- a/gamemode/modules/hud/sv_admintell.lua
+++ b/gamemode/modules/hud/sv_admintell.lua
@@ -4,11 +4,6 @@ Messages
 local function ccTell(ply, arg)
     local args = string.Explode(" ", arg)
 
-    if not args or not args[1] then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-        return
-    end
-
     local target = DarkRP.findPlayer(args[1])
 
     if target then
@@ -28,17 +23,12 @@ local function ccTell(ply, arg)
             DarkRP.log(ply:Nick() .. " (" .. ply:SteamID() .. ") did admintell \"" .. msg .. "\" on " .. target:SteamName(), Color(30, 30, 30))
         end
     else
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", tostring(args[1])))
     end
 end
 DarkRP.definePrivilegedChatCommand("admintell", "DarkRP_AdminCommands", ccTell)
 
 local function ccTellAll(ply, args)
-    if not args then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-        return
-    end
-
     umsg.Start("AdminTell")
         umsg.String(args)
     umsg.End()

--- a/gamemode/modules/jobs/sv_jobs.lua
+++ b/gamemode/modules/jobs/sv_jobs.lua
@@ -412,16 +412,15 @@ end
 DarkRP.definePrivilegedChatCommand("teamban", "DarkRP_AdminCommands", DoTeamBan)
 
 local function DoTeamUnBan(ply, args)
-    if not args or args == "" then
+    local a,b = string.find(args, " ")
+
+    if not a or a == #args then
         DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("invalid_x", "arguments", ""))
         return
     end
 
-    local ent = args
-    local Team = args
-    local a,b = string.find(args, " ")
-    ent = string.sub(args, 1, a - 1)
-    Team = string.sub(args, a + 1)
+    local ent = string.sub(args, 1, a - 1)
+    local Team = string.sub(args, a + 1)
 
     local target = DarkRP.findPlayer(ent)
     if not target or not IsValid(target) then

--- a/gamemode/modules/jobs/sv_jobs.lua
+++ b/gamemode/modules/jobs/sv_jobs.lua
@@ -369,14 +369,15 @@ DarkRP.defineChatCommand("jobswitch", SwitchJob)
 
 
 local function DoTeamBan(ply, args)
-    if not args or args == "" then
+    args = string.Explode(" ", args)
+
+    local ent = args[1]
+    local Team = args[2]
+
+    if not Team then
         DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("invalid_x", "arguments", ""))
         return
     end
-
-    args = string.Explode(" ", args)
-    local ent = args[1]
-    local Team = args[2]
 
     local target = DarkRP.findPlayer(ent)
     if not target or not IsValid(target) then
@@ -407,8 +408,6 @@ local function DoTeamBan(ply, args)
         nick = ply:Nick()
     end
     DarkRP.notifyAll(0, 5, DarkRP.getPhrase("x_teambanned_y", nick, target:Nick(), team.GetName(tonumber(Team))))
-
-    return
 end
 DarkRP.definePrivilegedChatCommand("teamban", "DarkRP_AdminCommands", DoTeamBan)
 
@@ -456,8 +455,6 @@ local function DoTeamUnBan(ply, args)
     else
         nick = ply:Nick()
     end
-    DarkRP.notifyAll(1, 5, DarkRP.getPhrase("x_teamunbanned_y", nick, target:Nick(), team.GetName(tonumber(Team))))
-
-    return
+    DarkRP.notifyAll(0, 5, DarkRP.getPhrase("x_teamunbanned_y", nick, target:Nick(), team.GetName(tonumber(Team))))
 end
 DarkRP.definePrivilegedChatCommand("teamunban", "DarkRP_AdminCommands", DoTeamUnBan)

--- a/gamemode/modules/money/sv_money.lua
+++ b/gamemode/modules/money/sv_money.lua
@@ -229,14 +229,14 @@ local function ccSetMoney(ply, arg)
     local args = string.Explode(" ", arg)
 
     if not tonumber(args[2]) then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
         return
     end
 
     local target = DarkRP.findPlayer(args[1])
 
     if not target then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", tostring(args[1])))
         return
     end
 
@@ -246,7 +246,7 @@ local function ccSetMoney(ply, arg)
         DarkRP.storeMoney(target, amount)
         target:setDarkRPVar("money", amount)
 
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("you_set_x_money", target:Nick(), DarkRP.formatMoney(amount), ""))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("you_set_x_money", target:Nick(), DarkRP.formatMoney(amount), ""))
 
         DarkRP.notify(target, 0, 4, DarkRP.getPhrase("x_set_your_money", ply:EntIndex() == 0 and "Console" or ply:Nick(), DarkRP.formatMoney(amount), ""))
         if ply:EntIndex() == 0 then
@@ -255,7 +255,7 @@ local function ccSetMoney(ply, arg)
             DarkRP.log(ply:Nick() .. " (" .. ply:SteamID() .. ") set " .. target:SteamName() .. "'s money to " ..  DarkRP.formatMoney(amount), Color(30, 30, 30))
         end
     else
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", args[1]))
     end
 end
 DarkRP.definePrivilegedChatCommand("setmoney", "DarkRP_SetMoney", ccSetMoney)
@@ -264,14 +264,14 @@ local function ccAddMoney(ply, arg)
     local args = string.Explode(" ", arg)
 
     if not tonumber(args[2]) then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
         return
     end
 
     local target = DarkRP.findPlayer(args[1])
 
     if not target then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", tostring(args[1])))
         return
     end
 
@@ -280,7 +280,7 @@ local function ccAddMoney(ply, arg)
     if target then
         target:addMoney(amount)
 
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("you_gave", target:Nick(), DarkRP.formatMoney(amount)))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("you_gave", target:Nick(), DarkRP.formatMoney(amount)))
 
         DarkRP.notify(target, 0, 4, DarkRP.getPhrase("x_set_your_money", ply:EntIndex() == 0 and "Console" or ply:Nick(), DarkRP.formatMoney(target:getDarkRPVar("money")), ""))
         if ply:EntIndex() == 0 then
@@ -289,7 +289,7 @@ local function ccAddMoney(ply, arg)
             DarkRP.log(ply:Nick() .. " (" .. ply:SteamID() .. ") added " .. DarkRP.formatMoney(amount) .. " to " .. target:SteamName() .. "'s wallet", Color(30, 30, 30))
         end
     else
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", args[1]))
     end
 end
 DarkRP.definePrivilegedChatCommand("addmoney", "DarkRP_SetMoney", ccAddMoney)
@@ -298,18 +298,14 @@ local function ccSetSalary(ply, arg)
     local args = string.Explode(" ", arg)
 
     if not tonumber(args[2]) then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-        return
-    end
-    if ply:EntIndex() ~= 0 and not ply:IsSuperAdmin() then
-        ply:PrintMessage(HUD_PRINTCONSOLE, DarkRP.getPhrase("need_sadmin", "rp_setsalary"))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
         return
     end
 
     local amount = math.floor(tonumber(args[2]))
 
     if amount < 0 or amount > 150 then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), tostring(args[2]) .. " (0-150)"))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), tostring(args[2]) .. " (0-150)"))
         return
     end
 
@@ -319,7 +315,7 @@ local function ccSetSalary(ply, arg)
         DarkRP.storeSalary(target, amount)
         target:setSelfDarkRPVar("salary", amount)
 
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("you_set_x_salary", target:Nick(), DarkRP.formatMoney(amount), ""))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("you_set_x_salary", target:Nick(), DarkRP.formatMoney(amount), ""))
 
         DarkRP.notify(target, 0, 4, DarkRP.getPhrase("x_set_your_salary", ply:EntIndex() == 0 and "Console" or ply:Nick(), DarkRP.formatMoney(amount), ""))
         if ply:EntIndex() == 0 then
@@ -328,7 +324,7 @@ local function ccSetSalary(ply, arg)
             DarkRP.log(ply:Nick() .. " (" .. ply:SteamID() .. ") set " .. target:SteamName() .. "'s salary to " .. DarkRP.formatMoney(amount), Color(30, 30, 30))
         end
     else
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(args[1])))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", tostring(args[1])))
         return
     end
 end

--- a/gamemode/modules/police/sv_commands.lua
+++ b/gamemode/modules/police/sv_commands.lua
@@ -78,7 +78,7 @@ local function EnterLottery(answer, ent, initiator, target, TimeIsUp)
         local chosen = LotteryPeople[math.random(1, #LotteryPeople)]
         hook.Run("lotteryEnded", LotteryPeople, chosen, #LotteryPeople * LotteryAmount)
         chosen:addMoney(#LotteryPeople * LotteryAmount)
-        DarkRP.notifyAll(0,10, DarkRP.getPhrase("lottery_won", chosen:Nick(), DarkRP.formatMoney(#LotteryPeople * LotteryAmount)))
+        DarkRP.notifyAll(0, 10, DarkRP.getPhrase("lottery_won", chosen:Nick(), DarkRP.formatMoney(#LotteryPeople * LotteryAmount)))
     end
 end
 
@@ -290,15 +290,10 @@ end
 DarkRP.defineChatCommand("givelicense", GiveLicense)
 
 local function rp_GiveLicense(ply, arg)
-    if not arg then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-        return
-    end
-
     local target = DarkRP.findPlayer(arg)
 
     if not target then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(arg)))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", tostring(arg)))
         return
     end
 
@@ -315,22 +310,17 @@ local function rp_GiveLicense(ply, arg)
 
     DarkRP.notify(target, 0, 4, DarkRP.getPhrase("gunlicense_granted", nick, target:Nick()))
     if ply ~= target then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("gunlicense_granted", nick, target:Nick()))
+        DarkRP.notify(ply, 0, 4, DarkRP.getPhrase("gunlicense_granted", nick, target:Nick()))
     end
     DarkRP.log(nick .. " (" .. steamID .. ") force-gave " .. target:Nick() .. " a gun license", Color(30, 30, 30))
 end
 DarkRP.definePrivilegedChatCommand("setlicense", "DarkRP_SetLicense", rp_GiveLicense)
 
 local function rp_RevokeLicense(ply, arg)
-    if not arg then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-        return
-    end
-
     local target = DarkRP.findPlayer(arg)
 
     if not target then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", tostring(arg)))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", tostring(arg)))
         return
     end
 
@@ -347,7 +337,7 @@ local function rp_RevokeLicense(ply, arg)
 
     DarkRP.notify(target, 1, 4, DarkRP.getPhrase("gunlicense_denied", nick, target:Nick()))
     if ply ~= target then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("gunlicense_denied", nick, target:Nick()))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("gunlicense_denied", nick, target:Nick()))
     end
     DarkRP.log(nick .. " (" .. steamID .. ") force-removed " .. target:Nick() .. "'s gun license", Color(30, 30, 30))
 end

--- a/gamemode/modules/police/sv_init.lua
+++ b/gamemode/modules/police/sv_init.lua
@@ -211,20 +211,15 @@ Admin commands
 local function ccArrest(ply, arg)
     local args = string.Explode(" ", arg)
 
-    if not args[1] then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-        return
-    end
-
     if DarkRP.jailPosCount() == 0 then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("no_jail_pos"))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("no_jail_pos"))
         return
     end
 
     local targets = DarkRP.findPlayers(args[1])
 
     if not targets then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", args[1]))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", args[1]))
         return
     end
 
@@ -248,15 +243,10 @@ DarkRP.definePrivilegedChatCommand("arrest", "DarkRP_AdminCommands", ccArrest)
 local function ccUnarrest(ply, arg)
     local args = string.Explode(" ", arg)
 
-    if not args or not args[1] then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
-        return
-    end
-
     local targets = DarkRP.findPlayers(args[1])
 
     if not targets then
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("could_not_find", args[1]))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", args[1]))
         return
     end
 

--- a/gamemode/modules/positions/sv_spawnpos.lua
+++ b/gamemode/modules/positions/sv_spawnpos.lua
@@ -14,8 +14,6 @@ local function SetSpawnPos(ply, args)
     else
         DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", tostring(args)))
     end
-
-    return
 end
 DarkRP.definePrivilegedChatCommand("setspawn", "DarkRP_AdminCommands", SetSpawnPos)
 
@@ -35,8 +33,6 @@ local function AddSpawnPos(ply, args)
     else
         DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", tostring(args)))
     end
-
-    return
 end
 DarkRP.definePrivilegedChatCommand("addspawn", "DarkRP_AdminCommands", AddSpawnPos)
 
@@ -56,7 +52,5 @@ local function RemoveSpawnPos(ply, args)
     else
         DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("could_not_find", tostring(args)))
     end
-
-    return
 end
 DarkRP.definePrivilegedChatCommand("removespawn", "DarkRP_AdminCommands", RemoveSpawnPos)

--- a/gamemode/modules/voting/sv_votes.lua
+++ b/gamemode/modules/voting/sv_votes.lua
@@ -171,7 +171,7 @@ local function CancelVote(ply)
             print(DarkRP.getPhrase("x_cancelled_vote", "Console"))
         end
     else
-        DarkRP.printConsoleMessage(ply, DarkRP.getPhrase("cant_cancel_vote"))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("cant_cancel_vote"))
     end
 end
 DarkRP.definePrivilegedChatCommand("forcecancelvote", "DarkRP_AdminCommands", CancelVote)


### PR DESCRIPTION
Fixes a few bugs with the new privileged commands:
* Fixed new privileged commands printing errors to console directly rather than through DarkRP.notify.
  - DarkRP.notify now prints to console for the dedicated server console entity.
* Fixed dedicated server console erroring in some.
* Fixed /teamunban erroring with invalid arguments.
* Fixed /forceown falsely printing success notifications in some cases.