### PR TITLE
GAMEMODE.Config.jobBecomeNotification

### DIFF
--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -97,6 +97,8 @@ GM.Config.enforceplayermodel            = true
 GM.Config.globalshow                    = false
 -- ironshoot - Enable/disable whether people need iron sights to shoot.
 GM.Config.ironshoot                     = true
+-- jobBecomeNotification - Whether or not to display the notification notifying everyone about a job switch.
+GM.Config.jobBecomeNotification         = true
 -- showjob - Whether or not to display a player's job above their head in-game.
 GM.Config.showjob                       = true
 -- letters - Enable/disable letter writing / typing.

--- a/gamemode/modules/jobs/sv_jobs.lua
+++ b/gamemode/modules/jobs/sv_jobs.lua
@@ -94,7 +94,9 @@ function meta:changeTeam(t, force, suppressNotification)
     end
     self:updateJob(TEAM.name)
     self:setSelfDarkRPVar("salary", TEAM.salary)
-    notifyAll(0, 4, DarkRP.getPhrase("job_has_become", self:Nick(), TEAM.name))
+    if GAMEMODE.Config.jobBecomeNotification then
+        notifyAll(0, 4, DarkRP.getPhrase("job_has_become", self:Nick(), TEAM.name))
+    end
 
 
     if self:getDarkRPVar("HasGunlicense") and GAMEMODE.Config.revokeLicenseOnJobChange then


### PR DESCRIPTION
Creates GAMEMODE.Config.jobBecomeNotification, which is a config value that allows the server owner to choose whether to display the notification notifying everyone about a job switch.