### PR TITLE
Added hook onPlayerSay

### DIFF
--- a/gamemode/modules/chat/sv_chat.lua
+++ b/gamemode/modules/chat/sv_chat.lua
@@ -89,6 +89,10 @@ local function RP_PlayerChat(ply, text, teamonly)
         callback = callback or "" .. " "
     end
 
+    local command = tblCmd and tblCmd.command or ""
+    local overrideTxt = hook.Run("onPlayerSay", ply, command, text, teamonly)
+    if overrideTxt then return overrideTxt, callback, DoSayFunc end
+
     return text, callback, DoSayFunc;
 end
 

--- a/gamemode/modules/chat/sv_interface.lua
+++ b/gamemode/modules/chat/sv_interface.lua
@@ -47,6 +47,40 @@ DarkRP.definePrivilegedChatCommand = DarkRP.stub{
 }
 
 DarkRP.hookStub{
+    name = "onPlayerSay",
+    description = "Called right before a players message is shown in chat.",
+    parameters = {
+        {
+            name = "ply",
+            description = "The player who spoke.",
+            type = "Player"
+        },
+        {
+            name = "command",
+            description = "They command they used or an empty string if no command is used.",
+            type = "string"
+        },
+        {
+            name = "text",
+            description = "The thing they said.",
+            type = "string"
+        },
+        {
+            name = "teamonly",
+            description = "Whether they said it to their team only.",
+            type = "boolean"
+        }
+    },
+    returns = {
+        {
+            name = "overrideText",
+            description = "Overrides the message that will be put in everyone's chat box. Return nil to not change behaviour.",
+            type = "string"
+        }
+    }
+}
+
+DarkRP.hookStub{
     name = "PostPlayerSay",
     description = "Called after a player has said something.",
     parameters = {


### PR DESCRIPTION
As it stands right now there is no way to to alter messages the player
sends in chat. Since DarkRP rips out all the other PlayerSay hooks, this hook is
needed as an alternative.