### PR TITLE
Update DarkRP links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # THE GITHUB ISSUES PAGE IS NOT FOR GETTING HELP!
-Remember that! We've got a forum for that kind of stuff. It can be found here:
-https://forum.darkrp.com/
+Remember that! We've got a Discord for that kind of stuff. It can be found here:
+https://discord.com/invite/DYxVExH
 
 # What to do when you have a problem in DarkRP
 

--- a/HELP/Avoid editing core files.txt
+++ b/HELP/Avoid editing core files.txt
@@ -6,9 +6,9 @@ If this isn't possible, it should be MADE possible.
 
 Open an issue on GitHub if there is no
 - DarkRP function that allows you to change DarkRP the way you want:
-	https://wiki.darkrp.com/index.php/Category:Functions
+	https://darkrp.miraheze.org/wiki/Category:Functions
 - DarkRP Hook that allows you to change DarkRP the way you want:
-	https://wiki.darkrp.com/index.php/Category:Hooks
+	https://darkrp.miraheze.org/wiki/Category:Hooks
 
 --[[---------------------------------------------------------------------------
             How to configure

--- a/HELP/DarkRP wiki.txt
+++ b/HELP/DarkRP wiki.txt
@@ -1,6 +1,4 @@
 The official DarkRP wiki can be found at
-https://wiki.darkrp.com/index.php/Main_Page
-
-or just https://darkrp.com/
+https://darkrp.miraheze.org/wiki/Main_Page
 
 You can find out how to make custom jobs, shipments and many other things there!

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 
 [//]: # (DO NOT REMOVE THIS TEMPLATE.)
 [//]: # (GITHUB ISSUES ARE **NOT** FOR HELP)
-[//]: # (GO TO THE FORUMS INSTEAD: https://forum.darkrp.com/ )
+[//]: # (GO TO THE DISCORD INSTEAD: https://discord.com/invite/DYxVExH )
 
 ### Description of the bug
 [//]: # (Describe the issue as accurately as possible)

--- a/gamemode/modules/cssmount.lua
+++ b/gamemode/modules/cssmount.lua
@@ -5,8 +5,8 @@ local texts = {
     "You need to mount CSS",
     "DarkRP will not work without it",
     "Read these pages:",
-    "https://wiki.garrysmod.com/page/Retrieving_content_to_be_mounted_on_a_Dedicated_Server",
-    "https://wiki.garrysmod.com/page/Mounting_Content_on_a_DS"
+    "https://wiki.facepunch.com/gmod/Downloading_Game_Content_to_a_Dedicated_Server",
+    "https://wiki.facepunch.com/gmod/Mounting_Content_on_a_Dedicated_Server"
 }
 
 hook.Add("PlayerInitialSpawn", "CSSCheck", function(ply)


### PR DESCRIPTION
All Garry's Mod/DarkRP wiki links have been updated.

**Note**:  This is a bit off topic but I noticed when I updated the links that it was possible to use `ipairs` instead of `pairs` [here](https://github.com/FPtje/DarkRP/blob/d0f5a6245ea68590dbc712d0780d057010597ae4/gamemode/modules/cssmount.lua#L15).