### PR TITLE
Fixed database migration error if a job no longer existed

### DIFF
--- a/gamemode/modules/base/sv_data.lua
+++ b/gamemode/modules/base/sv_data.lua
@@ -225,7 +225,7 @@ function migrateDB(callback)
             ]])
 
             for i, row in pairs(oldData) do
-                local teamcmd = RPExtraTeams[tonumber(row.team)].command
+                local teamcmd = (RPExtraTeams[tonumber(row.team)] or {}).command
                 if not teamcmd then continue end
 
                 MySQLite.queueQuery(string.format([[INSERT INTO darkrp_jobspawn(id, teamcmd) VALUES(%s, %s)]], row.id, MySQLite.SQLStr(teamcmd)))


### PR DESCRIPTION
Example scenario:

1. A sever has 10 jobs. Job index 10 is set a spawn and saved.
2. The sever developer removes a job. Nothing happens and the data is still in the database.
3. The developer then updates DarkRP. DarkRP tries to migrate the entry with job index 10 by looking up `RPExtraTeams` but the there isn't 10 jobs anymore. This results in it doing `(nil).command`.

Disclaimer: I haven't actually tested this in-game but surely I haven't fucked up this small of a change.