### PR TITLE
Fixed changeTeam not giving a descriptive message.

### DIFF
--- a/gamemode/modules/jobs/sv_jobs.lua
+++ b/gamemode/modules/jobs/sv_jobs.lua
@@ -60,7 +60,7 @@ function meta:changeTeam(t, force, suppressNotification)
             for a, b in pairs(TEAM.NeedToChangeFrom) do
                 teamnames = teamnames .. " or " .. team.GetName(b)
             end
-            notify(self, 1,4, string.format(string.sub(teamnames, 5), team.GetName(TEAM.NeedToChangeFrom), TEAM.name))
+            notify(self, 1, 8, DarkRP.getPhrase("need_to_be_before", string.sub(teamnames, 5), TEAM.name))
             return false
         end
         local max = TEAM.max


### PR DESCRIPTION
It used to simply say "TEAM NAME or TEAM NAME" or even, if you only had one job in the table just "TEAM NAME".

Now it's "You need to be TEAM 1 or TEAM 2 first in order to be able to become WANTED NAME", I also increased the time as 4 seconds might not be enough if the table is big. Unsure how it'd behave with tables with many entires or long job names.