### PR TITLE
Added darkRPPreGiveWeapon, darkRPPostGiveWeapon

### DIFF
--- a/entities/entities/spawned_weapon/init.lua
+++ b/entities/entities/spawned_weapon/init.lua
@@ -66,6 +66,9 @@ function ENT:Use(activator, caller)
 
     weapon = activator:Give(class, true)
 
+    hook.Call("darkRPPreGiveWeapon", nil, activator, self, weapon)
+    if not IsValid(weapon) then return end
+
     local clip1, clip2 = self.clip1, self.clip2
     if weapon:IsValid() then
         if clip1 and clip1 ~= -1 and weapon:Clip1() ~= -1 then
@@ -94,6 +97,8 @@ function ENT:Use(activator, caller)
         local secAmmo = activator:GetAmmoCount(secondaryAmmoType) + (clip2 or 0)
         activator:SetAmmo(secAmmo, secondaryAmmoType)
     end
+
+    hook.Call("darkRPPostGiveWeapon", nil, activator, self, weapon)
 
     self:DecreaseAmount()
 end

--- a/entities/weapons/weapon_cs_base2/sv_commands.lua
+++ b/entities/weapons/weapon_cs_base2/sv_commands.lua
@@ -122,7 +122,36 @@ DarkRP.hookStub{
     parameters = {
         {
             name = "ply",
-            description = "The player who dropped the weapon.",
+            description = "The player who picks up the weapon.",
+            type = "Player"
+        },
+        {
+            name = "spawned_weapon",
+            description = "The spawned_weapon created from the weapon that is dropped.",
+            type = "Entity"
+        },
+        {
+            name = "real_weapon",
+            description = "The weapon entity. This is not the weapon that will be used by the player!",
+            type = "Weapon"
+        }
+    },
+    returns = {
+        {
+            name = "ShouldntContinue",
+            description = "Whether weapon should be picked up or not.",
+            type = "boolean"
+        }
+    }
+}
+
+DarkRP.hookStub{
+    name = "darkRPPreGiveWeapon",
+    description = "When a player picks up a spawned_weapon and target weapon is already given to the player. You can remove the spawned weapon here, but really shouldn't do. Removing the weapon will prevent spawned_weapon count decrease.",
+    parameters = {
+        {
+            name = "ply",
+            description = "The player who picks up the weapon.",
             type = "Player"
         },
         {
@@ -135,12 +164,27 @@ DarkRP.hookStub{
             description = "The actual weapon that will be used by the player.",
             type = "Weapon"
         }
-    },
-    returns = {
+    }
+}
+
+DarkRP.hookStub{
+    name = "darkRPPostGiveWeapon",
+    description = "When a player picks up a spawned_weapon and target weapon is already given to the player. Called after all spawned_weapon's weapon spawning logic, but before spawned_weapon:DecreaseAmount().",
+    parameters = {
         {
-            name = "ShouldntContinue",
-            description = "Whether weapon should be picked up or not.",
-            type = "boolean"
+            name = "ply",
+            description = "The player who picks up the weapon.",
+            type = "Player"
+        },
+        {
+            name = "spawned_weapon",
+            description = "The spawned_weapon created from the weapon that is dropped.",
+            type = "Entity"
+        },
+        {
+            name = "real_weapon",
+            description = "The actual weapon that will be used by the player.",
+            type = "Weapon"
         }
     }
 }


### PR DESCRIPTION
This will allow other addons to modify weapon given to players.

Example usage: Other addon spawn `spawned_weapon`, giving it it's special meta, which then will apply to newly given weapon to player.