### PR TITLE
Fix team sorting when a player used /job

### DIFF
--- a/gamemode/modules/fadmin/fadmin/cl_interface/cl_PlayerLists.lua
+++ b/gamemode/modules/fadmin/fadmin/cl_interface/cl_PlayerLists.lua
@@ -8,7 +8,7 @@ local function SortedPairsByFunction(Table, Sorted, SortDown)
     local SortedTable = {}
     for _, v in ipairs(CopyTable) do
         if not IsValid(v.PLY) or not v.PLY[Sorted] then continue end
-        local SortBy = (Sorted ~= "Team" and v.PLY[Sorted](v.PLY)) or team.GetName(v.PLY[Sorted](v.PLY))
+        local SortBy = (Sorted ~= "Team" and v.PLY[Sorted](v.PLY)) or (v.PLY:getDarkRPVar("job") or team.GetName(v.PLY[Sorted](v.PLY)))
         SortedTable[SortBy] = SortedTable[SortBy] or {}
         table.insert(SortedTable[SortBy], v.PLY)
     end


### PR DESCRIPTION
When player like used /job to hide in another job, he's spotted because he's not with others members of the team