### PR TITLE
Minor fixes for non-DarkRP Skins

### DIFF
--- a/entities/weapons/keys/cl_menu.lua
+++ b/entities/weapons/keys/cl_menu.lua
@@ -50,7 +50,9 @@ local function openMenu(setDoorOwnerAccess, doorSettingsAccess)
 
     KeyFrameVisible = true
     local Frame = vgui.Create("DFrame")
-    Frame:SetSize(200, 30) -- base size
+    Frame:SetSize(200, 30) -- Base size
+    Frame.btnMaxim:SetVisible(false)
+    Frame.btnMinim:SetVisible(false)
     Frame:SetVisible(true)
     Frame:MakePopup()
 

--- a/entities/weapons/pocket/cl_menu.lua
+++ b/entities/weapons/pocket/cl_menu.lua
@@ -34,6 +34,8 @@ function DarkRP.openPocketMenu()
     frame = vgui.Create("DFrame")
 
     frame:SetTitle(DarkRP.getPhrase("drop_item"))
+    frame.btnMaxim:SetVisible(false)
+    frame.btnMinim:SetVisible(false)
     frame:SetVisible(true)
     frame:MakePopup()
 

--- a/gamemode/modules/animations/sh_animations.lua
+++ b/gamemode/modules/animations/sh_animations.lua
@@ -180,6 +180,8 @@ local function AnimationMenu()
     AnimFrame:SetSize(130, Height)
     AnimFrame:SetPos(ScrW() / 2 + ScrW() * 0.1, ScrH() / 2 - (Height / 2))
     AnimFrame:SetTitle(DarkRP.getPhrase("custom_animation"))
+    AnimFrame.btnMaxim:SetVisible(false)
+    AnimFrame.btnMinim:SetVisible(false)
     AnimFrame:SetVisible(true)
     AnimFrame:MakePopup()
 

--- a/gamemode/modules/f1menu/cl_searchbox.lua
+++ b/gamemode/modules/f1menu/cl_searchbox.lua
@@ -6,15 +6,18 @@ function PANEL:Init()
     self.BaseClass.Init(self)
     self.F1Down = true
     self:SetFont("DarkRPHUD2")
-    self:SetTextColor(Color(255,255,255,255))
-    self:SetCursorColor(Color(255,255,255,255))
 
     self.lblSearch = vgui.Create("DLabel", self)
     self.lblSearch:SetFont("DarkRPHUD2")
-    self.lblSearch:SetColor(Color(200, 200, 200, 200))
     self.lblSearch:SetText(DarkRP.getPhrase("f1Search"))
     self.lblSearch:SizeToContents()
     self.lblSearch:SetPos(5)
+
+    if GAMEMODE.Config.DarkRPSkin == "DarkRP" then
+        self:SetTextColor(Color(255,255,255,255))
+        self:SetCursorColor(Color(255,255,255,255))
+        self.lblSearch:SetColor(Color(200, 200, 200, 200))
+    end
 end
 
 function PANEL:OnLoseFocus()

--- a/gamemode/modules/f1menu/cl_searchbox.lua
+++ b/gamemode/modules/f1menu/cl_searchbox.lua
@@ -6,18 +6,15 @@ function PANEL:Init()
     self.BaseClass.Init(self)
     self.F1Down = true
     self:SetFont("DarkRPHUD2")
+    self:SetTextColor(Color(255,255,255,255))
+    self:SetCursorColor(Color(255,255,255,255))
 
     self.lblSearch = vgui.Create("DLabel", self)
     self.lblSearch:SetFont("DarkRPHUD2")
+    self.lblSearch:SetColor(Color(200, 200, 200, 200))
     self.lblSearch:SetText(DarkRP.getPhrase("f1Search"))
     self.lblSearch:SizeToContents()
     self.lblSearch:SetPos(5)
-
-    if GAMEMODE.Config.DarkRPSkin == "DarkRP" then
-        self:SetTextColor(Color(255,255,255,255))
-        self:SetCursorColor(Color(255,255,255,255))
-        self.lblSearch:SetColor(Color(200, 200, 200, 200))
-    end
 end
 
 function PANEL:OnLoseFocus()

--- a/gamemode/modules/voting/cl_voting.lua
+++ b/gamemode/modules/voting/cl_voting.lua
@@ -20,6 +20,8 @@ local function MsgDoVote(msg)
     panel:SetSize(140, 140)
     panel:SetSizable(false)
     panel.btnClose:SetVisible(false)
+    panel.btnMaxim:SetVisible(false)
+    panel.btnMinim:SetVisible(false)
     panel:SetDraggable(false)
     function panel:Close()
         PanelNum = PanelNum - 140
@@ -62,7 +64,7 @@ local function MsgDoVote(msg)
     label:SizeToContents()
     label:SetVisible(true)
 
-    local nextHeight = label:GetTall() > 78 and label:GetTall() - 78 or 0 -- make panel taller for divider and buttons
+    local nextHeight = label:GetTall() > 78 and label:GetTall() - 78 or 0 -- Make panel taller for divider and buttons
     panel:SetTall(panel:GetTall() + nextHeight)
 
     local divider = vgui.Create("Divider")
@@ -120,10 +122,12 @@ local function MsgDoQuestion(msg)
     local OldTime = CurTime()
     LocalPlayer():EmitSound("Town.d1_town_02_elevbell1", 100, 100)
     local panel = vgui.Create("DFrame")
-    panel:SetPos(3 + PanelNum, ScrH() / 2 - 50) --Times 140 because if the quesion is the second screen, the first screen is always a vote screen.
+    panel:SetPos(3 + PanelNum, ScrH() / 2 - 50) -- Times 140 because if the question is the second screen, the first screen is always a vote screen.
     panel:SetSize(300, 140)
     panel:SetSizable(false)
     panel.btnClose:SetVisible(false)
+    panel.btnMaxim:SetVisible(false)
+    panel.btnMinim:SetVisible(false)
     panel:SetKeyboardInputEnabled(false)
     panel:SetMouseInputEnabled(true)
     panel:SetVisible(true)


### PR DESCRIPTION
- Hidden the minimise/maximise buttons on vote/question windows.
- Removed the hardcoded text and cursor colour used in the search box of the F1 help menu when not using the official DarkRP skin.
- Corrected a typo in a comment.