### PR TITLE
Added TEAM_COOK to disabled compatibility list.

### DIFF
--- a/gamemode/config/jobrelated.lua
+++ b/gamemode/config/jobrelated.lua
@@ -233,7 +233,7 @@ TEAM_MEDIC   = TEAM_MEDIC    or -1
 TEAM_CHIEF   = TEAM_CHIEF    or -1
 TEAM_MAYOR   = TEAM_MAYOR    or -1
 TEAM_HOBO    = TEAM_HOBO     or -1
-
+TEAM_COOK    = TEAM_COOK     or -1
 
 /*
 --------------------------------------------------------


### PR DESCRIPTION
Fixes issues with all teams being able to purchase microwave if the default team is disabled.