### PR TITLE
clamp health to not go below 0

### DIFF
--- a/gamemode/modules/hud/cl_hud.lua
+++ b/gamemode/modules/hud/cl_hud.lua
@@ -280,7 +280,7 @@ plyMeta.drawPlayerInfo = plyMeta.drawPlayerInfo or function(self)
     end
 
     if GAMEMODE.Config.showhealth then
-        local health = DarkRP.getPhrase("health", self:Health())
+        local health = DarkRP.getPhrase("health", math.max(0, self:Health()))
         draw.DrawNonParsedText(health, "DarkRPHUD2", pos.x + 1, pos.y + 21, colors.black, 1)
         draw.DrawNonParsedText(health, "DarkRPHUD2", pos.x, pos.y + 20, colors.white1, 1)
     end


### PR DESCRIPTION
When you kill someone, you can see the negative health left for a few seconds, because meta:Alive is networked slow.
This will fixed the negative health to be drawn.