### PR TITLE
Added universal playerCanPickUp hook

### DIFF
--- a/entities/entities/darkrp_cheque/init.lua
+++ b/entities/entities/darkrp_cheque/init.lua
@@ -20,6 +20,12 @@ end
 
 
 function ENT:Use(activator, caller)
+    local canUse, reason = hook.Call("canDarkRPUse", nil, activator, self)
+    if canUse == false then
+      if reason then DarkRP.notify(activator, 1, 4, reason) end
+      return
+    end
+
     local owner = self:Getowning_ent()
     local recipient = self:Getrecipient()
     local amount = self:Getamount() or 0

--- a/entities/entities/spawned_ammo/init.lua
+++ b/entities/entities/spawned_ammo/init.lua
@@ -7,6 +7,12 @@ function ENT:Initialize()
 end
 
 function ENT:Use(activator, caller)
+    local canUse, reason = hook.Call("canDarkRPUse", nil, activator, self)
+    if canUse == false then
+      if reason then DarkRP.notify(activator, 1, 4, reason) end
+      return
+    end
+
     activator:GiveAmmo(self.amountGiven, self.ammoType)
     self:Remove()
 end

--- a/entities/entities/spawned_food/init.lua
+++ b/entities/entities/spawned_food/init.lua
@@ -18,6 +18,12 @@ function ENT:OnTakeDamage(dmg)
 end
 
 function ENT:Use(activator, caller)
+    local canUse, reason = hook.Call("canDarkRPUse", nil, activator, self)
+    if canUse == false then
+      if reason then DarkRP.notify(activator, 1, 4, reason) end
+      return
+    end
+
     local override = self.foodItem.onEaten and self.foodItem.onEaten(self, activator, self.foodItem)
 
     if override then

--- a/entities/entities/spawned_money/init.lua
+++ b/entities/entities/spawned_money/init.lua
@@ -17,8 +17,15 @@ function ENT:Initialize()
     phys:Wake()
 end
 
-function ENT:Use(activator,caller)
+function ENT:Use(activator, caller)
     if self.USED or self.hasMerged then return end
+
+    local canUse, reason = hook.Call("canDarkRPUse", nil, activator, self)
+    if canUse == false then
+      if reason then DarkRP.notify(activator, 1, 4, reason) end
+      return
+    end
+
     self.USED = true
     local amount = self:Getamount()
 
@@ -78,4 +85,34 @@ DarkRP.hookStub{
     returns = {
     },
     realm = "Server"
+}
+
+DarkRP.hookStub{
+    name = "canDarkRPUse",
+    description = "When a player uses an entity.",
+    parameters = {
+        {
+            name = "ply",
+            description = "The player who tries to use the entity.",
+            type = "Player"
+        },
+        {
+            name = "entity",
+            description = "The actual entity the player attempts to use.",
+            type = "Entity"
+        },
+    },
+    returns = {
+        {
+            name = "canUse",
+            description = "Whether the entity should be used or not.",
+            type = "boolean"
+        },
+        {
+            name = "reason",
+            description = "Why the entity cannot be used.",
+            optional = true,
+            type = "string"
+        },
+    },
 }


### PR DESCRIPTION
This hook can be used for every entity. It should stop the proliferation of  `canPickUp` hooks.

I also think `spawned_weapon` should use this too, but replacing it with the existing `shouldntPickUpDarkRPWeapon` will definitely break addons.