### PR TITLE
Allowing Admins Lockdown/UnLockdown

### DIFF
--- a/gamemode/modules/police/sv_commands.lua
+++ b/gamemode/modules/police/sv_commands.lua
@@ -134,7 +134,7 @@ function DarkRP.lockdown(ply)
         return ""
     end
 
-    if ply:EntIndex() ~= 0 and not ply:isMayor() then
+    if ply:EntIndex() ~= 0 and not ply:isMayor() or ply:IsAdmin() then
         show(DarkRP.getPhrase("incorrect_job", "/lockdown", ""))
         return ""
     end
@@ -148,6 +148,7 @@ function DarkRP.lockdown(ply)
         show(DarkRP.getPhrase("wait_with_that"))
         return ""
     end
+    
 
     for _, v in pairs(player.GetAll()) do
         v:ConCommand("play " .. GAMEMODE.Config.lockdownsound .. "\n")
@@ -169,7 +170,7 @@ function DarkRP.unLockdown(ply)
         return ""
     end
 
-    if ply:EntIndex() ~= 0 and not ply:isMayor() then
+    if ply:EntIndex() ~= 0 and not ply:isMayor() or ply:IsAdmin() then
         show(DarkRP.getPhrase("incorrect_job", "/unlockdown", ""))
         return ""
     end


### PR DESCRIPTION
Granting ability to Admins to lockdown and unlockdown.
I would add if to the CAMI privilege of DarkRP_AdminCommands but I was unsure if what I have will work. What I had is this     CAMI.PlayerHasAccess(ply, "DarkRP_AdminCommands", function(access) 
     if not access then return end 
)
If it does, I will change the Commit (if possible).