### PR TITLE
Fixed error when using disjoint.FindSet

### DIFF
--- a/gamemode/libraries/disjointset.lua
+++ b/gamemode/libraries/disjointset.lua
@@ -7,7 +7,7 @@ by FPtje Atheos
 Running time per operation (Union/FindSet): O(a(n)) where a is the inverse of the Ackermann function.
 ---------------------------------------------------------------------------*/
 
-local pairs = pairs
+local ipairs = ipairs
 local setmetatable = setmetatable
 local string = string
 local table = table


### PR DESCRIPTION
This regression (from b8d395d) broke demote groups in certain situations.

Also would have affected `disjoint.Union` (used via the `__add` metamethod) since that calls `FindSet`.

https://forum.darkrp.com/threads/update-lua-error.10976/