### PR TITLE
Added the viewmodel to PreDrawViewModel Deploy call

### DIFF
--- a/entities/weapons/stick_base/shared.lua
+++ b/entities/weapons/stick_base/shared.lua
@@ -71,7 +71,7 @@ function SWEP:Deploy()
 
     local vm = self:GetOwner():GetViewModel()
     if not IsValid(vm) then return true end
-    self:PreDrawViewModel()
+    self:PreDrawViewModel(vm)
     vm:SendViewModelMatchingSequence(vm:LookupSequence("idle01"))
     return true
 end


### PR DESCRIPTION
Does nothing otherwise. This would have been noticed if there wasn't an IsValid check in PreDrawViewModel since the viewmodel will always be valid when called by the engine, but it masked the problem with the Deploy call. Too many validity checks can be just as bad as having too little!