### PR TITLE
Fixed DarkRP being completely broken

### DIFF
--- a/gamemode/libraries/interfaceloader.lua
+++ b/gamemode/libraries/interfaceloader.lua
@@ -99,8 +99,7 @@ local function notImplemented(name, args, thisFunc)
     if stubs[name] and stubs[name].metatable[name] ~= thisFunc then -- when calling the not implemented function after the function was implemented
         return stubs[name].metatable[name](unpack(args))
     end
-    delayedCalls[name] = delayedCalls[name] or {}
-    table.insert(delayedCalls[name], args)
+    table.insert(delayedCalls, {name = name, args = args})
 
     return nil -- no return value because the method is not implemented
 end
@@ -156,12 +155,12 @@ Call the cached methods
 ---------------------------------------------------------------------------*/
 function finish()
     local calls = table.Copy(delayedCalls) -- Loop through a copy, so the notImplemented function doesn't get called again
-    for name, log in pairs(calls) do
+    for _, tbl in pairs(calls) do
+        local name = tbl.name
+
         if not stubs[name] then ErrorNoHalt("Calling non-existing stub \"" .. name .. "\"") continue end
 
-        for _, args in pairs(log) do
-            stubs[name].metatable[name](unpack(args))
-        end
+        stubs[name].metatable[name](unpack(tbl.args))
     end
 
     delayedCalls = {}

--- a/gamemode/modules/chat/sh_chatcommands.lua
+++ b/gamemode/modules/chat/sh_chatcommands.lua
@@ -40,8 +40,10 @@ function DarkRP.chatCommandAlias(command, ...)
     for k, v in pairs{...} do
         name = string.lower(v)
 
-        DarkRP.chatCommands[name] = table.Copy(DarkRP.chatCommands[command])
-        DarkRP.chatCommands[name].command = name
+        DarkRP.chatCommands[name] = {command = name}
+        setmetatable(DarkRP.chatCommands[name], {
+            __index = DarkRP.chatCommands[command]
+        })
     end
 end
 


### PR DESCRIPTION
Indirectly caused by 2d4689f.

```
[ERROR] gamemodes/darkrp/gamemode/modules/chat/sh_chatcommands.lua:44: attempt to index a nil value
  1. unknown - gamemodes/darkrp/gamemode/modules/chat/sh_chatcommands.lua:44
   2. finish - gamemodes/darkrp/gamemode/libraries/interfaceloader.lua:163
    3. unknown - gamemodes/darkrp/gamemode/init.lua:84

Couldn't Load Init Script: 'darkrp/gamemode/init.lua'
```

There was a couple issues:
* Delayed stub calling order was undefined. What was happening was that the `DarkRP.chatCommandAlias` call was actually being called _before_ `DarkRP.declareChatCommand `despite being located afterwards in code. The `delayedCall` table has now been modified to be a sequential table (less nicely packed but functionally better).
* There was issues with `DarkRP.defineChatCommand` and `DarkRP.declareChatCommand` being separate. After the previous fix, `DarkRP.chatCommandAlias` would no longer error since it was called after the `DarkRP.declareChatCommand` call, but the command itself would error when run due to `DarkRP.defineChatCommand` being called _after_ `DarkRP.chatCommandAlias` (due to the file execution order). Because the table copying occurred when `DarkRP.chatCommandAlias` was called, the callback function was never added to the alias's command table and thus threw an error. This was fixed by making the alias more like a true alias through a `__index` metamethod.

Technically it could've been fixed by wrapping the `DarkRP.chatCommandAlias` call in a timer or hook, but this made it less useful as it would've been boilerplate code required nearly every time the function was called. You might as well put the timer inside the function if you wanted to go in that direction.

These fixes also had the advantage of potentially fixing further problems caused by the undefined order in calling functions in the `delayedCalls` table and any manual chat command table editing that some addons may have done.