### PR TITLE
Fix MOTD message

### DIFF
--- a/gamemode/modules/darkrpmessages/cl_darkrpmessage.lua
+++ b/gamemode/modules/darkrpmessages/cl_darkrpmessage.lua
@@ -19,7 +19,7 @@ local function receiveMOTD(html, len, headers, code)
 end
 
 local function showMOTD()
-    http.Fetch("https://raw.github.com/FPtje/DarkRPMotd/master/motd.txt", receiveMOTD, fn.Id)
+    http.Fetch("https://raw.githubusercontent.com/FPtje/DarkRPMotd/master/motd.txt", receiveMOTD, fn.Id)
 end
 timer.Simple(5, showMOTD)
 


### PR DESCRIPTION
The old link (https://raw.github.com/FPtje/DarkRPMotd/master/motd.txt) [no longer seems to work](https://imgur.com/a/ig4ul7t).
I don't know if this is due to a temporary problem or if the link has changed permanently.