### PR TITLE
fixes for the cam library block and more

### DIFF
--- a/gamemode/modules/workarounds/sh_workarounds.lua
+++ b/gamemode/modules/workarounds/sh_workarounds.lua
@@ -87,7 +87,7 @@ timer.Simple(3, function()
 end)
 
 if game.SinglePlayer() or GetConVar("sv_lan"):GetBool() then
-    if not DarkRP.disabledDefaults["workarounds"]["nil SteamID64 and AccountID local server fix"] then return
+    if not DarkRP.disabledDefaults["workarounds"]["nil SteamID64 and AccountID local server fix"] then
         local plyMeta = FindMetaTable("Player")
 
         if SERVER then
@@ -108,69 +108,60 @@ end
 
 
 if CLIENT and not DarkRP.disabledDefaults["workarounds"]["Cam function descriptive errors"] then
-	local cams3D, cams2D = 0, 0
-	local cam_Start = cam.Start
-	cam.Start=function(tbl, ...)
-		-- https://github.com/Facepunch/garrysmod-issues/issues/3361
-		if (not istable(tbl)) then
-		   argError(tbl, 1, "table")
-		end
-		if tbl.type=="3D" then
-			cams3D=cams3D+1
-		elseif tbl.type == "2D" then
-			cams2D=cams2D+1
-		else
-			error("bad argument #1 to '%s' (bad key 'type' - 2D or 3D expected, got %s)",debug.getinfo(1,"n").name,tbl.type, 2)
-		end
-		-- Could pcall this but it'd be impossible to
-		-- tell if a render instance was created or not.
-		-- Assume creation/deletion
-		return cam_Start(tbl,...)
-	end
-	local cam_Start3D,cam_End3D = cam.Start3D,cam.End3D
-	cam.Start2D=function(...)
-		cams2D = cams2D + 1
-		return cam_Start2D(...)
-	end
-	cam.End3D=function(...)
-		if cams3D == 0 then
-			error("tried to end invalid render instance", 2)
-		end
-		cams3D = cams3D - 1
-		return cam_End3D(...)
-	end
-	cam.End=function(...)--wiki says this is an alias of cam.End3D
-		if cams3D == 0 then
-			error("tried to end invalid render instance", 2)
-		end
-		cams3D = cams3D - 1
-		return cam_End3D(...)
-	end
-	local cam_Start2D,cam_End2D=cam.Start3D,cam.End2D
-	cam.Start2D=function(...)
-		cams2D = cams2D + 1
-		return cam_Start2D(...)
-	end
-	cam.End2D=function(...)
-		if cams2D == 0 then
-			error("tried to end invalid render instance", 2)
-		end
-		cams2D = cams2D - 1
-		return cam_End2D(...)
-	end
-	local cams3D2D = 0
-	local cam_Start3D2D,cam_End3D2D=cam.Start3D2D,cam.End3D2D
-	cam.Start3D2D=function(...)
-		cams3D2D = cams3D2D + 1
-		return cam_Start3D2D(...)
-	end
-	cam.End3D2D=function(...)
-		if cams3D2D == 0 then
-			error("tried to end invalid render instance", 2)
-		end
-		cams3D2D = cams3D2D - 1
-		return cam_End2D(...)
-	end
+    local cams3D, cams2D = 0, 0
+    local cam_Start = cam.Start
+    function cam.Start(tbl, ...)
+        -- https://github.com/Facepunch/garrysmod-issues/issues/3361
+        if (not istable(tbl)) then
+           argError(tbl, 1, "table")
+        end
+
+        if (tbl.type == "3D") then
+            cams3D = cams3D + 1
+        elseif (tbl.type == "2D") then
+            cams2D = cams2D + 1
+        else
+            error("bad argument #1 to '%s' (bad key 'type' - 2D or 3D expected, got %s)", debug.getinfo(1, "n").name, tbl.type, 2)
+        end
+
+        -- Could pcall this but it'd be impossible to
+        -- tell if a render instance was created or not.
+        -- Assume creation/deletion
+        return cam_Start(tbl, ...)
+    end
+    local cam_End3D = cam.End3D
+    function cam.End3D(...)
+        if (cams3D == 0) then
+            error("tried to end invalid render instance", 2)
+        end
+        cams3D = cams3D - 1
+        return cam_End3D(...)
+    end
+    cam.End=cam.End3D
+    local cam_End2D = cam.End2D
+    function cam.End2D(...)
+        if (cams2D == 0) then
+            error("tried to end invalid render instance", 2)
+        end
+        cams2D = cams2D - 1
+        return cam_End2D(...)
+    end
+
+    local cams3D2D = 0
+    local cam_Start3D2D = cam.Start3D2D
+
+    function cam.Start3D2D(...)
+        cams3D2D = cams3D2D + 1
+        return cam_Start3D2D(...)
+    end
+    local cam_End3D2D=cam.End3D2D
+    function cam.End3D2D(...)
+        if (cams3D2D == 0) then
+            error("tried to end invalid render instance", 2)
+        end
+        cams3D2D = cams3D2D - 1
+        return cam_End3D2D(...)
+    end
 end
 
 if SERVER and not DarkRP.disabledDefaults["workarounds"]["Error on edict limit"] then


### PR DESCRIPTION
the way the block that contains the cam library detours was setup prevented the rest of the file from being read by the client,
also some of the blocks could also prevent the rest of the file from being read.