### PR TITLE
Move PrintName to shared since:

### DIFF
--- a/entities/weapons/arrest_stick/shared.lua
+++ b/entities/weapons/arrest_stick/shared.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 if CLIENT then
-    SWEP.PrintName = "Arrest Baton"
     SWEP.Slot = 1
     SWEP.SlotPos = 3
 end
@@ -11,6 +10,7 @@ DEFINE_BASECLASS("stick_base")
 SWEP.Instructions = "Left click to arrest\nRight click to switch batons"
 SWEP.IsDarkRPArrestStick = true
 
+SWEP.PrintName = "Arrest Baton"
 SWEP.Spawnable = true
 SWEP.Category = "DarkRP (Utility)"
 

--- a/entities/weapons/door_ram/shared.lua
+++ b/entities/weapons/door_ram/shared.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 if CLIENT then
-    SWEP.PrintName = "Battering Ram"
     SWEP.Slot = 5
     SWEP.SlotPos = 1
     SWEP.DrawAmmo = false
@@ -11,6 +10,7 @@ end
 -- Variables that are used on both client and server
 DEFINE_BASECLASS("weapon_cs_base2")
 
+SWEP.PrintName = "Battering Ram"
 SWEP.Author = "DarkRP Developers"
 SWEP.Instructions = "Left click to break open doors/unfreeze props or get people out of their vehicles\nRight click to raise"
 SWEP.Contact = ""

--- a/entities/weapons/keys/shared.lua
+++ b/entities/weapons/keys/shared.lua
@@ -5,7 +5,6 @@ if SERVER then
 end
 
 if CLIENT then
-    SWEP.PrintName = "Keys"
     SWEP.Slot = 1
     SWEP.SlotPos = 1
     SWEP.DrawAmmo = false
@@ -14,6 +13,7 @@ if CLIENT then
     include("cl_menu.lua")
 end
 
+SWEP.PrintName = "Keys"
 SWEP.Author = "DarkRP Developers"
 SWEP.Instructions = "Left click to lock\nRight click to unlock\nReload for door settings or animation menu"
 SWEP.Contact = ""

--- a/entities/weapons/lockpick/shared.lua
+++ b/entities/weapons/lockpick/shared.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 if CLIENT then
-    SWEP.PrintName = "Lock Pick"
     SWEP.Slot = 5
     SWEP.SlotPos = 1
     SWEP.DrawAmmo = false
@@ -10,6 +9,7 @@ end
 
 -- Variables that are used on both client and server
 
+SWEP.PrintName = "Lock Pick"
 SWEP.Author = "DarkRP Developers"
 SWEP.Instructions = "Left or right click to pick a lock"
 SWEP.Contact = ""

--- a/entities/weapons/ls_sniper/shared.lua
+++ b/entities/weapons/ls_sniper/shared.lua
@@ -5,7 +5,6 @@ if SERVER then
 end
 
 if CLIENT then
-    SWEP.PrintName = "Silenced Sniper"
     SWEP.Author = "DarkRP Developers"
     SWEP.Slot = 0
     SWEP.SlotPos = 0
@@ -16,6 +15,7 @@ end
 
 DEFINE_BASECLASS("weapon_cs_base2")
 
+SWEP.PrintName = "Silenced Sniper"
 SWEP.Spawnable = true
 SWEP.AdminOnly = false
 SWEP.Category = "DarkRP (Weapon)"

--- a/entities/weapons/stunstick/shared.lua
+++ b/entities/weapons/stunstick/shared.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 if CLIENT then
-    SWEP.PrintName = "Stun Stick"
     SWEP.Slot = 0
     SWEP.SlotPos = 5
     SWEP.RenderGroup = RENDERGROUP_BOTH
@@ -19,6 +18,7 @@ DEFINE_BASECLASS("stick_base")
 SWEP.Instructions = "Left click to discipline\nRight click to kill\nHold reload to threaten"
 SWEP.IsDarkRPStunstick = true
 
+SWEP.PrintName = "Stun Stick"
 SWEP.Spawnable = true
 SWEP.Category = "DarkRP (Utility)"
 

--- a/entities/weapons/unarrest_stick/shared.lua
+++ b/entities/weapons/unarrest_stick/shared.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 if CLIENT then
-    SWEP.PrintName = "Unarrest Baton"
     SWEP.Slot = 1
     SWEP.SlotPos = 3
 end
@@ -11,6 +10,7 @@ DEFINE_BASECLASS("stick_base")
 SWEP.Instructions = "Left click to unarrest\nRight click to switch batons"
 SWEP.IsDarkRPUnarrestStick = true
 
+SWEP.PrintName = "Unarrest Baton"
 SWEP.Spawnable = true
 SWEP.Category = "DarkRP (Utility)"
 

--- a/entities/weapons/weapon_ak472/shared.lua
+++ b/entities/weapons/weapon_ak472/shared.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 if CLIENT then
-    SWEP.PrintName = "AK47"
     SWEP.Author = "DarkRP Developers"
     SWEP.Slot = 3
     SWEP.SlotPos = 0
@@ -12,6 +11,7 @@ end
 
 SWEP.Base = "weapon_cs_base2"
 
+SWEP.PrintName = "AK47"
 SWEP.Spawnable = true
 SWEP.AdminOnly = false
 SWEP.Category = "DarkRP (Weapon)"

--- a/entities/weapons/weapon_deagle2/shared.lua
+++ b/entities/weapons/weapon_deagle2/shared.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 if CLIENT then
-    SWEP.PrintName = "Deagle"
     SWEP.Author = "DarkRP Developers"
     SWEP.Slot = 1
     SWEP.SlotPos = 1
@@ -12,6 +11,7 @@ end
 
 SWEP.Base = "weapon_cs_base2"
 
+SWEP.PrintName = "Deagle"
 SWEP.Spawnable = true
 SWEP.AdminOnly = false
 SWEP.Category = "DarkRP (Weapon)"

--- a/entities/weapons/weapon_fiveseven2/shared.lua
+++ b/entities/weapons/weapon_fiveseven2/shared.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 if CLIENT then
-    SWEP.PrintName = "FiveSeven"
     SWEP.Author = "DarkRP Developers"
     SWEP.Slot = 1
     SWEP.SlotPos = 1
@@ -12,6 +11,7 @@ end
 
 SWEP.Base = "weapon_cs_base2"
 
+SWEP.PrintName = "FiveSeven"
 SWEP.Spawnable = true
 SWEP.AdminOnly = false
 SWEP.Category = "DarkRP (Weapon)"

--- a/entities/weapons/weapon_glock2/shared.lua
+++ b/entities/weapons/weapon_glock2/shared.lua
@@ -2,7 +2,6 @@ AddCSLuaFile()
 
 if CLIENT then
     SWEP.Author = "DarkRP Developers"
-    SWEP.PrintName = "Glock"
     SWEP.Instructions = "Shoot with it"
     SWEP.Slot = 1
     SWEP.SlotPos = 0
@@ -13,6 +12,7 @@ end
 
 SWEP.Base = "weapon_cs_base2"
 
+SWEP.PrintName = "Glock"
 SWEP.Spawnable = true
 SWEP.AdminOnly = false
 SWEP.Category = "DarkRP (Weapon)"

--- a/entities/weapons/weapon_m42/shared.lua
+++ b/entities/weapons/weapon_m42/shared.lua
@@ -5,7 +5,6 @@ if CLIENT then
     SWEP.Contact = ""
     SWEP.Purpose = ""
     SWEP.Instructions = ""
-    SWEP.PrintName = "M4"
     SWEP.Instructions = "Hold use and right-click to change firemodes or left-click to attach silencer."
     SWEP.Slot = 2
     SWEP.SlotPos = 0
@@ -16,6 +15,7 @@ end
 
 SWEP.Base = "weapon_cs_base2"
 
+SWEP.PrintName = "M4"
 SWEP.Spawnable = true
 SWEP.AdminOnly = false
 SWEP.Category = "DarkRP (Weapon)"

--- a/entities/weapons/weapon_mac102/shared.lua
+++ b/entities/weapons/weapon_mac102/shared.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 if CLIENT then
-    SWEP.PrintName = "Mac10"
     SWEP.Author = "DarkRP Developers"
     SWEP.Slot = 2
     SWEP.SlotPos = 0
@@ -12,6 +11,7 @@ end
 
 SWEP.Base = "weapon_cs_base2"
 
+SWEP.PrintName = "Mac10"
 SWEP.Spawnable = true
 SWEP.AdminOnly = false
 SWEP.Category = "DarkRP (Weapon)"

--- a/entities/weapons/weapon_mp52/shared.lua
+++ b/entities/weapons/weapon_mp52/shared.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 if CLIENT then
-    SWEP.PrintName = "MP5"
     SWEP.Author = "DarkRP Developers"
     SWEP.Slot = 2
     SWEP.SlotPos = 0
@@ -12,6 +11,7 @@ end
 
 SWEP.Base = "weapon_cs_base2"
 
+SWEP.PrintName = "MP5"
 SWEP.Spawnable = true
 SWEP.AdminOnly = false
 SWEP.Category = "DarkRP (Weapon)"

--- a/entities/weapons/weapon_p2282/shared.lua
+++ b/entities/weapons/weapon_p2282/shared.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 if CLIENT then
-    SWEP.PrintName = "P228"
     SWEP.Author = "DarkRP Developers"
     SWEP.Slot = 1
     SWEP.SlotPos = 1
@@ -12,6 +11,7 @@ end
 
 SWEP.Base = "weapon_cs_base2"
 
+SWEP.PrintName = "P228"
 SWEP.Spawnable = true
 SWEP.AdminOnly = false
 SWEP.Category = "DarkRP (Weapon)"

--- a/entities/weapons/weapon_pumpshotgun2/shared.lua
+++ b/entities/weapons/weapon_pumpshotgun2/shared.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 if CLIENT then
-    SWEP.PrintName = "Pump Shotgun"
     SWEP.Author = "DarkRP Developers"
     SWEP.Slot = 2
     SWEP.SlotPos = 0
@@ -12,6 +11,7 @@ end
 
 DEFINE_BASECLASS("weapon_cs_base2")
 
+SWEP.PrintName = "Pump Shotgun"
 SWEP.Spawnable = true
 SWEP.AdminOnly = false
 SWEP.Category = "DarkRP (Weapon)"

--- a/entities/weapons/weaponchecker/shared.lua
+++ b/entities/weapons/weaponchecker/shared.lua
@@ -1,7 +1,6 @@
 AddCSLuaFile()
 
 if CLIENT then
-    SWEP.PrintName = "Weapon Checker"
     SWEP.Slot = 1
     SWEP.SlotPos = 9
     SWEP.DrawAmmo = false
@@ -18,6 +17,7 @@ SWEP.ViewModelFOV = 62
 SWEP.ViewModelFlip = false
 SWEP.AnimPrefix = "rpg"
 
+SWEP.PrintName = "Weapon Checker"
 SWEP.Spawnable = true
 SWEP.AdminOnly = true
 SWEP.Category = "DarkRP (Utility)"


### PR DESCRIPTION
a) Weapon:GetPrintName() exist for ages now
b) SWEP.PrintName got marked as shared variable (took long enough for Rubat to make a such announcment)

This addresses the issue with `GetPrintName()` returning `"Scripted Weapon"` serverside