### PR TITLE
spawned_shipment use engine behaviour for ammo

### DIFF
--- a/entities/entities/spawned_shipment/init.lua
+++ b/entities/entities/spawned_shipment/init.lua
@@ -130,10 +130,16 @@ function ENT:SpawnItem()
     local class = CustomShipments[contents].entity
     local model = CustomShipments[contents].model
 
+    local defaultClip
+    local wep_tbl = weapons.Get(class)
+    if wep_tbl and wep_tbl.Primary and wep_tbl.Primary.DefaultClip then
+        defaultClip = wep_tbl.Primary.DefaultClip
+    end
+
     weapon:SetWeaponClass(class)
     weapon:SetModel(model)
-    weapon.ammoadd = self.ammoadd or (weapons.Get(class) and weapons.Get(class).Primary.DefaultClip)
-    weapon.clip1 = self.clip1
+    weapon.ammoadd = self.ammoadd or defaultClip
+    weapon.clip1 = self.clip1 or defaultClip
     weapon.clip2 = self.clip2
     weapon:SetPos(self:GetPos() + weaponPos)
     weapon:SetAngles(weaponAng)
@@ -173,13 +179,18 @@ function ENT:Destruct()
         return
     end
 
+    local defaultClip
+    local wep_tbl = weapons.Get(class)
+    if wep_tbl and wep_tbl.Primary and wep_tbl.Primary.DefaultClip then
+        defaultClip = wep_tbl.Primary.DefaultClip
+    end
 
     local weapon = ents.Create("spawned_weapon")
     weapon:SetModel(model)
     weapon:SetWeaponClass(class)
     weapon:SetPos(Vector(vPoint.x, vPoint.y, vPoint.z + 5))
-    weapon.ammoadd = self.ammoadd or (weapons.Get(class) and weapons.Get(class).Primary.DefaultClip)
-    weapon.clip1 = self.clip1
+    weapon.ammoadd = self.ammoadd or defaultClip
+    weapon.clip1 = self.clip1 or defaultClip
     weapon.clip2 = self.clip2
     weapon.nodupe = true
     weapon:Spawn()


### PR DESCRIPTION
Currently, spawning 2 weapons from a spawned shipment will make you loose ammo, because clip1 isn't stored. (Only the first weapon is given a full clip1)

This pull request corrects this behaviour, making it match the engine and fixes loosing ammo due to shipments completely.