### PR TITLE
Tax system: hook taxableEntities to decide which entities are taxable

### DIFF
--- a/gamemode/modules/doorsystem/sv_interface.lua
+++ b/gamemode/modules/doorsystem/sv_interface.lua
@@ -803,6 +803,30 @@ DarkRP.hookStub{
 }
 
 DarkRP.hookStub{
+    name = "taxableEntities",
+    description = "With this hook you can decide which entities are to be taxed.",
+    parameters = {
+        {
+            name = "ply",
+            description = "The player whose property will be taxed.",
+            type = "Player"
+        },
+        {
+            name = "taxables",
+            description = "Table holding entities that will be taxed as keys and 'true' as value. NOTE: Your function may be called different times with different values. Try to use this table to come to your answer. To remove something, please remove entities from the table (as opposed to setting them to 'false')",
+            type = "table"
+        }
+    },
+    returns = {
+        {
+            name = "taxables",
+            description = "Table holding entities that will be taxed as keys and 'true' as value.",
+            type = "table"
+        },
+    }
+}
+
+DarkRP.hookStub{
     name = "onPropertyTax",
     description = "Called right AFTER a player's property is taxed. Please use canPropertyTax if you want to influence the taxing process.",
     parameters = {


### PR DESCRIPTION
Alternative implementation for #2808

The behaviour @mcNuggets1 desires would be implemented as follows:

```lua
hook.Add("taxableEntities", "no vehicles", function(ply, taxables)
    for k, _ in pairs(taxables) do
        if k:IsVehicle() then
            taxables[k] = nil
        end
    end

    return taxables
end)
```

Admittedly the fixpoint algorithm is way overkill. It allows one hook listener to modify the output of other hook listeners. So if listener A removes vehicles from the list, and listener B adds all entities spawned by the player to the list (for some reason), the end result will be all entities spawned by the player except for vehicles. Even if listener B runs after listener A. That's pretty cool, huh?

@mcNuggets1 @Bo98 Other than having overengineered this, what do you think?