### PR TITLE
Check if a customer is alive in order to place a hit.

### DIFF
--- a/gamemode/modules/hitmenu/sh_init.lua
+++ b/gamemode/modules/hitmenu/sh_init.lua
@@ -30,6 +30,7 @@ DarkRP.getHitmanTeams = fp{fn.Id, hitmanTeams}
 function DarkRP.hooks:canRequestHit(hitman, customer, target, price)
     if not hitman:isHitman() then return false, DarkRP.getPhrase("player_not_hitman") end
     if customer:GetPos():DistToSqr(hitman:GetPos()) > minHitDistanceSqr then return false, DarkRP.getPhrase("distance_too_big") end
+    if not customer:Alive() then return false, Darkrp.getPhrase("must_be_alive_to_do_x", DarkRP.getPhrase("place_a_hit")) end
     if hitman == target then return false, DarkRP.getPhrase("hitman_no_suicide") end
     if hitman == customer then return false, DarkRP.getPhrase("hitman_no_self_order") end
     if not customer:canAfford(price) then return false, DarkRP.getPhrase("cant_afford", DarkRP.getPhrase("hit")) end

--- a/gamemode/modules/hitmenu/sh_init.lua
+++ b/gamemode/modules/hitmenu/sh_init.lua
@@ -30,7 +30,7 @@ DarkRP.getHitmanTeams = fp{fn.Id, hitmanTeams}
 function DarkRP.hooks:canRequestHit(hitman, customer, target, price)
     if not hitman:isHitman() then return false, DarkRP.getPhrase("player_not_hitman") end
     if customer:GetPos():DistToSqr(hitman:GetPos()) > minHitDistanceSqr then return false, DarkRP.getPhrase("distance_too_big") end
-    if not customer:Alive() then return false, Darkrp.getPhrase("must_be_alive_to_do_x", DarkRP.getPhrase("place_a_hit")) end
+    if not customer:Alive() then return false, DarkRP.getPhrase("must_be_alive_to_do_x", DarkRP.getPhrase("place_a_hit")) end
     if hitman == target then return false, DarkRP.getPhrase("hitman_no_suicide") end
     if hitman == customer then return false, DarkRP.getPhrase("hitman_no_self_order") end
     if not customer:canAfford(price) then return false, DarkRP.getPhrase("cant_afford", DarkRP.getPhrase("hit")) end

--- a/gamemode/modules/language/sh_english.lua
+++ b/gamemode/modules/language/sh_english.lua
@@ -469,6 +469,7 @@ local my_language = {
     hitman_arrested = "The hitman was arrested!",
     hitman_changed_team = "The hitman changed team!",
     x_had_hit_ordered_by_y = "%s had an active hit ordered by %s",
+    place_a_hit = "place a hit!",
 
     -- Vote Restrictions
     hobos_no_rights = "Hobos have no voting rights!",


### PR DESCRIPTION
As of now, dead people can interact with the hit menu and place hits from the grave. This commit should fix this.