### PR TITLE
Fixed ammo maths

### DIFF
--- a/entities/entities/spawned_weapon/init.lua
+++ b/entities/entities/spawned_weapon/init.lua
@@ -88,7 +88,7 @@ function ENT:Use(activator, caller)
     end
 
     if secondaryAmmoType > 0 then
-        local secAmmo = activator:GetAmmoCount(secondaryAmmoType)
+        local secAmmo = activator:GetAmmoCount(secondaryAmmoType) + (clip2 or 0)
         activator:SetAmmo(secAmmo, secondaryAmmoType)
     end
 

--- a/entities/weapons/weapon_cs_base2/sv_commands.lua
+++ b/entities/weapons/weapon_cs_base2/sv_commands.lua
@@ -12,7 +12,7 @@ function meta:dropDRPWeapon(weapon)
         if not found then return end
     end
 
-    local ammo = self:GetAmmoCount(weapon:GetPrimaryAmmoType())
+    local primAmmo = self:GetAmmoCount(weapon:GetPrimaryAmmoType())
     self:DropWeapon(weapon) -- Drop it so the model isn't the viewmodel
 
     local ent = ents.Create("spawned_weapon")
@@ -26,11 +26,12 @@ function meta:dropDRPWeapon(weapon)
     ent.nodupe = true
     ent.clip1 = weapon:Clip1()
     ent.clip2 = weapon:Clip2()
-    ent.ammoadd = ammo
+    ent.ammoadd = primAmmo
 
     hook.Call("onDarkRPWeaponDropped", nil, self, ent, weapon)
 
-    self:RemoveAmmo(ammo, weapon:GetPrimaryAmmoType())
+    self:RemoveAmmo(primAmmo, weapon:GetPrimaryAmmoType())
+    self:RemoveAmmo(self:GetAmmoCount(weapon:GetSecondaryAmmoType()), weapon:GetSecondaryAmmoType())
 
     ent:Spawn()
 


### PR DESCRIPTION
* Fixed loosing ammo when collecting clip1 ammo twice. Clip1 ammo is automatically added to spare ammo if the ammo type is working.
* Clip2 ammo is automatically substracted from the player, when dropping a weapon with clip2 ammo in it.
The clip2 is automatically added back, when the weapon is collected again.

This took me a bit.
I tested the whole shit for like 10 minutes.
Now it should work flawlessly.

HL2 weapons don't work with ammo, but they are broke as fuck anyway.
It's because GetPrimaryAmmoType returns 0.
It was broken even before I updated the behaviour.