### PR TITLE
Fixed /me breaking when default garry's mod chat text is blocked

### DIFF
--- a/gamemode/modules/chat/cl_chat.lua
+++ b/gamemode/modules/chat/cl_chat.lua
@@ -32,7 +32,7 @@ local function AddToChat(bits)
             chat.AddNonParsedText(col1, prefixText, col2, ": " .. text)
         end
     else
-        shouldShow = hook.Call("ChatText", GAMEMODE, "0", prefixText, prefixText, "none")
+        shouldShow = hook.Call("ChatText", GAMEMODE, "0", prefixText, prefixText, "darkrp")
 
         if shouldShow ~= true then
             chat.AddNonParsedText(col1, prefixText)


### PR DESCRIPTION
The type of default garry's mod chat text is `none` (cvar changed, etc.). This gives darkrp chat text (like /me) its own type, which separates it from other chat text.