### PR TITLE
Allow players to drop $1

### DIFF
--- a/gamemode/modules/money/sv_money.lua
+++ b/gamemode/modules/money/sv_money.lua
@@ -126,8 +126,8 @@ local function DropMoney(ply, args)
     end
     local amount = math.floor(tonumber(args))
 
-    if amount <= 1 then
-        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("invalid_x", "argument", ">1"))
+    if amount < 1 then
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("invalid_x", "argument", ">0"))
         return ""
     end
 


### PR DESCRIPTION
It's pointless to prevent players from dropping $1 but allow them to drop $2.

Note: Since this is a trivial change, I've made it with GitHub's online editor and haven't tested it in-game.