### PR TITLE
Replacing the default page link in the F1 menu

### DIFF
--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -314,8 +314,8 @@ GM.Config.lockdownsound = "npc/overwatch/cityvoice/f_confirmcivilstatus_1_spkr.w
 GM.Config.DarkRPSkin = "DarkRP"
 GM.Config.currency = "$"
 GM.Config.chatCommandPrefix = "/"
-GM.Config.F1MenuHelpPage = "https://docs.google.com/document/d/10pvotowOA3EA7K5BMgdaKVOYjbrbx6dxrQn4LWxm30A/edit#heading=h.e5iaqteza8x7"
-GM.Config.F1MenuHelpPageTitle = "Server tips"
+GM.Config.F1MenuHelpPage = "https://forum.darkrp.com/"
+GM.Config.F1MenuHelpPageTitle = "DarkRP Forum"
 
 -- Put Steam ID's and ranks in this list, and the players will have that rank when they join.
 GM.Config.DefaultPlayerGroups = {

--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -314,8 +314,8 @@ GM.Config.lockdownsound = "npc/overwatch/cityvoice/f_confirmcivilstatus_1_spkr.w
 GM.Config.DarkRPSkin = "DarkRP"
 GM.Config.currency = "$"
 GM.Config.chatCommandPrefix = "/"
-GM.Config.F1MenuHelpPage = "https://forum.darkrp.com/"
-GM.Config.F1MenuHelpPageTitle = "DarkRP Forum"
+GM.Config.F1MenuHelpPage = "https://wiki.darkrp.com/index.php/Main_Page"
+GM.Config.F1MenuHelpPageTitle = "DarkRP Wiki"
 
 -- Put Steam ID's and ranks in this list, and the players will have that rank when they join.
 GM.Config.DefaultPlayerGroups = {


### PR DESCRIPTION
The old page can no longer be displayed with Awesomium.