### PR TITLE
Some typically bad Shigbeard code for custom /cr aliases.

### DIFF
--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -453,6 +453,13 @@ GM.Config.allowedProperties = {
     bodygroups = true,
 }
 
+-- Define additional aliases for the /cr command, useful for players to request the aid of police.
+-- /cr will always be the default command, and cannot be removed. These are simply alternatives you can use.
+GM.Config.combineRequestAliases = {
+	["911"] = true,
+	["000"] = true
+}
+
 --[[---------------------------------------------------------------------------
 F4 menu
 ---------------------------------------------------------------------------]]

--- a/gamemode/modules/police/sv_init.lua
+++ b/gamemode/modules/police/sv_init.lua
@@ -137,6 +137,14 @@ local function CombineRequest(ply, args)
 end
 DarkRP.defineChatCommand("cr", CombineRequest, 1.5)
 
+timer.Simple(1, function()
+    for alias, enabled in pairs(GAMEMODE.Config.combineRequestAliases) do
+        if enabled then
+            DarkRP.defineChatCommand(alias, CombineRequest, 1.5)
+        end
+    end
+end)
+
 local function warrantCommand(ply, args)
     local target = DarkRP.findPlayer(args[1])
     local reason = table.concat(args, " ", 2)


### PR DESCRIPTION
It works, should address #2420 

I'm disgusted in my usage of `timer.Simple(1, function() ... end)` but it works.

![http://i.imgur.com/EMaoQ1V.png](http://i.imgur.com/EMaoQ1V.png)