### PR TITLE
Update init.lua

### DIFF
--- a/entities/entities/spawned_weapon/init.lua
+++ b/entities/entities/spawned_weapon/init.lua
@@ -10,7 +10,9 @@ function ENT:Initialize()
     self:SetSolid(SOLID_VPHYSICS)
     self:SetUseType(SIMPLE_USE)
     local phys = self:GetPhysicsObject()
-    phys:Wake()
+    if IsValid(phys) then
+        phys:Wake()
+    end
 
     if self:Getamount() == 0 then
         self:Setamount(1)


### PR DESCRIPTION
Avoid following error:
[ERROR] gamemodes/darkrp/entities/entities/spawned_weapon/init.lua:13: Tried to use a NULL physics object!
1. Wake - [C]:-1
2. unknown - gamemodes/darkrp/entities/entities/spawned_weapon/init.lua:13
3. Spawn - [C]:-1
4. dropDRPWeapon - gamemodes/darkrp/entities/weapons/weapon_cs_base2/sv_commands.lua:43
5. unknown - gamemodes/darkrp/entities/weapons/weapon_cs_base2/sv_commands.lua:69