### PR TITLE
Bugfix for ULib's prioritized hook system

### DIFF
--- a/gamemode/modules/chat/sv_chat.lua
+++ b/gamemode/modules/chat/sv_chat.lua
@@ -123,6 +123,112 @@ function GM:canChatCommand(ply, cmd, ...)
 end
 
 GM.OldChatHooks = GM.OldChatHooks or {}
+
+local function callHooks(hooks, canReturn, ...)
+    local text
+
+    for id, f in pairs(hooks) do
+        local isString
+
+        -- ULib hook tables are {fn = func, isstring = istring(id)}
+        if istable(f) then
+            isString = f.isstring
+            f = f.fn
+        else
+            isString = isstring(id)
+        end
+
+        if not isfunction(f) then continue end
+
+        if not isString then
+            -- Non valid hooks are removed, as entities don't become valid after being non-valid
+            if IsValid(id) then
+                text = f(id, ...)
+            else
+                GAMEMODE.OldChatHooks[id] = nil
+            end
+        else
+            text = f(...)
+        end
+
+        if text and canReturn then return text end
+    end
+end
+
+local function callPlayerSayHooks(ply, text, teamonly, dead)
+    if ULib then
+        -- Run through priorities in order
+        for priority = -2, 2 do
+            local hooks = GAMEMODE.OldChatHooks[priority]
+            -- Monitor hooks cannot return
+            local canReturn = priority > -2 and priority < 2
+
+            callHooks(hooks, canReturn, ply, text, teamonly, dead)
+        end
+    else
+        callHooks(GAMEMODE.OldChatHooks, true, ply, text, teamonly, dead)
+    end
+end
+
+local function applyHookTable(tab, priority)
+    -- Set the metatable of the PlayerSay hook table
+    -- This will monitor any hooks that get added or removed
+    -- This is more efficient than overriding hook.Add and hook.Remove because it only adds logic to the PlayerSay hooks.
+    -- If a previous metatable exists, then add this one to the "chain"
+    local mt
+    local oldMetatable = getmetatable(tab)
+    if istable(oldMetatable) then
+        local oldNI = oldMetatable.__newindex or function() end
+
+        mt = oldMetatable
+        if priority then
+            mt.__newindex = function(t, k, v)
+                GAMEMODE.OldChatHooks[priority][k] = v
+                oldNI(t, k, v)
+            end
+        else
+            mt.__newindex = function(t, k, v)
+                GAMEMODE.OldChatHooks[k] = v
+                oldNI(t, k, v)
+            end
+        end
+    else
+        if priority then
+            mt = {
+                __newindex = function(_, k, v)
+                    GAMEMODE.OldChatHooks[priority][k] = v
+                end
+            }
+        else
+            mt = {
+                __newindex = function(_, k, v)
+                    GAMEMODE.OldChatHooks[k] = v
+                end
+            }
+        end
+    end
+
+    if priority then
+        mt.__index = function(tbl, k)
+            return GAMEMODE.OldChatHooks[priority][k]
+        end
+    else
+        mt.__index = function(tbl, k)
+            return GAMEMODE.OldChatHooks[k]
+        end
+    end
+
+    -- Someone preventing metatable changes
+    -- My metatable swap should be compatible.
+    -- This is a public table. Play nice, you cunt.
+    if oldMetatable ~= nil then
+        DarkRP.errorNoHalt("Some addon is fucking up DarkRP's chat hook reorganising mechanism. Start getting rid of scripts and addons until you don't see this error on startup anymore.")
+        return
+    end
+
+    setmetatable(tab, mt)
+end
+
 function GM:PlayerSay(ply, text, teamonly) -- We will make the old hooks run AFTER DarkRP's playersay has been run.
     local dead = not ply:Alive()
 
@@ -130,15 +236,7 @@ function GM:PlayerSay(ply, text, teamonly) -- We will make the old hooks run AFT
     local callback
     local DoSayFunc
 
-    for k, v in pairs(self.OldChatHooks) do
-        if not isfunction(v) then continue end
-
-        if isentity(k) then
-            text2 = v(k, ply, text, teamonly, dead) or text2
-        else
-            text2 = v(ply, text, teamonly, dead) or text2
-        end
-    end
+    text2 = callPlayerSayHooks(ply, text, teamonly, dead) or text2
 
     text2, callback, DoSayFunc = RP_PlayerChat(ply, text2, teamonly)
     if tostring(text2) == " " then text2, callback = callback, text2 end
@@ -173,59 +271,28 @@ local function ReplaceChatHooks()
     local warning = fn.Compose{ErrorNoHalt, fn.Curry(string.format, 2)("Chat command \"%s\" is defined but not declared!\n")}
     fn.ForEach(warning, DarkRP.getIncompleteChatCommands())
 
+    if ULib then
+        local ulibTbl = hook.GetULibTable()
+        -- Make sure the PlayerSay hook table exists
+        hookTbl.PlayerSay = hookTbl.PlayerSay or {}
+        ulibTbl.PlayerSay = ulibTbl.PlayerSay or {[-2] = {}, [-1] = {}, [0] = {}, [1] = {}, [2] = {}}
 
-    -- Make sure the PlayerSay hook table exists
-    hookTbl.PlayerSay = hookTbl.PlayerSay or {}
+        for priority, hooks in pairs(ulibTbl.PlayerSay) do
+            GAMEMODE.OldChatHooks[priority] = GAMEMODE.OldChatHooks[priority] or {}
 
-    -- Set the metatable of the PlayerSay hook table
-    -- This will monitor any hooks that get added or removed
-    -- This is more efficient than overriding hook.Add and hook.Remove because it only adds logic to the PlayerSay hooks.
-    -- If a previous metatable exists, then add this one to the "chain"
-    local mt
-    local oldMetatable = getmetatable(hookTbl.PlayerSay)
-    if istable(oldMetatable) then
-        local oldNI = oldMetatable.__newindex or function() end
-
-        mt = oldMetatable
-        mt.__newindex = function(t, k, v)
-            GAMEMODE.OldChatHooks[k] = v
-            oldNI(t, k, v)
-        end
-    else
-        mt = {
-            __newindex = function(_, k, v)
-                GAMEMODE.OldChatHooks[k] = v
+            for hookName in pairs(hooks) do
+                hooks[hookName] = nil
+                GAMEMODE.OldChatHooks[priority][hookName] = v
             end
-        }
-    end
 
-    mt.__index = function(tbl, k)
-        return GAMEMODE.OldChatHooks[k]
-    end
-
-    -- Someone preventing metatable changes
-    -- My metatable swap should be compatible.
-    -- This is a public table. Play nice, you cunt.
-    if oldMetatable ~= nil then
-        DarkRP.errorNoHalt("Some addon is fucking up DarkRP's chat hook reorganising mechanism. Start getting rid of scripts and addons until you don't see this error on startup anymore.")
-        return
-    end
-    setmetatable(hookTbl.PlayerSay, mt)
-
-    -- Of course ULib already doesn't play nice.
-    -- Their little hook thing never did make it in mainstream gmod
-    if not hook.GetULibTable then return end
-    local ulibTbl = hook.GetULibTable()
-
-    ulibTbl.PlayerSay = ulibTbl.PlayerSay or {[-2] = {}, [-1] = {}, [0] = {}, [1] = {}, [2] = {}}
-
-    for _, hooks in pairs(ulibTbl.PlayerSay) do
-        for hookName in pairs(hooks) do
-            hooks[hookName] = nil
-            GAMEMODE.OldChatHooks[hookName] = v
+            applyHookTable(hooks, priority)
         end
 
-        setmetatable(hooks, mt)
+    else
+        -- Make sure the PlayerSay hook table exists
+        hookTbl.PlayerSay = hookTbl.PlayerSay or {}
+
+        applyHookTable(hookTbl.PlayerSay)
     end
 end
 hook.Add("InitPostEntity", "RemoveChatHooks", ReplaceChatHooks)

--- a/gamemode/modules/chat/sv_chat.lua
+++ b/gamemode/modules/chat/sv_chat.lua
@@ -151,7 +151,7 @@ local function callHooks(hooks, canReturn, ...)
             text = f(...)
         end
 
-        if text and canReturn then return text end
+        if text ~= nil and canReturn then return text end
     end
 end
 
@@ -164,11 +164,11 @@ local function callPlayerSayHooks(ply, text, teamonly, dead)
             local canReturn = priority > -2 and priority < 2
 
             local out = callHooks(hooks, canReturn, ply, text, teamonly, dead)
-            if out then return out end
+            if out ~= nil then return out end
         end
     else
         local out = callHooks(GAMEMODE.OldChatHooks, true, ply, text, teamonly, dead)
-        if out then return out end
+        if out ~= nil then return out end
     end
 end
 


### PR DESCRIPTION
We noticed that DarkRP flattens the priority structure built by ULib, causing hooks not to be ran in the order expected. This caused some issues with other addons.

Fixed by changing the structure of `GAMEMODE.OldChatHooks` to match that of `ULib` if `ULib` is installed.
Actual method of overriding tables remains unchanged, simply overriding the metatables on the hook table.

Can't forsee any negative side-effects, as hooks default to priority `0` or `HOOK_NORMAL`, and thus will run as before.

Tested with and without `ULib`.