### PR TITLE
Customizable arrest stick range.

### DIFF
--- a/entities/weapons/arrest_stick/shared.lua
+++ b/entities/weapons/arrest_stick/shared.lua
@@ -10,6 +10,7 @@ DEFINE_BASECLASS("stick_base")
 
 SWEP.Instructions = "Left click to arrest\nRight click to switch batons"
 SWEP.IsDarkRPArrestStick = true
+SWEP.ArrestRange = 8100
 
 SWEP.Spawnable = true
 SWEP.Category = "DarkRP (Utility)"
@@ -69,7 +70,7 @@ function SWEP:PrimaryAttack()
 
     local ent = self:GetOwner():getEyeSightHitEntity(nil, nil, function(p) return p ~= self:GetOwner() and p:IsPlayer() and p:Alive() end)
 
-    if not IsValid(ent) or (self:GetOwner():EyePos():DistToSqr(ent:GetPos()) > 8100) or not ent:IsPlayer() then
+    if not IsValid(ent) or (self:GetOwner():EyePos():DistToSqr(ent:GetPos()) > self.ArrestRange) or not ent:IsPlayer() then
         return
     end
 

--- a/entities/weapons/arrest_stick/shared.lua
+++ b/entities/weapons/arrest_stick/shared.lua
@@ -10,7 +10,6 @@ DEFINE_BASECLASS("stick_base")
 
 SWEP.Instructions = "Left click to arrest\nRight click to switch batons"
 SWEP.IsDarkRPArrestStick = true
-SWEP.ArrestRange = 8100
 
 SWEP.Spawnable = true
 SWEP.Category = "DarkRP (Utility)"
@@ -49,6 +48,10 @@ DarkRP.hookStub{
     realm = "Server"
 }
 
+function SWEP:Initialize()
+    self.ArrestRange = 90
+end
+
 function SWEP:Deploy()
     self.Switched = true
     return BaseClass.Deploy(self)
@@ -70,7 +73,7 @@ function SWEP:PrimaryAttack()
 
     local ent = self:GetOwner():getEyeSightHitEntity(nil, nil, function(p) return p ~= self:GetOwner() and p:IsPlayer() and p:Alive() end)
 
-    if not IsValid(ent) or (self:GetOwner():EyePos():DistToSqr(ent:GetPos()) > self.ArrestRange) or not ent:IsPlayer() then
+    if not IsValid(ent) or (self:GetOwner():EyePos():DistToSqr(ent:GetPos()) > (self.ArrestRange * self.ArrestRange)) or not ent:IsPlayer() then
         return
     end
 
@@ -97,4 +100,12 @@ function SWEP:startDarkRPCommand(usrcmd)
     else
         self.Switched = false
     end
+end
+
+function SWEP:setArrestRange(amount)
+    self.ArrestRange = amount
+end
+
+function SWEP:getArrestRange()
+    return self.ArrestRange
 end


### PR DESCRIPTION
Allows changing the range so a developer can change how far away it can arrest from.

Useful if you want certain jobs to have a higher arrest range than others.