### PR TITLE
Dist check in keys in keys code isn't good

### DIFF
--- a/entities/weapons/keys/cl_menu.lua
+++ b/entities/weapons/keys/cl_menu.lua
@@ -43,10 +43,10 @@ local KeyFrameVisible = false
 
 local function openMenu(setDoorOwnerAccess, doorSettingsAccess)
     if KeyFrameVisible then return end
-
-    local ent = LocalPlayer():GetEyeTrace().Entity
+    local trace = LocalPlayer():GetEyeTrace()
+    local ent = trace.Entity
     -- Don't open the menu if the entity is not ownable, the entity is too far away or the door settings are not loaded yet
-    if not IsValid(ent) or not ent:isKeysOwnable() or ent:GetPos():DistToSqr(LocalPlayer():GetPos()) > 40000 then return end
+    if not IsValid(ent) or not ent:isKeysOwnable() or trace.HitPos:DistToSqr(LocalPlayer():EyePos()) > 40000 then return end
 
     KeyFrameVisible = true
     local Frame = vgui.Create("DFrame")
@@ -58,8 +58,9 @@ local function openMenu(setDoorOwnerAccess, doorSettingsAccess)
     Frame:ParentToHUD()
 
     function Frame:Think()
-        local LAEnt = LocalPlayer():GetEyeTrace().Entity
-        if not IsValid(LAEnt) or not LAEnt:isKeysOwnable() or LAEnt:GetPos():DistToSqr(LocalPlayer():GetPos()) > 40000 then
+        local trace = LocalPlayer():GetEyeTrace()
+        local LAEnt = trace.Entity
+        if not IsValid(LAEnt) or not LAEnt:isKeysOwnable() or trace.HitPos:DistToSqr(LocalPlayer():EyePos()) > 40000 then
             self:Close()
         end
         if not self.Dragging then return end

--- a/entities/weapons/keys/shared.lua
+++ b/entities/weapons/keys/shared.lua
@@ -136,7 +136,7 @@ end
 
 function SWEP:Reload()
     local trace = self:GetOwner():GetEyeTrace()
-    if not IsValid(trace.Entity) or ((not trace.Entity:isDoor() and not trace.Entity:IsVehicle()) or self.Owner:EyePos():DistToSqr(trace.HitPos) > 40000)) then
+    if not IsValid(trace.Entity) or ((not trace.Entity:isDoor() and not trace.Entity:IsVehicle()) or self.Owner:EyePos():DistToSqr(trace.HitPos) > 40000) then
         if CLIENT and not DarkRP.disabledDefaults["modules"]["animations"] then RunConsoleCommand("_DarkRP_AnimationMenu") end
         return
     end

--- a/entities/weapons/keys/shared.lua
+++ b/entities/weapons/keys/shared.lua
@@ -60,16 +60,15 @@ function SWEP:PreDrawViewModel()
     return true
 end
 
-local function lookingAtLockable(ply, ent)
+local function lookingAtLockable(ply, ent, hitpos)
     local eyepos = ply:EyePos()
     return IsValid(ent)             and
         ent:isKeysOwnable()         and
         (
-            ent:isDoor()    and eyepos:DistToSqr(ent:GetPos()) < 4225
+            ent:isDoor()    and eyepos:DistToSqr(hitpos) < 2000
             or
-            ent:IsVehicle() and eyepos:DistToSqr(ent:NearestPoint(eyepos)) < 10000
+            ent:IsVehicle() and eyepos:DistToSqr(hitpos) < 4000
         )
-
 end
 
 local function lockUnlockAnimation(ply, snd)
@@ -100,7 +99,7 @@ end
 function SWEP:PrimaryAttack()
     local trace = self:GetOwner():GetEyeTrace()
 
-    if not lookingAtLockable(self:GetOwner(), trace.Entity) then return end
+    if not lookingAtLockable(self:GetOwner(), trace.Entity, trace.HitPos) then return end
 
     self:SetNextPrimaryFire(CurTime() + 0.3)
 
@@ -119,7 +118,7 @@ end
 function SWEP:SecondaryAttack()
     local trace = self:GetOwner():GetEyeTrace()
 
-    if not lookingAtLockable(self:GetOwner(), trace.Entity) then return end
+    if not lookingAtLockable(self:GetOwner(), trace.Entity, trace.HitPos) then return end
 
     self:SetNextSecondaryFire(CurTime() + 0.3)
 
@@ -137,7 +136,7 @@ end
 
 function SWEP:Reload()
     local trace = self:GetOwner():GetEyeTrace()
-    if not IsValid(trace.Entity) or (((not trace.Entity:isDoor() and not trace.Entity:IsVehicle()) or self.Owner:EyePos():DistToSqr(trace.HitPos) > 40000)) then
+    if not IsValid(trace.Entity) or ((not trace.Entity:isDoor() and not trace.Entity:IsVehicle()) or self.Owner:EyePos():DistToSqr(trace.HitPos) > 40000)) then
         if CLIENT and not DarkRP.disabledDefaults["modules"]["animations"] then RunConsoleCommand("_DarkRP_AnimationMenu") end
         return
     end


### PR DESCRIPTION
When using the keys on a door (func_door) and if it's origin point of the entity or far from the entity itself, , you won't be able to use the keys on it, fix it by doing a trace.


Example, if a door is 1km wide, you will not be able to use the door anywhere near it but only at the place near the origin point


Video showing the door being far from it's origin point : https://www.youtube.com/watch?v=bp7OlidbMq0&feature=youtu.be