### PR TITLE
Updated door system

### DIFF
--- a/gamemode/modules/doorsystem/cl_doors.lua
+++ b/gamemode/modules/doorsystem/cl_doors.lua
@@ -4,14 +4,15 @@ local white = Color(255, 255, 255, 200)
 local red = Color(128, 30, 30, 255)
 
 function meta:drawOwnableInfo()
-    if LocalPlayer():InVehicle() then return end
+    local ply = LocalPlayer()
+    if ply:InVehicle() then return end
 
     -- Look, if you want to change the way door ownership is drawn, don't edit this file, use the hook instead!
     local doorDrawing = hook.Call("HUDDrawDoorData", nil, self)
     if doorDrawing == true then return end
 
     local blocked = self:getKeysNonOwnable()
-    local superadmin = LocalPlayer():IsSuperAdmin()
+    local superadmin = ply:IsSuperAdmin()
     local doorTeams = self:getKeysDoorTeams()
     local doorGroup = self:getKeysDoorGroup()
     local playerOwned = self:isKeysOwned() or table.GetFirstValue(self:getKeysCoOwners() or {}) ~= nil

--- a/gamemode/modules/doorsystem/sv_doors.lua
+++ b/gamemode/modules/doorsystem/sv_doors.lua
@@ -83,16 +83,11 @@ function meta:keysOwn(ply)
     ply.Ownedz[self:EntIndex()] = self
 end
 
-function meta:keysUnOwn(ply, tax)
+function meta:keysUnOwn(ply)
     if not ply then
         ply = self:getDoorOwner()
 
         if not IsValid(ply) then return end
-    end
-
-    if tax then
-        local isAllowed = hook.Call("canTaxRemove", nil, ply, self)
-        if isAllowed == false then return end
     end
 
     if self:isMasterOwner(ply) then
@@ -115,8 +110,12 @@ function pmeta:keysUnOwnAll(tax)
     if self.Ownedz then
         for k, v in pairs(self.Ownedz) do
             if not v:isKeysOwnable() then self.Ownedz[k] = nil continue end
+            if tax then
+                local isAllowed = hook.Call("canTaxUnOwn", nil, self, v)
+                if isAllowed == false then return end
+            end
             v:Fire("unlock", "", 0.6)
-            v:keysUnOwn(self, tax)
+            v:keysUnOwn(self)
             count = count + 1
         end
     end

--- a/gamemode/modules/doorsystem/sv_doors.lua
+++ b/gamemode/modules/doorsystem/sv_doors.lua
@@ -91,7 +91,7 @@ function meta:keysUnOwn(ply, tax)
     end
 
     if tax then
-        local isAllowed = hook.Call("canTaxRemove", nil, ply, self, tax)
+        local isAllowed = hook.Call("canTaxRemove", nil, ply, self)
         if isAllowed == false then return end
     end
 

--- a/gamemode/modules/doorsystem/sv_doors.lua
+++ b/gamemode/modules/doorsystem/sv_doors.lua
@@ -46,7 +46,7 @@ function meta:keysOwn(ply)
         return
     end
 
-    local isAllowed = hook.Call("canOwn" .. (self:IsVehicle() and "Vehicle" or "Door"), GAMEMODE, ply, self)
+    local isAllowed = hook.Call("canOwn" .. (self:IsVehicle() and "Vehicle" or "Door"), nil, ply, self)
     if isAllowed == false then return end
 
     local Owner = self:CPPIGetOwner()
@@ -94,7 +94,7 @@ function meta:keysUnOwn(ply, tax)
         if not IsValid(ply) then return end
     end
 
-    local isAllowed = hook.Call("canUnOwn" .. (self:IsVehicle() and "Vehicle" or "Door"), GAMEMODE, ply, self, tax)
+    local isAllowed = hook.Call("canUnOwn" .. (self:IsVehicle() and "Vehicle" or "Door"), nil, ply, self, tax)
     if isAllowed == false then return end
 
     if self:isMasterOwner(ply) then
@@ -147,7 +147,7 @@ function pmeta:doPropertyTax()
     local price = 10
     local tax = price * numowned + math.random(-5, 5)
 
-    local shouldTax, taxOverride = hook.Call("canPropertyTax", GAMEMODE, self, tax)
+    local shouldTax, taxOverride = hook.Call("canPropertyTax", nil, self, tax)
 
     if shouldTax == false then return end
 
@@ -166,7 +166,7 @@ function pmeta:doPropertyTax()
         end
     end
 
-    hook.Call("onPropertyTax", GAMEMODE, self, tax, canAfford)
+    hook.Call("onPropertyTax", nil, self, tax, canAfford)
 end
 
 function pmeta:initiateTax()
@@ -195,7 +195,7 @@ function pmeta:initiateTax()
 
         local taxAmount = tax * money
 
-        local shouldTax, amount = hook.Call("canTax", GAMEMODE, self, taxAmount)
+        local shouldTax, amount = hook.Call("canTax", nil, self, taxAmount)
 
         if shouldTax == false then return end
 

--- a/gamemode/modules/doorsystem/sv_doors.lua
+++ b/gamemode/modules/doorsystem/sv_doors.lua
@@ -408,7 +408,7 @@ local function UnOwnAll(ply, cmd, args)
     if ply.Ownedz then
         for k, v in pairs(ply.Ownedz) do
             if not v:isKeysOwnable() then ply.Ownedz[k] = nil continue end
-            local bAllowed, strReason = hook.Call("playerSell" .. (ent:IsVehicle() and "Vehicle" or "Door"), GAMEMODE, ply, ent)
+            local bAllowed, strReason = hook.Call("playerSell" .. (v:IsVehicle() and "Vehicle" or "Door"), GAMEMODE, ply, v)
 
             if bAllowed == false then
                 if strReason and strReason ~= "" then

--- a/gamemode/modules/doorsystem/sv_doors.lua
+++ b/gamemode/modules/doorsystem/sv_doors.lua
@@ -91,7 +91,7 @@ function meta:keysUnOwn(ply, tax)
     end
 
     if tax then
-        local isAllowed = hook.Call("canTaxRemove" .. (self:IsVehicle() and "Vehicle" or "Door"), nil, ply, self, tax)
+        local isAllowed = hook.Call("canTaxRemove", nil, ply, self, tax)
         if isAllowed == false then return end
     end
 

--- a/gamemode/modules/doorsystem/sv_doors.lua
+++ b/gamemode/modules/doorsystem/sv_doors.lua
@@ -104,7 +104,7 @@ function meta:keysUnOwn(ply)
     ply.OwnedNumz = math.Clamp((ply.OwnedNumz or 1) - 1, 0, math.huge)
 end
 
-function pmeta:keysUnOwnAll(tax)
+function pmeta:keysUnOwnAll()
     if self.Ownedz then
         for k, v in pairs(self.Ownedz) do
             if not v:isKeysOwnable() then self.Ownedz[k] = nil continue end
@@ -124,31 +124,31 @@ function pmeta:keysUnOwnAll(tax)
     self.OwnedNumz = 0
 end
 
-local function taxesUnOwnAll(self)
-    local count = 0
+local function taxesUnOwnAll(ply)
+    local sold = false
 
-    if self.Ownedz then
-        for k, v in pairs(self.Ownedz) do
-            if not v:isKeysOwnable() then self.Ownedz[k] = nil continue end
-            local isAllowed = hook.Call("canTaxUnOwn", nil, self, v)
-            if isAllowed == false then return end
+    if ply.Ownedz then
+        for k, v in pairs(ply.Ownedz) do
+            if not v:isKeysOwnable() then ply.Ownedz[k] = nil continue end
+            local isAllowed = hook.Call("canTaxEntity", nil, ply, v)
+            if isAllowed == false then continue end
             v:Fire("unlock", "", 0.6)
-            v:keysUnOwn(self)
-            count = count + 1
+            v:keysUnOwn(ply)
+            sold = true
         end
     end
 
     for _, v in ipairs(player.GetAll()) do
         for _, m in pairs(v.Ownedz or {}) do
-            if IsValid(m) and m:isKeysAllowedToOwn(self) then
-                m:removeKeysAllowedToOwn(self)
+            if IsValid(m) and m:isKeysAllowedToOwn(ply) then
+                m:removeKeysAllowedToOwn(ply)
             end
         end
     end
 
-    self.OwnedNumz = 0
+    ply.OwnedNumz = 0
 
-    return count > 0 and true or false
+    return sold
 end
 
 function pmeta:doPropertyTax()

--- a/gamemode/modules/doorsystem/sv_doors.lua
+++ b/gamemode/modules/doorsystem/sv_doors.lua
@@ -112,11 +112,14 @@ function meta:keysUnOwn(ply, tax)
 end
 
 function pmeta:keysUnOwnAll(tax)
+    local count = 0
+
     if self.Ownedz then
         for k, v in pairs(self.Ownedz) do
             if not v:isKeysOwnable() then self.Ownedz[k] = nil continue end
             v:Fire("unlock", "", 0.6)
             v:keysUnOwn(self, tax)
+            count = count + 1
         end
     end
 
@@ -129,6 +132,8 @@ function pmeta:keysUnOwnAll(tax)
     end
 
     self.OwnedNumz = 0
+
+    return count > 0 and true or false
 end
 
 function pmeta:doPropertyTax()
@@ -156,8 +161,9 @@ function pmeta:doPropertyTax()
             DarkRP.notify(self, 0, 5, DarkRP.getPhrase("property_tax", DarkRP.formatMoney(tax)))
         end
     else
-        DarkRP.notify(self, 1, 8, DarkRP.getPhrase("property_tax_cant_afford"))
-        self:keysUnOwnAll()
+        if self:keysUnOwnAll(true) then
+            DarkRP.notify(self, 1, 8, DarkRP.getPhrase("property_tax_cant_afford"))
+        end
     end
 
     hook.Call("onPropertyTax", GAMEMODE, self, tax, canAfford)

--- a/gamemode/modules/doorsystem/sv_doors.lua
+++ b/gamemode/modules/doorsystem/sv_doors.lua
@@ -46,9 +46,6 @@ function meta:keysOwn(ply)
         return
     end
 
-    local isAllowed = hook.Call("canOwn" .. (self:IsVehicle() and "Vehicle" or "Door"), nil, ply, self)
-    if isAllowed == false then return end
-
     local Owner = self:CPPIGetOwner()
 
     -- Increase vehicle count
@@ -83,7 +80,6 @@ function meta:keysOwn(ply)
     end
 
     ply.OwnedNumz = ply.OwnedNumz + 1
-
     ply.Ownedz[self:EntIndex()] = self
 end
 
@@ -94,8 +90,10 @@ function meta:keysUnOwn(ply, tax)
         if not IsValid(ply) then return end
     end
 
-    local isAllowed = hook.Call("canUnOwn" .. (self:IsVehicle() and "Vehicle" or "Door"), nil, ply, self, tax)
-    if isAllowed == false then return end
+    if tax then
+        local isAllowed = hook.Call("canTaxRemove" .. (self:IsVehicle() and "Vehicle" or "Door"), nil, ply, self, tax)
+        if isAllowed == false then return end
+    end
 
     if self:isMasterOwner(ply) then
         local doorData = self:getDoorData()


### PR DESCRIPTION
+ 1 new hook

* Redid unownalldoors command and removed unnecessary ents.GetAll call and made it work with hooks used by the regular door selling.
(note: this function was disgusting regarding performance)

* Removed unnecessary ents.GetAll call in keysUnOwnAll. It's only used to unlock doors which the other loop can also do.

* Use hook.Call instead of hook.Run because they are gamemode hooks.

* Code cleanup

* Suppress tax message when not unowning anything

Hope you like it <333