### PR TITLE
Remove OnRemove reset in baton base

### DIFF
--- a/entities/weapons/stick_base/shared.lua
+++ b/entities/weapons/stick_base/shared.lua
@@ -105,11 +105,6 @@ function SWEP:Holster()
     return true
 end
 
-function SWEP:OnRemove()
-    BaseClass.OnRemove(self)
-    self:ResetStick(true)
-end
-
 function SWEP:Think()
     if self:GetSeqIdling() then
         self:SetSeqIdling(false)

--- a/entities/weapons/stick_base/shared.lua
+++ b/entities/weapons/stick_base/shared.lua
@@ -88,9 +88,8 @@ function SWEP:ViewModelDrawn(vm)
     vm:SetSubMaterial() -- clear sub-materials
 end
 
-function SWEP:ResetStick(force)
-    if game.SinglePlayer() then force = true end
-    if not IsValid(self:GetOwner()) or (not force and (not IsValid(self:GetOwner():GetActiveWeapon()) or self:GetOwner():GetActiveWeapon():GetClass() ~= self:GetClass())) then return end
+function SWEP:ResetStick()
+    if not IsValid(self:GetOwner()) then return end
     if SERVER then
         self:SetMaterial() -- clear material
     end
@@ -101,7 +100,7 @@ end
 
 function SWEP:Holster()
     BaseClass.Holster(self)
-    self:ResetStick(false)
+    self:ResetStick()
     return true
 end
 


### PR DESCRIPTION
There's no need to reset the materials and sequences of a weapon that is going to be removed