### PR TITLE
Don't open animation menu if animations are disabled

### DIFF
--- a/entities/weapons/keys/shared.lua
+++ b/entities/weapons/keys/shared.lua
@@ -138,7 +138,7 @@ end
 function SWEP:Reload()
     local trace = self:GetOwner():GetEyeTrace()
     if not IsValid(trace.Entity) or (IsValid(trace.Entity) and ((not trace.Entity:isDoor() and not trace.Entity:IsVehicle()) or self.Owner:EyePos():DistToSqr(trace.HitPos) > 40000)) then
-        if CLIENT then RunConsoleCommand("_DarkRP_AnimationMenu") end
+        if CLIENT and not DarkRP.disabledDefaults["modules"]["animations"] then RunConsoleCommand("_DarkRP_AnimationMenu") end
         return
     end
     if SERVER then


### PR DESCRIPTION
If the animations module has been added to DarkRP.disabledDefaults, don't call _DarkRP_AnimationMenu in the keys swep

First commit to DarkRP so please let me know if you would like it changed.

Thanks.