### PR TITLE
Add postLoadCustomDarkRPItems

### DIFF
--- a/gamemode/libraries/modificationloader.lua
+++ b/gamemode/libraries/modificationloader.lua
@@ -147,5 +147,6 @@ function GM:DarkRPFinishedLoading()
     loadLanguages()
     loadModules()
     loadCustomDarkRPItems()
-    hook.Call("loadCustomDarkRPItems", GAMEMODE)
+    hook.Call("loadCustomDarkRPItems", self)
+    hook.Call("postLoadCustomDarkRPItems", self)
 end

--- a/gamemode/modules/base/sh_interface.lua
+++ b/gamemode/modules/base/sh_interface.lua
@@ -1494,6 +1494,15 @@ DarkRP.hookStub{
 }
 
 DarkRP.hookStub{
+    name = "postLoadCustomDarkRPItems",
+    description = "Runs right after loadCustomDarkRPItems. All custom DarkRP content will be loaded by this time.",
+    parameters = {
+    },
+    returns = {
+    }
+}
+
+DarkRP.hookStub{
     name = "DarkRPStartedLoading",
     description = "Runs at the very start of loading DarkRP. Not even sandbox has loaded here yet.",
     parameters = {


### PR DESCRIPTION
I am writing an entity for DarkRP that can only be registered after all teams have been loaded. This is not guaranteed by a loadCustomDarkRPItems hook due to unpredictable hook ordering. Though a timer would work, I also want the entity to be registered by the time map entities are loaded so I don't have to do extra hacks to recreate them after InitPostEntity.

GAMEMODE -> self when passing to hook.Call to support custom GAMEMODE tables (``GAMEMODE.DarkRPFinishedLoading(MY_CUSTOM_GM_TABLE)`` or ``local GM = setmetatable({}, {__index = GAMEMODE}) GM:DarkRPFinishedLoading()``). This should really be done across the entire gamemode.