### PR TITLE
Fixed duplication of ammo

### DIFF
--- a/entities/entities/spawned_shipment/init.lua
+++ b/entities/entities/spawned_shipment/init.lua
@@ -130,16 +130,17 @@ function ENT:SpawnItem()
     local class = CustomShipments[contents].entity
     local model = CustomShipments[contents].model
 
-    local defaultClip
+    local defaultClip, clipSize
     local wep_tbl = weapons.Get(class)
-    if wep_tbl and wep_tbl.Primary and wep_tbl.Primary.DefaultClip then
+    if wep_tbl and wep_tbl.Primary then
         defaultClip = wep_tbl.Primary.DefaultClip
+        clipSize = wep_tbl.Primary.ClipSize
     end
 
     weapon:SetWeaponClass(class)
     weapon:SetModel(model)
     weapon.ammoadd = self.ammoadd or defaultClip
-    weapon.clip1 = self.clip1 or defaultClip
+    weapon.clip1 = self.clip1 or clipSize
     weapon.clip2 = self.clip2
     weapon:SetPos(self:GetPos() + weaponPos)
     weapon:SetAngles(weaponAng)
@@ -179,10 +180,11 @@ function ENT:Destruct()
         return
     end
 
-    local defaultClip
+    local defaultClip, clipSize
     local wep_tbl = weapons.Get(class)
-    if wep_tbl and wep_tbl.Primary and wep_tbl.Primary.DefaultClip then
+    if wep_tbl and wep_tbl.Primary then
         defaultClip = wep_tbl.Primary.DefaultClip
+        clipSize = wep_tbl.Primary.ClipSize
     end
 
     local weapon = ents.Create("spawned_weapon")
@@ -190,7 +192,7 @@ function ENT:Destruct()
     weapon:SetWeaponClass(class)
     weapon:SetPos(Vector(vPoint.x, vPoint.y, vPoint.z + 5))
     weapon.ammoadd = self.ammoadd or defaultClip
-    weapon.clip1 = self.clip1 or defaultClip
+    weapon.clip1 = self.clip1 or clipSize
     weapon.clip2 = self.clip2
     weapon.nodupe = true
     weapon:Spawn()

--- a/entities/entities/spawned_weapon/init.lua
+++ b/entities/entities/spawned_weapon/init.lua
@@ -61,7 +61,7 @@ function ENT:Use(activator, caller)
     local secondaryAmmoType = weapon:GetSecondaryAmmoType()
     weapon:Remove()
 
-    weapon = activator:Give(class)
+    weapon = activator:Give(class, true)
 
     local clip1, clip2 = self.clip1, self.clip2
     if weapon:IsValid() then

--- a/entities/weapons/weaponchecker/shared.lua
+++ b/entities/weapons/weaponchecker/shared.lua
@@ -219,16 +219,16 @@ function SWEP:Reload()
         DarkRP.notify(self:GetOwner(), 1, 4, DarkRP.getPhrase("no_weapons_confiscated", ent:Nick()))
         return
     else
+        ent:RemoveAllAmmo()
         for _, v in pairs(ent.ConfiscatedWeapons) do
-            local wep = ent:Give(v.class)
+            local wep = ent:Give(v.class, true)
 
             -- :Give returns NULL when the player already has the weapon
             wep = IsValid(wep) and wep or ent:GetWeapon(v.class)
             if not IsValid(wep) then continue end
 
-            ent:RemoveAllAmmo()
-            ent:SetAmmo(v.primaryAmmoCount, v.primaryAmmoType, false)
-            ent:SetAmmo(v.secondaryAmmoCount, v.secondaryAmmoType, false)
+            ent:GiveAmmo(v.primaryAmmoCount, v.primaryAmmoType, true)
+            ent:GiveAmmo(v.secondaryAmmoCount, v.secondaryAmmoType, true)
 
             wep:SetClip1(v.clip1)
             wep:SetClip2(v.clip2)

--- a/gamemode/modules/base/sv_purchasing.lua
+++ b/gamemode/modules/base/sv_purchasing.lua
@@ -67,12 +67,19 @@ local function BuyPistol(ply, args)
 
     local tr = util.TraceLine(trace)
 
+    local defaultClip, clipSize
+    local wep_tbl = weapons.Get(shipment.entity)
+    if wep_tbl and wep_tbl.Primary then
+        defaultClip = wep_tbl.Primary.DefaultClip
+        clipSize = wep_tbl.Primary.ClipSize
+    end
+
     local weapon = ents.Create("spawned_weapon")
     weapon:SetModel(shipment.model)
     weapon:SetWeaponClass(shipment.entity)
     weapon:SetPos(tr.HitPos)
-    weapon.ammoadd = weapons.Get(shipment.entity) and (shipment.spareammo or weapons.Get(shipment.entity).Primary.DefaultClip)
-    weapon.clip1 = shipment.clip1
+    weapon.ammoadd = shipment.spareammo or defaultClip
+    weapon.clip1 = shipment.clip1 or clipSize
     weapon.clip2 = shipment.clip2
     weapon.nodupe = true
     weapon:Spawn()

--- a/gamemode/modules/sleep/sv_sleep.lua
+++ b/gamemode/modules/sleep/sv_sleep.lua
@@ -82,7 +82,7 @@ function DarkRP.toggleSleep(player, command)
             player:RemoveAllAmmo()
             for _, v in pairs(player.WeaponsForSleep) do
                 local wep = player:Give(v[1])
-                if !IsValid(wep) then continue end
+                if not IsValid(wep) then continue end
 
                 player:GiveAmmo(v[2], v[3], true)
                 player:GiveAmmo(v[4], v[5], true)

--- a/gamemode/modules/sleep/sv_sleep.lua
+++ b/gamemode/modules/sleep/sv_sleep.lua
@@ -79,11 +79,13 @@ function DarkRP.toggleSleep(player, command)
         ragdoll:Remove()
         ragdoll.OwnerINT = 0
         if player.WeaponsForSleep and player:GetTable().BeforeSleepTeam == player:Team() then
+            player:RemoveAllAmmo()
             for _, v in pairs(player.WeaponsForSleep) do
                 local wep = player:Give(v[1])
-                player:RemoveAllAmmo()
-                player:SetAmmo(v[2], v[3], false)
-                player:SetAmmo(v[4], v[5], false)
+                if !IsValid(wep) then continue end
+
+                player:GiveAmmo(v[2], v[3], true)
+                player:GiveAmmo(v[4], v[5], true)
 
                 wep:SetClip1(v[6])
                 wep:SetClip2(v[7])


### PR DESCRIPTION
* The Give function gave players additional ammo, while they shouldn't receive any, fixed.
* DefaultClip was used to determine clip1 fill, now ClipSize is used, that's how it should have been.
* sleep module, weapon checker were making player loose ammo, fixed.