### PR TITLE
Wanted improvements

### DIFF
--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -460,7 +460,7 @@ function GM:PlayerDeath(ply, weapon, killer)
         end
     end
 
-    if IsValid(ply) and (ply ~= killer or ply.Slayed) and not ply:isArrested() then
+    if IsValid(ply) and (ply ~= killer or ply.Slayed) and IsValid(killer) and not ply:isArrested() then
         ply:setDarkRPVar("wanted", nil)
         ply.DeathPos = nil
         ply.Slayed = false

--- a/gamemode/modules/police/sv_init.lua
+++ b/gamemode/modules/police/sv_init.lua
@@ -51,11 +51,13 @@ function plyMeta:wanted(actor, reason, time)
 
     self:setDarkRPVar("wanted", true)
     self:setDarkRPVar("wantedReason", reason)
-
-    timer.Create(self:SteamID64() .. " wantedtimer", time or GAMEMODE.Config.wantedtime, 1, function()
-        if not IsValid(self) then return end
-        self:unWanted()
-    end)
+    
+    if time and time > 0 or GAMEMODE.Config.wantedtime > 0 then
+        timer.Create(self:SteamID64() .. " wantedtimer", time or GAMEMODE.Config.wantedtime, 1, function()
+            if not IsValid(self) then return end
+            self:unWanted()
+        end)
+    end
 
     if suppressMsg then return end
 


### PR DESCRIPTION
This prevents players from jumping off buildings to get unwanted and also allows GAMEMODE.Config.wantedtime to be set to 0 (will not create a timer, wanted will only go away when killed)