### PR TITLE
Adds the onNotify hook.

### DIFF
--- a/gamemode/modules/base/sv_util.lua
+++ b/gamemode/modules/base/sv_util.lua
@@ -14,6 +14,8 @@ function DarkRP.notify(ply, msgtype, len, msg)
         rcp:AddPlayer(v)
     end
 
+    if hook.Run("onNotify", ply, msgtype, len, msg) == false then return end
+
     umsg.Start("_Notify", rcp)
         umsg.String(msg)
         umsg.Short(msgtype)
@@ -22,6 +24,8 @@ function DarkRP.notify(ply, msgtype, len, msg)
 end
 
 function DarkRP.notifyAll(msgtype, len, msg)
+    if hook.Run("onNotify", player.GetHumans(), msgtype, len, msg) == false then return end
+
     umsg.Start("_Notify")
         umsg.String(msg)
         umsg.Short(msgtype)


### PR DESCRIPTION
The onNotify hook is a serverside hook that runs when DarkRP.notify is run with the parameters: ply (table), msgtype, len, and msg.