### PR TITLE
Fix owner/recipient targeting in cheque

### DIFF
--- a/entities/entities/darkrp_cheque/cl_init.lua
+++ b/entities/entities/darkrp_cheque/cl_init.lua
@@ -1,31 +1,31 @@
 include("shared.lua")
 
+ENT.TextColors = {
+    OtherToSelf = Color(0, 255, 0, 255),
+    SelfToSelf = Color(255, 255, 0, 255),
+    SelfToOther = Color(0, 0, 255, 255),
+    OtherToOther = Color(255, 0, 0, 255)
+}
+
 function ENT:Draw()
     self:DrawModel()
-    if not IsValid(self:Getowning_ent()) or not IsValid(self:Getrecipient()) then return end
+
+    local owner = self:Getowning_ent()
+    local recipient = self:Getrecipient()
+    local ownerplayer = owner:IsPlayer()
+    local recipientplayer = recipient:IsPlayer()
+    local localplayer = LocalPlayer()
 
     local Pos = self:GetPos()
     local Ang = self:GetAngles()
-
-    local amount = self:Getamount()
-    local owner = (IsValid(self:Getowning_ent()) and self:Getowning_ent().Name and self:Getowning_ent():Name()) or DarkRP.getPhrase("unknown")
-    local recipient = (self:Getrecipient().Name and self:Getrecipient():Name()) or DarkRP.getPhrase("unknown")
+    local Up = Ang:Up()
+    Up:Mul(0.9)
+    Pos:Add(Up)
 
     surface.SetFont("ChatFont")
-    local text = DarkRP.getPhrase("cheque_pay", recipient) .. "\n" .. DarkRP.formatMoney(amount) .. "\n" .. DarkRP.getPhrase("signed", owner)
-    local TextWidth = surface.GetTextSize(text)
+    local text = DarkRP.getPhrase("cheque_pay", recipientplayer and recipient:Nick() or DarkRP.getPhrase("unknown")) .. "\n" .. DarkRP.formatMoney(self:Getamount()) .. "\n" .. DarkRP.getPhrase("signed", ownerplayer and owner:Nick() or DarkRP.getPhrase("unknown"))
 
-    cam.Start3D2D(Pos + Ang:Up() * 0.9, Ang, 0.1)
-    if recipient == LocalPlayer():Name() and owner ~= LocalPlayer():Name() then
-        draw.DrawNonParsedText(text, "ChatFont", -TextWidth * 0.5, -25, Color(0, 255, 0, 255), 0)
-    elseif recipient == LocalPlayer():Name() and owner == LocalPlayer():Name() then
-        draw.DrawNonParsedText(text, "ChatFont", -TextWidth * 0.5, -25, Color(255, 255, 0, 255), 0)
-    elseif recipient ~= LocalPlayer():Name() and owner == LocalPlayer():Name() then
-        draw.DrawNonParsedText(text, "ChatFont", -TextWidth * 0.5, -25, Color(0, 0, 255, 255), 0)
-    elseif recipient ~= LocalPlayer():Name() and owner ~= LocalPlayer():Name() then
-        draw.DrawNonParsedText(text, "ChatFont", -TextWidth * 0.5, -25, Color(255, 0, 0, 255), 0)
-    else
-        draw.DrawNonParsedText(text, "ChatFont", -TextWidth * 0.5, -25, Color(255, 255, 255, 255), 0)
-    end
+    cam.Start3D2D(Pos, Ang, 0.1)
+        draw.DrawNonParsedText(text, "ChatFont", surface.GetTextSize(text) * -0.5, -25, localplayer:IsValid() and (ownerplayer and localplayer == owner and (recipientplayer and localplayer == recipient and self.TextColors.SelfToSelf or self.TextColors.SelfToOther) or recipientplayer and localplayer == recipient and self.TextColors.OtherToSelf) or self.TextColors.OtherToOther, 0)
     cam.End3D2D()
 end


### PR DESCRIPTION
Targeting now uses entity comparisons instead of name, which can be incorrect if two people have the same name or someone has a name equal to DarkRP.getPhrase("unknown")'s return. I also changed Name -> Nick and added the colours as an entity config.