### PR TITLE
Updated Advert Billboard

### DIFF
--- a/entities/entities/darkrp_billboard/cl_init.lua
+++ b/entities/entities/darkrp_billboard/cl_init.lua
@@ -40,3 +40,6 @@ function ENT:Draw()
     render.PopCustomClipPlane()
     render.EnableClipping(false)
 end
+
+language.Add("Cleanup_advert_billboards", "Advert Billboards")
+language.Add("Undone_advert_billboard", "Undone Advert Billboard")

--- a/entities/entities/darkrp_billboard/init.lua
+++ b/entities/entities/darkrp_billboard/init.lua
@@ -17,10 +17,6 @@ function ENT:Initialize()
     end
 end
 
-local hookcanAdvert = {canAdvert = function(_, ply, action, args)
-    return true
-end}
-
 function ENT:SetDefaults(txt)
     txt = string.gsub(string.gsub(txt or "", "//", "\n"), "\\n", "\n")
     local split = string.Split(txt, "\n") or {}
@@ -33,15 +29,16 @@ function ENT:SetDefaults(txt)
     self:SetBarColor(Vector(1, 0.5, 0))
 end
 
-local function canEditVariable(_, ent, ply, key, val, editor)
-    return ent:CPPICanPhysgun(ply)
+local function canEditVariable(self, ent, ply, key, val, editor)
+	if self ~= ent then return end
+    return self:CPPICanPhysgun(ply)
 end
 
 local function placeBillboard(ply, args)
-    local canEdit, message = hook.Call("canAdvert", hookcanAdvert, ply, args)
+    local canEdit, message = hook.Call("canAdvert", nil, ply, args)
 
-    if not canEdit then
-        DarkRP.notify(ply, 1, 4, message ~= nil and message or DarkRP.getPhrase("unable", GAMEMODE.Config.chatCommandPrefix .. "advertise", ""))
+    if canEdit == false then
+        DarkRP.notify(ply, 1, 4, message or DarkRP.getPhrase("unable", GAMEMODE.Config.chatCommandPrefix .. "advertise", ""))
         return ""
     end
 
@@ -81,10 +78,12 @@ local function placeBillboard(ply, args)
 
     ply:DeleteOnRemove(ent)
 
-    undo.Create("Advert Billboard")
+    undo.Create("advert_billboard")
         undo.SetPlayer(ply)
         undo.AddEntity(ent)
     undo.Finish()
+
+    ply:AddCleanup("advert_billboards", ent)
 
     return ""
 end
@@ -97,5 +96,3 @@ function ENT:OnRemove()
 
     ply.DarkRP_advertboards = (ply.DarkRP_advertboards or 1) - 1
 end
-
-

--- a/entities/entities/darkrp_billboard/init.lua
+++ b/entities/entities/darkrp_billboard/init.lua
@@ -30,7 +30,7 @@ function ENT:SetDefaults(txt)
 end
 
 local function canEditVariable(self, ent, ply, key, val, editor)
-	if self ~= ent then return end
+    if self ~= ent then return end
     return self:CPPICanPhysgun(ply)
 end
 

--- a/entities/entities/darkrp_billboard/shared.lua
+++ b/entities/entities/darkrp_billboard/shared.lua
@@ -7,6 +7,8 @@ ENT.Author = "FPtje"
 ENT.Spawnable = false
 ENT.Editable = true
 
+cleanup.Register("advert_billboards")
+
 function ENT:SetupDataTables()
     self:NetworkVar("String", 0, "TopText", {
         KeyName = "toptext",


### PR DESCRIPTION
The most interesting mistake was:
![2016-06-20_07-39_h-srv-gm_test-garrysmod-gamem](https://cloud.githubusercontent.com/assets/6339511/16180842/c70418a2-36ba-11e6-8a9a-6a2a78833ad8.jpg)
![2016-06-20_07-46_dbot test server](https://cloud.githubusercontent.com/assets/6339511/16180843/c776cc3a-36ba-11e6-9efe-d35844cc935d.jpg)

Summary:
Added billboards cleanup on clientside
Fixed weird undo message
Fixed CanEditVariable hook
Removed rubbish