### PR TITLE
use player to emit sound

### DIFF
--- a/entities/weapons/lockpick/shared.lua
+++ b/entities/weapons/lockpick/shared.lua
@@ -159,7 +159,7 @@ function SWEP:Think()
     if CurTime() >= self:GetNextSoundTime() then
         self:SetNextSoundTime(CurTime() + 1)
         local snd = {1,3,4}
-        self:EmitSound("weapons/357/357_reload" .. tostring(snd[math.Round(util.SharedRandom("DarkRP_LockpickSnd" .. CurTime(), 1, #snd))]) .. ".wav", 50, 100)
+        self:GetOwner():EmitSound("weapons/357/357_reload" .. tostring(snd[math.Round(util.SharedRandom("DarkRP_LockpickSnd" .. CurTime(), 1, #snd))]) .. ".wav", 50, 100)
     end
     if CLIENT and (not self.NextDotsTime or SysTime() >= self.NextDotsTime) then
         self.NextDotsTime = SysTime() + 0.5

--- a/entities/weapons/med_kit/shared.lua
+++ b/entities/weapons/med_kit/shared.lua
@@ -62,7 +62,7 @@ function SWEP:PrimaryAttack()
 
     if found then
         found:SetHealth(found:Health() + 1)
-        self:EmitSound("hl1/fvox/boop.wav", 150, found:Health() / found:GetMaxHealth() * 100, 1, CHAN_AUTO)
+        self:GetOwner():EmitSound("hl1/fvox/boop.wav", 150, found:Health() / found:GetMaxHealth() * 100, 1, CHAN_AUTO)
     end
 end
 
@@ -72,6 +72,6 @@ function SWEP:SecondaryAttack()
     local maxhealth = self:GetOwner():GetMaxHealth() or 100
     if ply:Health() < maxhealth then
         ply:SetHealth(ply:Health() + 1)
-        self:EmitSound("hl1/fvox/boop.wav", 150, ply:Health() / ply:GetMaxHealth() * 100, 1, CHAN_AUTO)
+        self:GetOwner():EmitSound("hl1/fvox/boop.wav", 150, ply:Health() / ply:GetMaxHealth() * 100, 1, CHAN_AUTO)
     end
 end

--- a/entities/weapons/stick_base/shared.lua
+++ b/entities/weapons/stick_base/shared.lua
@@ -121,7 +121,7 @@ function SWEP:Think()
 
         if not IsValid(self:GetOwner()) then return end
         self:GetOwner():SetAnimation(PLAYER_ATTACK1)
-        self:EmitSound(self.Sound)
+        self:GetOwner():EmitSound(self.Sound)
 
         local vm = self:GetOwner():GetViewModel()
         if not IsValid(vm) then return end

--- a/entities/weapons/stunstick/shared.lua
+++ b/entities/weapons/stunstick/shared.lua
@@ -179,5 +179,5 @@ function SWEP:Reload()
 
     if self:GetLastReload() + 0.1 > CurTime() then self:SetLastReload(CurTime()) return end
     self:SetLastReload(CurTime())
-    self:EmitSound("weapons/stunstick/spark" .. math.random(1, 3) .. ".wav")
+    self:GetOwner():EmitSound("weapons/stunstick/spark" .. math.random(1, 3) .. ".wav")
 end

--- a/entities/weapons/weapon_cs_base2/shared.lua
+++ b/entities/weapons/weapon_cs_base2/shared.lua
@@ -180,7 +180,7 @@ function SWEP:PrimaryAttack()
     self:SetNextSecondaryFire(CurTime() + self.Primary.Delay)
 
     if self:Clip1() <= 0 then
-        self:EmitSound("weapons/clipempty_rifle.wav")
+        self:GetOwner():EmitSound("weapons/clipempty_rifle.wav")
         self:SetNextPrimaryFire(CurTime() + 2)
         return
     end
@@ -188,7 +188,7 @@ function SWEP:PrimaryAttack()
     if not self:CanPrimaryAttack() then self:SetIronsights(false) return end
     if not self:GetIronsights() and GAMEMODE.Config.ironshoot then return end
     -- Play shoot sound
-    self:EmitSound(self.Primary.Sound)
+    self:GetOwner():EmitSound(self.Primary.Sound)
 
     -- Shoot the bullet
     self:CSShootBullet(self.Primary.Damage, self.Primary.Recoil + 3, self.Primary.NumShots, self.Primary.Cone + .05)

--- a/entities/weapons/weaponchecker/shared.lua
+++ b/entities/weapons/weaponchecker/shared.lua
@@ -157,7 +157,7 @@ function SWEP:PrimaryAttack()
         return
     end
 
-    self:EmitSound("npc/combine_soldier/gear5.wav", 50, 100)
+    self:GetOwner():EmitSound("npc/combine_soldier/gear5.wav", 50, 100)
     self:SetNextSoundTime(CurTime() + 0.3)
 
     if not IsFirstTimePredicted() then return end
@@ -281,10 +281,10 @@ function SWEP:Succeed()
     hook.Call("playerWeaponsConfiscated", nil, self:GetOwner(), ent, ent.ConfiscatedWeapons)
 
     if next(stripped) ~= nil then
-        self:EmitSound("npc/combine_soldier/gear5.wav", 50, 100)
+        self:GetOwner():EmitSound("npc/combine_soldier/gear5.wav", 50, 100)
         self:SetNextSoundTime(CurTime() + 0.3)
     else
-        self:EmitSound("ambient/energy/zap1.wav", 50, 100)
+        self:GetOwner():EmitSound("ambient/energy/zap1.wav", 50, 100)
         self:SetNextSoundTime(0)
     end
 end
@@ -339,10 +339,10 @@ function SWEP:Think()
     if self:GetNextSoundTime() ~= 0 and CurTime() >= self:GetNextSoundTime() then
         if self:GetIsWeaponChecking() then
             self:SetNextSoundTime(CurTime() + 0.5)
-            self:EmitSound("npc/combine_soldier/gear5.wav", 100, 100)
+            self:GetOwner():EmitSound("npc/combine_soldier/gear5.wav", 100, 100)
         else
             self:SetNextSoundTime(0)
-            self:EmitSound("npc/combine_soldier/gear5.wav", 50, 100)
+            self:GetOwner():EmitSound("npc/combine_soldier/gear5.wav", 50, 100)
         end
     end
     if CLIENT and self.NextDotsTime and CurTime() >= self.NextDotsTime then


### PR DESCRIPTION
The flashlight sound can mute/remove the sound played on weapons for some reason (presumably because of the one sound object per entity restriction). It's not doing it on the player itself, so we call sounds from the player from now on.

btw. in a lot of places, it already uses the player to emit sounds but in some functions not.