### PR TITLE
Add a delay option

### DIFF
--- a/gamemode/modules/base/sh_checkitems.lua
+++ b/gamemode/modules/base/sh_checkitems.lua
@@ -487,6 +487,12 @@ DarkRP.validateEntity = fn.FAnd{buyableSchema, tc.checkTable{
                 "The allowTools must be either true or false."
             )
         ),
+
+    delay =
+        tc.addHint(
+            tc.optional(isnumber),
+            "The delay must be a number."
+        ),
 }}
 
 

--- a/gamemode/modules/base/sh_createitems.lua
+++ b/gamemode/modules/base/sh_createitems.lua
@@ -277,7 +277,7 @@ local function addEntityCommands(tblEnt)
     DarkRP.declareChatCommand{
         command = tblEnt.cmd,
         description = "Purchase a " .. tblEnt.name,
-        delay = 2,
+        delay = tblEnt.delay or 2,
         condition =
             function(ply)
                 if ply:isArrested() then return false end


### PR DESCRIPTION
Adds a delay option in custom entity creation with tblEnt.delay and adds validation for the delay option.