### PR TITLE
Prevent iterating nil table in code from last pull request

### DIFF
--- a/gamemode/modules/chat/sv_chat.lua
+++ b/gamemode/modules/chat/sv_chat.lua
@@ -161,10 +161,11 @@ local function callPlayerSayHooks(ply, text, teamonly, dead)
         for priority = -2, 2 do
             local hooks = GAMEMODE.OldChatHooks[priority]
             -- Monitor hooks cannot return
-            local canReturn = priority > -2 and priority < 2
 
-            local out = callHooks(hooks, canReturn, ply, text, teamonly, dead)
-            if out ~= nil then return out end
+            if hooks then
+                local out = callHooks(hooks, priority > -2 and priority < 2, ply, text, teamonly, dead)
+                if out ~= nil then return out end
+            end
         end
     else
         local out = callHooks(GAMEMODE.OldChatHooks, true, ply, text, teamonly, dead)


### PR DESCRIPTION
Fixes
```
[ERROR] gamemodes/darkrp/gamemode/modules/chat/sv_chat.lua:130: bad argument #1 to 'pairs' (table expected, got nil)
  1. pairs - [C]:-1
   2. callHooks - gamemodes/darkrp/gamemode/modules/chat/sv_chat.lua:130
    3. callPlayerSayHooks - gamemodes/darkrp/gamemode/modules/chat/sv_chat.lua:166
     4. Call - gamemodes/darkrp/gamemode/modules/chat/sv_chat.lua:241
      5. func - addons/hatschat2/lua/hatschat/sv_init.lua:49
       6. unknown - lua/includes/extensions/net.lua:32
```