### PR TITLE
Changed Touch to StartTouch methods in spawned_shipment/spawned_weapon/spawned_ammo

### DIFF
--- a/entities/entities/spawned_ammo/init.lua
+++ b/entities/entities/spawned_ammo/init.lua
@@ -15,7 +15,7 @@ function ENT:OnTakeDamage(dmg)
     self:TakePhysicsDamage(dmg)
 end
 
-function ENT:Touch(ent)
+function ENT:StartTouch(ent)
     -- the .USED var is also used in other mods for the same purpose
     if ent.IsSpawnedAmmo ~= true or
         self.ammoType ~= ent.ammoType or

--- a/entities/entities/spawned_shipment/init.lua
+++ b/entities/entities/spawned_shipment/init.lua
@@ -176,7 +176,7 @@ function ENT:Destruct()
     self:Remove()
 end
 
-function ENT:Touch(ent)
+function ENT:StartTouch(ent)
     -- the .USED var is also used in other mods for the same purpose
     if not ent.IsSpawnedShipment or
         self:Getcontents() ~= ent:Getcontents() or

--- a/entities/entities/spawned_weapon/init.lua
+++ b/entities/entities/spawned_weapon/init.lua
@@ -85,7 +85,7 @@ function ENT:Use(activator, caller)
     self:DecreaseAmount()
 end
 
-function ENT:Touch(ent)
+function ENT:StartTouch(ent)
     -- the .USED var is also used in other mods for the same purpose
     if ent.IsSpawnedWeapon ~= true or
         self:GetWeaponClass() ~= ent:GetWeaponClass() or


### PR DESCRIPTION
Improves performance when having many entities close to any of these as Touch is called much more often than StartTouch but the behavior of the entities only requires StartTouch to function.