### PR TITLE
Update sv_doors.lua

### DIFF
--- a/gamemode/modules/doorsystem/sv_doors.lua
+++ b/gamemode/modules/doorsystem/sv_doors.lua
@@ -430,7 +430,7 @@ local function UnOwnAll(ply, cmd, args)
 
     local unownables = {}
     for entIndex, ent in pairs(ply.Ownedz or {}) do
-        if not ent:isKeysOwnable() then ply.Ownedz[entIndex] = nil continue end
+        if not ent:isKeysOwnable() or ent:IsVehicle() then ply.Ownedz[entIndex] = nil continue end
         table.insert(unownables, ent)
     end
 


### PR DESCRIPTION
Stoping vehicle doors from being sold on job-change or unownalldoors as it will cost the player to rebuy the doors or he/her could lose the ownership of his/her car.