### PR TITLE
Config option to allow remaining wanted after death

### DIFF
--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -159,7 +159,7 @@ GM.Config.unlockdoorsonstart            = false
 GM.Config.voiceradius                   = true
 -- tax - Whether players pay taxes on their wallets.
 GM.Config.wallettax                     = false
--- wantedrespawn
+-- wantedrespawn - Whether players remain wanted on respawn.
 GM.Config.wantedrespawn                 = false
 -- wantedsuicide - Enable/Disable suiciding while you are wanted by the police.
 GM.Config.wantedsuicide                 = false

--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -159,6 +159,8 @@ GM.Config.unlockdoorsonstart            = false
 GM.Config.voiceradius                   = true
 -- tax - Whether players pay taxes on their wallets.
 GM.Config.wallettax                     = false
+-- wantedrespawn
+GM.Config.wantedrespawn                 = false
 -- wantedsuicide - Enable/Disable suiciding while you are wanted by the police.
 GM.Config.wantedsuicide                 = false
 -- realisticfalldamage - Enable/Disable dynamic fall damage. Setting mp_falldamage to 1 will over-ride this.

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -461,7 +461,9 @@ function GM:PlayerDeath(ply, weapon, killer)
     end
 
     if IsValid(ply) and (ply ~= killer or ply.Slayed) and not ply:isArrested() then
-        ply:setDarkRPVar("wanted", nil)
+        if not GAMEMODE.Config.wantedrespawn then
+			ply:setDarkRPVar("wanted", nil)
+		end
         ply.DeathPos = nil
         ply.Slayed = false
     end

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -462,8 +462,8 @@ function GM:PlayerDeath(ply, weapon, killer)
 
     if IsValid(ply) and (ply ~= killer or ply.Slayed) and not ply:isArrested() then
         if not GAMEMODE.Config.wantedrespawn then
-			ply:setDarkRPVar("wanted", nil)
-		end
+            ply:setDarkRPVar("wanted", nil)
+        end
         ply.DeathPos = nil
         ply.Slayed = false
     end


### PR DESCRIPTION
This adds an option that skips the code setting the DarkRPVar, wanted, to nil on death by players other then themselves. When false (default), it continues the current behavior of removing the wanted status of the perp in most cases. 

This has been discussed in #2949, but it seems there might have been a misunderstanding. Players are indeed losing their wanted status on death if it wasn't from suicide, etc. Falco summarizes the issue with this in his comment:
> DarkRP is not built for NLR. I don't mind changes that fuck it over. Removing wanted on death is something that can always be scripted externally, the other way around is more difficult.

_Originally posted by @FPtje in https://github.com/FPtje/DarkRP/pull/2949#issuecomment-535073645_

On top of that, since it doesn't call the playerUnwanted hook or use the unwanted player function, there is no clean way of blocking, handling, logging, or otherwise dealing with this. 

This won't modify the current behavior unless you set it to true, but it will permit server owners to keep people wanted after death so that even through the fiery red virtual hell of your HL2-style demise, you cannot escape the highly trained professionals of {insert name}RP and their unyielding pursuit of justice.

We appreciate your time and consideration.