### PR TITLE
Make spawned_money work with all models

### DIFF
--- a/entities/entities/spawned_money/cl_init.lua
+++ b/entities/entities/spawned_money/cl_init.lua
@@ -3,27 +3,25 @@ include("shared.lua")
 function ENT:Initialize()
 end
 
+local vector_up = Vector(0,0,1)
 function ENT:Draw()
     self:DrawModel()
+    local offset = (self:OBBMaxs() - self:OBBCenter())*vector_up
 
-    -- Do not draw labels when a different model is used.
-    -- If you want a different model with labels, make your own money entity and use GM.Config.MoneyClass.
-    if self:GetModel() ~= "models/props/cs_assault/money.mdl" then return end
-
-    local Pos = self:GetPos()
+    local Pos = self:OBBCenter() 
     local Ang = self:GetAngles()
 
     surface.SetFont("ChatFont")
     local text = DarkRP.formatMoney(self:Getamount())
     local TextWidth = surface.GetTextSize(text)
 
-    cam.Start3D2D(Pos + Ang:Up() * 0.9, Ang, 0.1)
+    cam.Start3D2D(self:LocalToWorld(Pos+offset), Ang, 0.1)
         draw.WordBox(2, -TextWidth * 0.5, -10, text, "ChatFont", Color(140, 0, 0, 100), Color(255, 255, 255, 255))
     cam.End3D2D()
 
     Ang:RotateAroundAxis(Ang:Right(), 180)
 
-    cam.Start3D2D(Pos, Ang, 0.1)
+    cam.Start3D2D(self:LocalToWorld(Pos-offset), Ang, 0.1)
         draw.WordBox(2, -TextWidth * 0.5, -10, text, "ChatFont", Color(140, 0, 0, 100), Color(255, 255, 255, 255))
     cam.End3D2D()
 end


### PR DESCRIPTION
I was creating my own spawned money entity for ARCBank to make the thing cross-gamemode compatible. I decided to look at the DarkRP spawned money to see how that worked. So, I took that entity, added some stuff I did to my entity, and now I am giving back (part) of what I did to make it better!