### PR TITLE
DarkRP.removeAgenda not removing agendas from DarkRPAgendas

### DIFF
--- a/gamemode/modules/base/sh_createitems.lua
+++ b/gamemode/modules/base/sh_createitems.lua
@@ -684,7 +684,7 @@ function DarkRP.removeAgenda(title)
     end
 
     for k, v in pairs(DarkRPAgendas) do
-        if v.Title == title then agendas[k] = nil end
+        if v.Title == title then DarkRPAgendas[k] = nil end
     end
     hook.Run("onAgendaRemoved", title, agenda)
 end


### PR DESCRIPTION
The typo meant that agendas were not properly removed from the `DarkRPAgendas` table but were removed from the local `agendas` table.
  