### PR TITLE
Make the NPC Kill Pay system extensible

### DIFF
--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -99,6 +99,10 @@ function GM:canEarnNPCKillPay(ply, npc)
 end
 
 function GM:calculateNPCKillPay(ply, npc)
+    -- A NPC spawned by an addon might be worth more money than the default
+    if npc.KillValue then
+        return npc.KillValue
+    end
     return GAMEMODE.Config.npckillpay
 end
 

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -94,6 +94,14 @@ function GM:canSeeLogMessage(ply, message, colour)
     return true
 end
 
+function GM:canEarnNPCKillPay(ply, npc)
+    return GAMEMODE.Config.npckillpay > 0
+end
+
+function GM:calculateNPCKillPay(ply, npc)
+    return GAMEMODE.Config.npckillpay
+end
+
 --[[---------------------------------------------------------
  Gamemode functions
  ---------------------------------------------------------]]
@@ -263,9 +271,10 @@ function GM:OnNPCKilled(victim, ent, weapon)
     end
 
     -- If we know by now who killed the NPC, pay them.
-    if IsValid(ent) and GAMEMODE.Config.npckillpay > 0 then
-        ent:addMoney(GAMEMODE.Config.npckillpay)
-        DarkRP.notify(ent, 0, 4, DarkRP.getPhrase("npc_killpay", DarkRP.formatMoney(GAMEMODE.Config.npckillpay)))
+    if IsValid(ent) and hook.Call("canEarnNPCKillPay", GAMEMODE, ent, victim) then
+        local amount = hook.Call("calculateNPCKillPay", GAMEMODE, ent, victim)
+        ent:addMoney(amount)
+        DarkRP.notify(ent, 0, 4, DarkRP.getPhrase("npc_killpay", DarkRP.formatMoney(amount)))
     end
 end
 

--- a/gamemode/modules/base/sv_interface.lua
+++ b/gamemode/modules/base/sv_interface.lua
@@ -1212,3 +1212,53 @@ DarkRP.hookStub{
     },
     returns = {}
 }
+
+
+DarkRP.hookStub{
+    name = "canEarnNPCKillPay",
+    description = "If a player should profit from killing a NPC",
+    parameters = {
+        {
+            name = "ply",
+            description = "The player who killed the NPC.",
+            type = "Player"
+        },
+        {
+            name = "npc",
+            description = "The NPC that they killed.",
+            type = "Entity"
+        }
+    },
+    returns = {
+        {
+            name = "answer",
+            description = "Whether the player can earn money.",
+            type = "boolean"
+        }
+    }
+}
+
+
+DarkRP.hookStub{
+    name = "calculateNPCKillPay",
+    description = "How much a player should profit from killing a NPC",
+    parameters = {
+        {
+            name = "ply",
+            description = "The player who killed the NPC.",
+            type = "Player"
+        },
+        {
+            name = "npc",
+            description = "The NPC that they killed.",
+            type = "Entity"
+        }
+    },
+    returns = {
+        {
+            name = "total",
+            description = "How much money they should earn.",
+            type = "number"
+        }
+    }
+}


### PR DESCRIPTION
A user asked me to make my [NPC Spawn Platforms](https://steamcommunity.com/sharedfiles/filedetails/?id=107821465) allow them to configure the amount of money players get when they kill a spawned NPC.
I've added a generic variable for this (Lexicality/Lexical-Tools@fac1d107615c39b4cd9ef76f0144e20396f7f583), but currently DarkRP doesn't allow you to configure that value per-npc.
This PR changes that. 