### PR TITLE
Fix hardcoded check in door info HUD

### DIFF
--- a/gamemode/modules/doorsystem/cl_doors.lua
+++ b/gamemode/modules/doorsystem/cl_doors.lua
@@ -12,7 +12,7 @@ function meta:drawOwnableInfo()
     if doorDrawing == true then return end
 
     local blocked = self:getKeysNonOwnable()
-    local superadmin = ply:IsSuperAdmin()
+    local access = CAMI.PlayerHasAccess(ply, "DarkRP_ChangeDoorSettings")
     local doorTeams = self:getKeysDoorTeams()
     local doorGroup = self:getKeysDoorGroup()
     local playerOwned = self:isKeysOwned() or table.GetFirstValue(self:getKeysCoOwners() or {}) ~= nil
@@ -53,11 +53,11 @@ function meta:drawOwnableInfo()
 
             table.insert(doorInfo, RPExtraTeams[k].name)
         end
-    elseif blocked and superadmin then
+    elseif blocked and access then
         table.insert(doorInfo, DarkRP.getPhrase("keys_allow_ownership"))
     elseif not blocked then
         table.insert(doorInfo, DarkRP.getPhrase("keys_unowned"))
-        if superadmin then
+        if access then
             table.insert(doorInfo, DarkRP.getPhrase("keys_disallow_ownership"))
         end
     end

--- a/gamemode/modules/doorsystem/cl_doors.lua
+++ b/gamemode/modules/doorsystem/cl_doors.lua
@@ -12,7 +12,7 @@ function meta:drawOwnableInfo()
     if doorDrawing == true then return end
 
     local blocked = self:getKeysNonOwnable()
-    local access = CAMI.PlayerHasAccess(ply, "DarkRP_ChangeDoorSettings") or ply:IsSuperAdmin()
+    local access = FAdmin.Access.PlayerHasPrivilege(ply, "DarkRP_ChangeDoorSettings")
     local doorTeams = self:getKeysDoorTeams()
     local doorGroup = self:getKeysDoorGroup()
     local playerOwned = self:isKeysOwned() or table.GetFirstValue(self:getKeysCoOwners() or {}) ~= nil

--- a/gamemode/modules/doorsystem/cl_doors.lua
+++ b/gamemode/modules/doorsystem/cl_doors.lua
@@ -2,6 +2,19 @@ local meta = FindMetaTable("Entity")
 local black = Color(0, 0, 0, 255)
 local white = Color(255, 255, 255, 200)
 local red = Color(128, 30, 30, 255)
+local access = false
+
+local function updatePrivs()
+    CAMI.PlayerHasAccess(LocalPlayer(), "DarkRP_ChangeDoorSettings", function(b, _)
+        access = b
+    end)
+end
+hook.Add("InitPostEntity", "DarkRP_Doors", updatePrivs)
+
+hook.Add("DarkRPVarChanged", "DarkRP_Doors", function(ply, _, _, _)
+    if ply ~= LocalPlayer() then return end
+    updatePrivs()
+end)
 
 function meta:drawOwnableInfo()
     local ply = LocalPlayer()
@@ -12,7 +25,6 @@ function meta:drawOwnableInfo()
     if doorDrawing == true then return end
 
     local blocked = self:getKeysNonOwnable()
-    local access = FAdmin.Access.PlayerHasPrivilege(ply, "DarkRP_ChangeDoorSettings")
     local doorTeams = self:getKeysDoorTeams()
     local doorGroup = self:getKeysDoorGroup()
     local playerOwned = self:isKeysOwned() or table.GetFirstValue(self:getKeysCoOwners() or {}) ~= nil

--- a/gamemode/modules/doorsystem/cl_doors.lua
+++ b/gamemode/modules/doorsystem/cl_doors.lua
@@ -12,7 +12,7 @@ function meta:drawOwnableInfo()
     if doorDrawing == true then return end
 
     local blocked = self:getKeysNonOwnable()
-    local access = CAMI.PlayerHasAccess(ply, "DarkRP_ChangeDoorSettings")
+    local access = CAMI.PlayerHasAccess(ply, "DarkRP_ChangeDoorSettings") or ply:IsSuperAdmin()
     local doorTeams = self:getKeysDoorTeams()
     local doorGroup = self:getKeysDoorGroup()
     local playerOwned = self:isKeysOwned() or table.GetFirstValue(self:getKeysCoOwners() or {}) ~= nil


### PR DESCRIPTION
By ignoring CAMI permissions, the DarkRP doesn't display an information on the door HUD.
Currently, only superadmins can see the text [keys_disallow_ownership](https://github.com/FPtje/DarkRP/blob/4fd2c3c315427e79bb7624702cfaefe9ad26ac7e/gamemode/modules/language/sh_english.lua#L150). Now, by checking CAMI's `DarkRP_ChangeDoorSettings` permission, other user groups will be able to see the text.