### PR TITLE
Changed direct datatable usage to methods

### DIFF
--- a/entities/entities/darkrp_cheque/init.lua
+++ b/entities/entities/darkrp_cheque/init.lua
@@ -51,8 +51,8 @@ end
 function ENT:StartTouch(ent)
     -- the .USED var is also used in other mods for the same purpose
     if ent:GetClass() ~= "darkrp_cheque" or self.USED or ent.USED or self.hasMerged or ent.hasMerged then return end
-    if ent.dt.owning_ent ~= self.dt.owning_ent then return end
-    if ent.dt.recipient ~= self.dt.recipient then return end
+    if ent:Getowning_ent() ~= self:Getowning_ent() then return end
+    if ent:Getrecipient() ~= self:Getrecipient() then return end
 
     -- Both hasMerged and USED are used by third party mods. Keep both in.
     ent.USED = true
@@ -74,7 +74,7 @@ function ENT:OnTakeDamage(dmg)
 end
 
 function ENT:onPlayerDisconnected(ply)
-    if self.dt.owning_ent == ply or self.dt.recipient == ply then
+    if self:Getowning_ent() == ply or self:Getrecipient() == ply then
         self:Remove()
     end
 end

--- a/entities/entities/letter/init.lua
+++ b/entities/entities/letter/init.lua
@@ -57,7 +57,7 @@ function ENT:SignLetter(ply)
 end
 
 function ENT:onPlayerDisconnected(ply)
-    if self.dt.owning_ent == ply then
+    if self:Getowning_ent() == ply then
         self:Remove()
     end
 end

--- a/entities/entities/spawned_shipment/commands.lua
+++ b/entities/entities/spawned_shipment/commands.lua
@@ -38,7 +38,7 @@ local function createShipment(ply, args)
     crate.SID = ply.SID
     crate:SetPos(ent:GetPos())
     crate.nodupe = true
-    crate:SetContents(shipID, ent.dt.amount)
+    crate:SetContents(shipID, ent:Getamount())
     crate:Spawn()
     crate:SetPlayer(ply)
     crate.clip1 = ent.clip1

--- a/entities/entities/spawned_shipment/init.lua
+++ b/entities/entities/spawned_shipment/init.lua
@@ -179,7 +179,7 @@ function ENT:Destruct()
     weapon.clip2 = self.clip2
     weapon.nodupe = true
     weapon:Spawn()
-    weapon.dt.amount = count
+    weapon:Setamount(count)
 
     self:Remove()
 end

--- a/entities/entities/spawned_weapon/cl_init.lua
+++ b/entities/entities/spawned_weapon/cl_init.lua
@@ -5,7 +5,7 @@ function ENT:Draw()
     if ret ~= nil then return end
     self:DrawModel()
 
-	local amount = self:Getamount()
+    local amount = self:Getamount()
     if amount == 1 then return end
 
     local Pos = self:GetPos()

--- a/entities/entities/spawned_weapon/cl_init.lua
+++ b/entities/entities/spawned_weapon/cl_init.lua
@@ -5,11 +5,12 @@ function ENT:Draw()
     if ret ~= nil then return end
     self:DrawModel()
 
-    if self.dt.amount == 1 then return end
+	local amount = self:Getamount()
+    if amount == 1 then return end
 
     local Pos = self:GetPos()
     local Ang = self:GetAngles()
-    local text = DarkRP.getPhrase("amount") .. self.dt.amount
+    local text = DarkRP.getPhrase("amount") .. amount
 
     surface.SetFont("HUDNumber5")
     local TextWidth = surface.GetTextSize(text)

--- a/entities/entities/spawned_weapon/init.lua
+++ b/entities/entities/spawned_weapon/init.lua
@@ -24,11 +24,10 @@ function ENT:Initialize()
 end
 
 function ENT:DecreaseAmount()
-    local amount = self.dt.amount
+    local amount = self:Getamount() - 1
+    self:Setamount(amount)
 
-    self.dt.amount = amount - 1
-
-    if self.dt.amount <= 0 then
+    if amount <= 0 then
         self:Remove()
         self.PlayerUse = false
         self.Removed = true -- because it is not removed immediately

--- a/entities/weapons/door_ram/shared.lua
+++ b/entities/weapons/door_ram/shared.lua
@@ -53,7 +53,7 @@ function SWEP:Initialize()
 end
 
 function SWEP:Holster()
-    self.dt.Ironsights = false
+    self:SetIronsights(false)
 
     return true
 end

--- a/entities/weapons/weapon_cs_base2/shared.lua
+++ b/entities/weapons/weapon_cs_base2/shared.lua
@@ -79,9 +79,9 @@ function SWEP:Initialize()
         self:SetNPCFireRate(0.01)
     end
 
-    self.dt.Ironsights = false
-    self.dt.TotalUsedMagCount = 0
-    self.dt.FireMode = self.Primary.Automatic and "auto" or "semi"
+    self:SetIronsights(false)
+    self:SetTotalUsedMagCount(0)
+    self:SetFireMode(self.Primary.Automatic and "auto" or "semi")
 end
 
 function SWEP:SetupDataTables()
@@ -111,7 +111,7 @@ function SWEP:OwnerChanged()
 end
 
 function SWEP:Holster()
-    self.dt.Ironsights = false
+    self:SetIronsights(false)
     if CLIENT then self.hasShot = false end
 
     if not IsValid(self:GetOwner()) then return true end
@@ -124,7 +124,7 @@ function SWEP:Holster()
 end
 
 function SWEP:OnRemove()
-    self.dt.Ironsights = false
+    self:SetIronsights(false)
 
     if CLIENT and IsValid(self:GetOwner()) then
         local vm = self:GetOwner():GetViewModel()
@@ -375,7 +375,7 @@ end
 
 function SWEP:OnRestore()
     self:SetNextSecondaryFire(0)
-    self.dt.Ironsights = false
+    self:SetIronsights(false)
 end
 
 function SWEP:OnDrop()

--- a/gamemode/modules/base/sh_createitems.lua
+++ b/gamemode/modules/base/sh_createitems.lua
@@ -297,8 +297,6 @@ local function addEntityCommands(tblEnt)
     local function defaultSpawn(ply, tr, tblE)
         local ent = ents.Create(tblE.ent)
         if not ent:IsValid() then error("Entity '" .. tblE.ent .. "' does not exist or is not valid.") end
-        ent.dt = ent.dt or {}
-        ent.dt.owning_ent = ply
         if ent.Setowning_ent then ent:Setowning_ent(ply) end
         ent:SetPos(tr.HitPos)
         -- These must be set before :Spawn()


### PR DESCRIPTION
Using self.dt to set datatable variables instead of the provided NetworkVar functions is undocumented behaviour. It also unnecessarily forces replacement entities mimicking the API of stock DarkRP entities to use NetworkVars for networking implementation.