### PR TITLE
Added "everyone" option to adminweapons config

### DIFF
--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -179,7 +179,7 @@ GM.Config.adminnpcs                     = 3
 GM.Config.adminsents                    = 1
 -- adminvehicles - Whether or not vehicles should be admin only. 0 = everyone, 1 = admin or higher, 2 = superadmin or higher, 3 = rcon only
 GM.Config.adminvehicles                 = 3
--- adminweapons - Who can spawn weapons: 0: admins only, 1: supadmins only, 2: no one
+-- adminweapons - Who can spawn weapons: 0: admins only, 1: supadmins only, 2: no one, 3: everyone
 GM.Config.adminweapons                  = 1
 -- arrestspeed - Sets the max arrest speed.
 GM.Config.arrestspeed                   = 120

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -167,7 +167,9 @@ end
 
 local function canSpawnWeapon(ply)
     if (GAMEMODE.Config.adminweapons == 0 and ply:IsAdmin()) or
-    (GAMEMODE.Config.adminweapons == 1 and ply:IsSuperAdmin()) then
+    (GAMEMODE.Config.adminweapons == 1 and ply:IsSuperAdmin()) or
+    -- Can't use 2 to maintain compatibility
+    (GAMEMODE.Config.adminweapons == 3) then
         return true
     end
     DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("cant_spawn_weapons"))


### PR DESCRIPTION
Would be better to work those options into CAPI so server owners can select specific groups, but this at least adds an option to remain consistent with adminsents and adminvehicles.