### PR TITLE
Take physics damage for food entity

### DIFF
--- a/entities/entities/food/init.lua
+++ b/entities/entities/food/init.lua
@@ -18,6 +18,8 @@ function ENT:Initialize()
 end
 
 function ENT:OnTakeDamage(dmg)
+    self:TakePhysicsDamage(dmg)
+
     self.damage = self.damage - dmg:GetDamage()
 
     if (self.damage <= 0) then


### PR DESCRIPTION
All other entities take physics damage while this entity does not for some reason.
I corrected the behaviour.