### PR TITLE
Remove PreDrawViewModel IsValid check

### DIFF
--- a/entities/weapons/stick_base/shared.lua
+++ b/entities/weapons/stick_base/shared.lua
@@ -90,7 +90,6 @@ function SWEP:Deploy()
 end
 
 function SWEP:PreDrawViewModel(vm)
-    if not IsValid(vm) then return end
     for i = 9, 15 do
         vm:SetSubMaterial(i, "!darkrp/" .. self:GetClass())
     end


### PR DESCRIPTION
To merge when the next update comes out. PreDrawViewModel will now only be called with valid viewmodels: https://github.com/Facepunch/garrysmod-issues/issues/3024