### PR TITLE
freeze AFK players salary

### DIFF
--- a/gamemode/modules/afk/sv_afk.lua
+++ b/gamemode/modules/afk/sv_afk.lua
@@ -99,6 +99,7 @@ local function BlockAFKTeamChange(ply, t, force)
 end
 hook.Add("playerCanChangeTeam", "AFKCanChangeTeam", BlockAFKTeamChange)
 
+-- Freeze AFK player's salary
 hook.Add("playerGetSalary", "AFKGetSalary", function(ply, amount)
     if ply:getDarkRPVar("AFK") then
         return true, "", 0

--- a/gamemode/modules/afk/sv_afk.lua
+++ b/gamemode/modules/afk/sv_afk.lua
@@ -99,10 +99,9 @@ local function BlockAFKTeamChange(ply, t, force)
 end
 hook.Add("playerCanChangeTeam", "AFKCanChangeTeam", BlockAFKTeamChange)
 
--- Freeze player's salary
 hook.Add("playerGetSalary", "AFKGetSalary", function(ply, amount)
     if ply:getDarkRPVar("AFK") then
-        return true, "", 0 -- false, DarkRP.getPhrase("salary_frozen"), 0
+        return true, "", 0
     end
 end)
 

--- a/gamemode/modules/afk/sv_afk.lua
+++ b/gamemode/modules/afk/sv_afk.lua
@@ -99,6 +99,13 @@ local function BlockAFKTeamChange(ply, t, force)
 end
 hook.Add("playerCanChangeTeam", "AFKCanChangeTeam", BlockAFKTeamChange)
 
+-- Freeze player's salary
+hook.Add("playerGetSalary", "AFKGetSalary", function(ply, amount)
+    if ply:getDarkRPVar("AFK") then
+        return true, "", 0 -- false, DarkRP.getPhrase("salary_frozen"), 0
+    end
+end)
+
 -- For when a player's team is changed by force
 hook.Add("OnPlayerChangedTeam", "AFKCanChangeTeam", function(ply)
     if not ply:getDarkRPVar("AFK") then return end


### PR DESCRIPTION
While it's shown to AFK players that their salary is frozen, it is not actually; only the darkrpvar is set to 0 and the function Player:payDay() isn't using that variable.