### PR TITLE
Updated spawning of entities to prevent stucking

### DIFF
--- a/entities/weapons/pocket/sv_init.lua
+++ b/entities/weapons/pocket/sv_init.lua
@@ -162,16 +162,16 @@ local function deserialize(ply, item)
     if ent:IsWeapon() and ent.Weapon ~= nil and not ent.Weapon:IsValid() then ent.Weapon = ent end
     if ent.Entity ~= nil and not ent.Entity:IsValid() then ent.Entity = ent end
 
-    local pos, mins = ent:GetPos(), ent:WorldSpaceAABB()
-    local offset = pos.z - mins.z
-
     local trace = {}
     trace.start = ply:EyePos()
     trace.endpos = trace.start + ply:GetAimVector() * 85
     trace.filter = ply
 
     local tr = util.TraceLine(trace)
-    ent:SetPos(tr.HitPos + Vector(0, 0, offset))
+
+    ent:SetPos(tr.HitPos)
+
+    DarkRP.unstuckEntity(ent, tr, ply)
 
     local phys = ent:GetPhysicsObject()
     timer.Simple(0, function() if phys:IsValid() then phys:Wake() end end)

--- a/entities/weapons/weapon_cs_base2/sv_commands.lua
+++ b/entities/weapons/weapon_cs_base2/sv_commands.lua
@@ -16,10 +16,10 @@ function meta:dropDRPWeapon(weapon)
     self:DropWeapon(weapon) -- Drop it so the model isn't the viewmodel
 
     local ent = ents.Create("spawned_weapon")
+
     local model = (weapon:GetModel() == "models/weapons/v_physcannon.mdl" and "models/weapons/w_physics.mdl") or weapon:GetModel()
     model = util.IsValidModel(model) and model or "models/weapons/w_rif_ak47.mdl"
 
-    ent:SetPos(self:GetShootPos() + self:GetAimVector() * 30)
     ent:SetModel(model)
     ent:SetSkin(weapon:GetSkin() or 0)
     ent:SetWeaponClass(weapon:GetClass())
@@ -28,12 +28,22 @@ function meta:dropDRPWeapon(weapon)
     ent.clip2 = weapon:Clip2()
     ent.ammoadd = primAmmo
 
-    hook.Call("onDarkRPWeaponDropped", nil, self, ent, weapon)
-
     self:RemoveAmmo(primAmmo, weapon:GetPrimaryAmmoType())
     self:RemoveAmmo(self:GetAmmoCount(weapon:GetSecondaryAmmoType()), weapon:GetSecondaryAmmoType())
 
+    local trace = {}
+    trace.start = self:GetShootPos()
+    trace.endpos = trace.start + self:GetAimVector() * 50
+    trace.filter = {self, weapon, ent}
+
+    local tr = util.TraceLine(trace)
+
+    ent:SetPos(tr.HitPos)
     ent:Spawn()
+
+    DarkRP.unstuckEntity(ent, tr, self)
+
+    hook.Call("onDarkRPWeaponDropped", nil, self, ent, weapon)
 
     weapon:Remove()
 end

--- a/gamemode/modules/base/sh_createitems.lua
+++ b/gamemode/modules/base/sh_createitems.lua
@@ -295,14 +295,19 @@ local function addEntityCommands(tblEnt)
     -- used if tblEnt.spawn is not defined
     local function defaultSpawn(ply, tr, tblE)
         local ent = ents.Create(tblE.ent)
+
         if not ent:IsValid() then error("Entity '" .. tblE.ent .. "' does not exist or is not valid.") end
         if ent.Setowning_ent then ent:Setowning_ent(ply) end
+
         ent:SetPos(tr.HitPos)
         -- These must be set before :Spawn()
         ent.SID = ply.SID
         ent.allowed = tblE.allowed
         ent.DarkRPItem = tblE
         ent:Spawn()
+        ent:Activate()
+
+        DarkRP.unstuckEntity(ent, tr, ply)
 
         local phys = ent:GetPhysicsObject()
         if phys:IsValid() then phys:Wake() end

--- a/gamemode/modules/base/sv_purchasing.lua
+++ b/gamemode/modules/base/sv_purchasing.lua
@@ -84,6 +84,8 @@ local function BuyPistol(ply, args)
     weapon.nodupe = true
     weapon:Spawn()
 
+    DarkRP.unstuckEntity(weapon, tr, ply)
+
     if shipment.onBought then
         shipment.onBought(ply, shipment, weapon)
     end
@@ -186,6 +188,8 @@ local function BuyShipment(ply, args)
     crate.clip2 = found.clip2
     crate:Spawn()
     crate:SetPlayer(ply)
+
+    DarkRP.unstuckEntity(crate, tr, ply)
 
     local phys = crate:GetPhysicsObject()
     phys:Wake()
@@ -303,12 +307,6 @@ local function BuyVehicle(ply, args)
         end
     end
 
-    local Angles = ply:GetAngles()
-    Angles.pitch = 0
-    Angles.roll = 0
-    Angles.yaw = Angles.yaw + 180
-    local angOff = found.angle or Angle(0, 0, 0)
-    ent:SetAngles(Angles + angOff)
     ent:SetPos(tr.HitPos)
     ent.VehicleName = found.name
     ent.VehicleTable = Vehicle
@@ -321,8 +319,15 @@ local function BuyVehicle(ply, args)
     end
     ent:CPPISetOwner(ply)
     ent:keysOwn(ply)
+
+    DarkRP.unstuckEntity(ent, tr, ply)
+
+    local angOff = found.angle or Angle(0, 0, 0)
+    ent:SetAngles(ent:GetAngles() + angOff)
+
     hook.Call("PlayerSpawnedVehicle", GAMEMODE, ply, ent) -- VUMod compatability
     hook.Call("playerBoughtCustomVehicle", nil, ply, found, ent, cost)
+
     if found.onBought then
         found.onBought(ply, found, ent)
     end
@@ -414,6 +419,8 @@ local function BuyAmmo(ply, args)
     ammo.nodupe = true
     ammo.amountGiven, ammo.ammoType = found.amountGiven, found.ammoType
     ammo:Spawn()
+
+    DarkRP.unstuckEntity(ammo, tr, ply)
 
     hook.Call("playerBoughtAmmo", nil, ply, found, ammo, cost)
 

--- a/gamemode/modules/base/sv_util.lua
+++ b/gamemode/modules/base/sv_util.lua
@@ -116,6 +116,21 @@ function DarkRP.isEmpty(vector, ignore)
     return a and b
 end
 
+function DarkRP.unstuckEntity(ent, tr, ply)
+    if IsValid(ply) then
+        local ang = ply:EyeAngles()
+        ang.pitch = 0
+        ang.yaw = ang.yaw + 180
+        ang.roll = 0
+        ent:SetAngles(ang)
+    end
+
+    local vFlushPoint = tr.HitPos - (tr.HitNormal * 512)
+    vFlushPoint = ent:NearestPoint(vFlushPoint)
+    vFlushPoint = ent:GetPos() - vFlushPoint
+    vFlushPoint = tr.HitPos + vFlushPoint
+    ent:SetPos(vFlushPoint)
+end
 
 --[[---------------------------------------------------------------------------
 Find an empty position near the position given in the first parameter

--- a/gamemode/modules/hungermod/sv_hungermod.lua
+++ b/gamemode/modules/hungermod/sv_hungermod.lua
@@ -32,13 +32,6 @@ local function BuyFood(ply, args)
         return ""
     end
 
-    local trace = {}
-    trace.start = ply:EyePos()
-    trace.endpos = trace.start + ply:GetAimVector() * 85
-    trace.filter = ply
-
-    local tr = util.TraceLine(trace)
-
     for _, v in pairs(FoodItems) do
         if string.lower(args) ~= string.lower(v.name) then continue end
 
@@ -76,6 +69,13 @@ local function BuyFood(ply, args)
         ply:addMoney(-cost)
         DarkRP.notify(ply, 0, 4, DarkRP.getPhrase("you_bought", v.name, DarkRP.formatMoney(cost), ""))
 
+        local trace = {}
+        trace.start = ply:EyePos()
+        trace.endpos = trace.start + ply:GetAimVector() * 85
+        trace.filter = ply
+
+        local tr = util.TraceLine(trace)
+
         local SpawnedFood = ents.Create("spawned_food")
         SpawnedFood.DarkRPItem = foodTable
         SpawnedFood:Setowning_ent(ply)
@@ -91,6 +91,8 @@ local function BuyFood(ply, args)
 
         SpawnedFood.foodItem = v
         SpawnedFood:Spawn()
+
+        DarkRP.unstuckEntity(SpawnedFood, tr, ply)
 
         hook.Call("playerBoughtFood", nil, ply, v, SpawnedFood, cost)
         return ""


### PR DESCRIPTION
This pull request fixes a lot of situations, in which entities are spawned in a wall or weapons get lost because dropping in the floor.

It uses the same functions as sandbox to ensure everything spawns properly on solid surface.

If an entity has an spawn function written onto it, it will not try to unstuck it, just like in the sandbox gamemode.