### PR TITLE
Utilize Player:GetAllowWeaponsInVehicle() inside Entity:drawOwnableInfo()

### DIFF
--- a/gamemode/modules/doorsystem/cl_doors.lua
+++ b/gamemode/modules/doorsystem/cl_doors.lua
@@ -5,7 +5,7 @@ local red = Color(128, 30, 30, 255)
 
 function meta:drawOwnableInfo()
     local ply = LocalPlayer()
-    if ply:InVehicle() then return end
+    if ply:InVehicle() and not ply:GetAllowWeaponsInVehicle() then return end
 
     -- Look, if you want to change the way door ownership is drawn, don't edit this file, use the hook instead!
     local doorDrawing = hook.Call("HUDDrawDoorData", nil, self)


### PR DESCRIPTION
It disgust me that when i ride someone or just sit on bench i can't see door/car owner info but can see everything else.

![20200216095834_1](https://user-images.githubusercontent.com/6339511/74598373-0a3eca80-50a3-11ea-9415-8f01b4d5e921.jpg)
--------------------------------------
Before
![20200216095838_1](https://user-images.githubusercontent.com/6339511/74598375-1165d880-50a3-11ea-8f07-32f750c0f473.jpg)
After
![20200216095910_1](https://user-images.githubusercontent.com/6339511/74598376-1460c900-50a3-11ea-8771-b3a1824c7308.jpg)
