### PR TITLE
Fixed SKIN support for F1 search box

### DIFF
--- a/gamemode/modules/dermaskin/cl_dermaskin.lua
+++ b/gamemode/modules/dermaskin/cl_dermaskin.lua
@@ -7,6 +7,11 @@ SKIN.DermaVersion       = 1
 SKIN.GwenTexture        = Material("darkrp/darkrpderma.png")
 
 
+SKIN.colTextEntryText               = Color(255, 255, 255)
+SKIN.colTextEntryTextCursor         = Color(255, 255, 255)
+
+SKIN.colTextEntryTextPlaceholder    = Color(200, 200, 200, 200) -- Unofficial but will probably be named this
+
 SKIN.tex = {}
 
 SKIN.tex.Selection                  = GWEN.CreateTextureBorder(384, 32, 31, 31, 4, 4, 4, 4)
@@ -237,5 +242,23 @@ SKIN.Colours.Category.LineAlt.Text_Selected     = GWEN.TextureColor(4 + 8 * 24, 
 SKIN.Colours.Category.LineAlt.Button            = GWEN.TextureColor(4 + 8 * 25, 508)
 SKIN.Colours.Category.LineAlt.Button_Hover      = GWEN.TextureColor(4 + 8 * 24, 500)
 SKIN.Colours.Category.LineAlt.Button_Selected   = GWEN.TextureColor(4 + 8 * 25, 500)
+
+-- Remove the following two functions when https://github.com/garrynewman/garrysmod/pull/1141 is merged
+function SKIN:PaintTextEntry(panel, w, h)
+    if panel.m_bBackground then
+        if panel:GetDisabled() then
+            self.tex.TextBox_Disabled(0, 0, w, h)
+        elseif panel:HasFocus() then
+            self.tex.TextBox_Focus(0, 0, w, h)
+        else
+            self.tex.TextBox(0, 0, w, h)
+        end
+    end
+
+    panel:DrawTextEntryText(panel.m_colText or self.colTextEntryText, panel.m_colHighlight or self.colTextEntryTextHighlight, panel.m_colCursor or self.colTextEntryTextCursor)
+end
+
+function SKIN:SchemeTextEntry()
+end
 
 derma.DefineSkin("DarkRP", "The official SKIN for DarkRP", SKIN)

--- a/gamemode/modules/f1menu/cl_f1menupanel.lua
+++ b/gamemode/modules/f1menu/cl_f1menupanel.lua
@@ -8,6 +8,11 @@ function PANEL:Init()
 
     self:SetPos(-self:GetWide(), ScrH() * 0.05)
 
+    -- Can be removed once https://github.com/garrynewman/garrysmod/pull/1141 is merged.
+    -- It is here so it is set BEFORE the following panels are created.
+    -- Normally, it is set in DarkRP.openF1Menu().
+    self:SetSkin(GAMEMODE.Config.DarkRPSkin)
+
     self.slideInTime = self.slideInTime or 0.3
     self.toggled = false
 

--- a/gamemode/modules/f1menu/cl_searchbox.lua
+++ b/gamemode/modules/f1menu/cl_searchbox.lua
@@ -3,18 +3,18 @@ local PANEL = {}
 function PANEL:Init()
     self:SetWide(300)
     self:SetKeyboardInputEnabled(true)
-    self.BaseClass.Init(self)
     self.F1Down = true
     self:SetFont("DarkRPHUD2")
-    self:SetTextColor(Color(255,255,255,255))
-    self:SetCursorColor(Color(255,255,255,255))
 
+    -- This will eventually be gone when placeholder support is added to GMod
     self.lblSearch = vgui.Create("DLabel", self)
     self.lblSearch:SetFont("DarkRPHUD2")
-    self.lblSearch:SetColor(Color(200, 200, 200, 200))
     self.lblSearch:SetText(DarkRP.getPhrase("f1Search"))
     self.lblSearch:SizeToContents()
     self.lblSearch:SetPos(5)
+    function self.lblSearch:UpdateColours(skin)
+        self:SetTextStyleColor(skin.colTextEntryTextPlaceholder or Color(169, 169, 169))
+    end
 end
 
 function PANEL:OnLoseFocus()


### PR DESCRIPTION
See #2367.

The two SKIN functions are from https://github.com/garrynewman/garrysmod/pull/1141 and can be removed once that's merged. It's forwards compatible as the implementation is identical and SKIN base classes don't exist.

Placeholder SKIN support is unofficial since that PR isn't merged but is also forwards compatible unless the SKIN field name is inconsistent with the rest for some stupid reason.

The cl_f1menupanel.lua change is there because under the broken GMod implementation of DTextEntry, SchemeTextEntry is called in PANEL:Init. This would be before SetSkin is set (it was set once F1MenuPanel is fully created which is after F1SearchBox is) and so would call the default skin's SchemeTextEntry which sets the text colour in a shitty way which breaks custom skins. The SetSkin call before F1SearchBox is created avoids the default skin. Again, this change is also forwards compatible.

There is a disadvantage of not being able to change GM.Config.DarkRPSkin "on the fly" but that affects _every_ DTextEntry currently anyway and I don't think people do change the skin like that.