### PR TITLE
Added a custom lockdown sound config

### DIFF
--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -284,7 +284,7 @@ GM.Config.MoneyClass = "spawned_money"
 GM.Config.moneyModel = "models/props/cs_assault/money.mdl"
 -- You can set your own, custom sound to be played for all players whenever a lockdown is initiated
 -- Note: Remember to include the folder where the sound file is located
-GM.Config.lockdownsound "npc/overwatch/cityvoice/f_confirmcivilstatus_1_spkr.wav"
+GM.Config.lockdownsound = "npc/overwatch/cityvoice/f_confirmcivilstatus_1_spkr.wav"
 
 -- The skin DarkRP uses. Set to "default" to use the GMod default derma theme
 GM.Config.DarkRPSkin = "DarkRP"

--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -282,6 +282,9 @@ Other settings
 GM.Config.MoneyClass = "spawned_money"
 -- In case you do wish to keep the default money, but change the model, this option is the way to go:
 GM.Config.moneyModel = "models/props/cs_assault/money.mdl"
+-- You can set your own, custom sound to be played for all players whenever a lockdown is initiated
+-- Note: Remember to include the folder where the sound file is located
+GM.Config.lockdownsound "npc/overwatch/cityvoice/f_confirmcivilstatus_1_spkr.wav"
 
 -- The skin DarkRP uses. Set to "default" to use the GMod default derma theme
 GM.Config.DarkRPSkin = "DarkRP"

--- a/gamemode/modules/police/sv_commands.lua
+++ b/gamemode/modules/police/sv_commands.lua
@@ -139,7 +139,7 @@ function DarkRP.lockdown(ply)
     end
 
     for k,v in pairs(player.GetAll()) do
-        v:ConCommand("play npc/overwatch/cityvoice/f_confirmcivilstatus_1_spkr.wav\n")
+        v:ConCommand("play GM.Config.lockdownsound\n")
     end
 
     DarkRP.printMessageAll(HUD_PRINTTALK, DarkRP.getPhrase("lockdown_started"))

--- a/gamemode/modules/police/sv_commands.lua
+++ b/gamemode/modules/police/sv_commands.lua
@@ -125,12 +125,6 @@ local function DoLottery(ply, amount)
 end
 DarkRP.defineChatCommand("lottery", DoLottery, 1)
 
-local wait_lockdown = false
-
-local function WaitLock()
-    wait_lockdown = false
-    timer.Remove("spamlock")
-end
 
 function DarkRP.lockdown(ply)
     local show = ply:EntIndex() == 0 and print or fp{DarkRP.notify, ply, 1, 4}
@@ -163,10 +157,6 @@ function DarkRP.unLockdown(ply)
         show(DarkRP.getPhrase("unable", "/unlockdown", DarkRP.getPhrase("lockdown_ended")))
         return ""
     end
-    if wait_lockdown then
-        show(DarkRP.getPhrase("wait_with_that"))
-        return ""
-    end
 
     if ply:EntIndex() ~= 0 and not ply:isMayor() then
         show(DarkRP.getPhrase("incorrect_job", "/unlockdown", ""))
@@ -175,9 +165,7 @@ function DarkRP.unLockdown(ply)
 
     DarkRP.printMessageAll(HUD_PRINTTALK, DarkRP.getPhrase("lockdown_ended"))
     DarkRP.notifyAll(0, 3, DarkRP.getPhrase("lockdown_ended"))
-    wait_lockdown = true
     SetGlobalBool("DarkRP_LockDown", false)
-    timer.Create("spamlock", 20, 1, WaitLock)
 
     return ""
 end

--- a/gamemode/modules/police/sv_commands.lua
+++ b/gamemode/modules/police/sv_commands.lua
@@ -139,7 +139,7 @@ function DarkRP.lockdown(ply)
     end
 
     for k,v in pairs(player.GetAll()) do
-        v:ConCommand("play GM.Config.lockdownsound\n")
+        v:ConCommand("play " .. GM.Config.lockdownsound .. "\n")
     end
 
     DarkRP.printMessageAll(HUD_PRINTTALK, DarkRP.getPhrase("lockdown_started"))


### PR DESCRIPTION
I thought it would be kind of cool to be able to have your own lockdown sound (like an epic siren instead of the HL2 alarm that gives people headaches every time they hear it).
I've also found some redundant code that didn't make any sense. Why would you need to wait 20 seconds to use /unlockdown again after you've used it? Very much unneeded.