### PR TITLE
Update sv_data.lua

### DIFF
--- a/gamemode/modules/base/sv_data.lua
+++ b/gamemode/modules/base/sv_data.lua
@@ -54,7 +54,7 @@ function DarkRP.initDatabase()
                 uid BIGINT NOT NULL PRIMARY KEY,
                 rpname VARCHAR(45),
                 salary INTEGER NOT NULL DEFAULT 45,
-                wallet INTEGER NOT NULL
+                wallet BIGINT NOT NULL
             );
         ]])
 
@@ -191,7 +191,7 @@ function migrateDB(callback)
                     uid BIGINT NOT NULL PRIMARY KEY,
                     rpname VARCHAR(45),
                     salary INTEGER NOT NULL DEFAULT 45,
-                    wallet INTEGER NOT NULL
+                    wallet BIGINT NOT NULL
                 );
             ]])
 


### PR DESCRIPTION
By using INTEGER it sets a default wallet hard cap of $2,147,483,647  by changing to a BIGINT this hard cap is much higher at $9,223,372,036,854,775,807 which seems unrealistic. Without the change of INTEGER to BIGINT a players money might be reset due to an sql error of "too high range" since the value of wallet is bigger than the max size of INT.