### PR TITLE
Fixed the failure to demote a player from his weapons license.

### DIFF
--- a/gamemode/modules/police/sv_commands.lua
+++ b/gamemode/modules/police/sv_commands.lua
@@ -352,7 +352,7 @@ end
 DarkRP.definePrivilegedChatCommand("unsetlicense", "DarkRP_SetLicense", rp_RevokeLicense)
 
 local function FinishRevokeLicense(vote, win)
-    if choice == 1 then
+    if win == 1 then
         vote.target:setDarkRPVar("HasGunlicense", nil)
         vote.target:StripWeapons()
         gamemode.Call("PlayerLoadout", vote.target)


### PR DESCRIPTION
The function now checks an existing variable "win" and no longer a variable "choice" that made the vote always negative.