### PR TITLE
More self:GetOwner() localizing

### DIFF
--- a/entities/weapons/door_ram/shared.lua
+++ b/entities/weapons/door_ram/shared.lua
@@ -201,16 +201,20 @@ Desc: +attack1 has been pressed
 function SWEP:PrimaryAttack()
     if not self:GetIronsights() then return end
 
+    local Owner = self:GetOwner()
+    
+    if not IsValid(Owner) then return end
+    
     self:SetNextPrimaryFire(CurTime() + 0.1)
 
-    self:GetOwner():LagCompensation(true)
-    local trace = self:GetOwner():GetEyeTrace()
-    self:GetOwner():LagCompensation(false)
+    Owner:LagCompensation(true)
+    local trace = Owner:GetEyeTrace()
+    Owner:LagCompensation(false)
 
-    local hasRammed = getRamFunction(self:GetOwner(), trace)()
+    local hasRammed = getRamFunction(Owner, trace)()
 
     if SERVER then
-        hook.Call("onDoorRamUsed", GAMEMODE, hasRammed, self:GetOwner(), trace)
+        hook.Call("onDoorRamUsed", GAMEMODE, hasRammed, Owner, trace)
     end
 
     if not hasRammed then return end
@@ -219,9 +223,9 @@ function SWEP:PrimaryAttack()
 
     self:SetTotalUsedMagCount(self:GetTotalUsedMagCount() + 1)
 
-    self:GetOwner():SetAnimation(PLAYER_ATTACK1)
-    self:GetOwner():EmitSound(self.Sound)
-    self:GetOwner():ViewPunch(Angle(-10, math.Round(util.SharedRandom("DarkRP_DoorRam" .. self:EntIndex() .. "_" .. self:GetTotalUsedMagCount(), -5, 5)), 0))
+    Owner:SetAnimation(PLAYER_ATTACK1)
+    Owner:EmitSound(self.Sound)
+    Owner:ViewPunch(Angle(-10, math.Round(util.SharedRandom("DarkRP_DoorRam" .. self:EntIndex() .. "_" .. self:GetTotalUsedMagCount(), -5, 5)), 0))
 end
 
 function SWEP:SecondaryAttack()

--- a/entities/weapons/keys/shared.lua
+++ b/entities/weapons/keys/shared.lua
@@ -98,40 +98,48 @@ local function doKnock(ply, sound)
 end
 
 function SWEP:PrimaryAttack()
-    local trace = self:GetOwner():GetEyeTrace()
+    local Owner = self:GetOwner()
+    
+    if not IsValid(Owner) then return end
+    
+    local trace = Owner:GetEyeTrace()
 
-    if not lookingAtLockable(self:GetOwner(), trace.Entity, trace.HitPos) then return end
+    if not lookingAtLockable(Owner, trace.Entity, trace.HitPos) then return end
 
     self:SetNextPrimaryFire(CurTime() + self.Primary.Delay)
 
     if CLIENT then return end
 
-    if self:GetOwner():canKeysLock(trace.Entity) then
+    if Owner:canKeysLock(trace.Entity) then
         trace.Entity:keysLock() -- Lock the door immediately so it won't annoy people
-        lockUnlockAnimation(self:GetOwner(), self.Sound)
+        lockUnlockAnimation(Owner, self.Sound)
     elseif trace.Entity:IsVehicle() then
-        DarkRP.notify(self:GetOwner(), 1, 3, DarkRP.getPhrase("do_not_own_ent"))
+        DarkRP.notify(Owner, 1, 3, DarkRP.getPhrase("do_not_own_ent"))
     else
-        doKnock(self:GetOwner(), "physics/wood/wood_crate_impact_hard2.wav")
+        doKnock(Owner, "physics/wood/wood_crate_impact_hard2.wav")
     end
 end
 
 function SWEP:SecondaryAttack()
-    local trace = self:GetOwner():GetEyeTrace()
+    local Owner = self:GetOwner()
+    
+    if not IsValid(Owner) then return end
+    
+    local trace = Owner:GetEyeTrace()
 
-    if not lookingAtLockable(self:GetOwner(), trace.Entity, trace.HitPos) then return end
+    if not lookingAtLockable(Owner, trace.Entity, trace.HitPos) then return end
 
     self:SetNextSecondaryFire(CurTime() + self.Secondary.Delay)
 
     if CLIENT then return end
 
-    if self:GetOwner():canKeysUnlock(trace.Entity) then
+    if Owner:canKeysUnlock(trace.Entity) then
         trace.Entity:keysUnLock() -- Unlock the door immediately so it won't annoy people
-        lockUnlockAnimation(self:GetOwner(), self.Sound)
+        lockUnlockAnimation(Owner, self.Sound)
     elseif trace.Entity:IsVehicle() then
-        DarkRP.notify(self:GetOwner(), 1, 3, DarkRP.getPhrase("do_not_own_ent"))
+        DarkRP.notify(Owner, 1, 3, DarkRP.getPhrase("do_not_own_ent"))
     else
-        doKnock(self:GetOwner(), "physics/wood/wood_crate_impact_hard3.wav")
+        doKnock(Owner, "physics/wood/wood_crate_impact_hard3.wav")
     end
 end
 

--- a/entities/weapons/med_kit/shared.lua
+++ b/entities/weapons/med_kit/shared.lua
@@ -36,17 +36,21 @@ SWEP.Secondary.Ammo = "none"
 
 function SWEP:PrimaryAttack()
     self:SetNextPrimaryFire(CurTime() + self.Primary.Delay)
-
+    
+    local Owner = self:GetOwner()
+    
+    if not IsValid(Owner) then return end
+    
     local found
     local lastDot = -1 -- the opposite of what you're looking at
-    self:GetOwner():LagCompensation(true)
-    local aimVec = self:GetOwner():GetAimVector()
-    local shootPos = self:GetOwner():GetShootPos()
+    Owner:LagCompensation(true)
+    local aimVec = Owner:GetAimVector()
+    local shootPos = Owner:GetShootPos()
 
     for _, v in ipairs(player.GetAll()) do
         local maxhealth = v:GetMaxHealth() or 100
         local targetShootPos = v:GetShootPos()
-        if v == self:GetOwner() or targetShootPos:DistToSqr(shootPos) > 7225 or v:Health() >= maxhealth or not v:Alive() then continue end
+        if v == Owner or targetShootPos:DistToSqr(shootPos) > 7225 or v:Health() >= maxhealth or not v:Alive() then continue end
 
         local direction = targetShootPos - shootPos
         direction:Normalize()
@@ -58,7 +62,7 @@ function SWEP:PrimaryAttack()
             found = v
         end
     end
-    self:GetOwner():LagCompensation(false)
+    Owner:LagCompensation(false)
 
     if found then
         found:SetHealth(found:Health() + 1)

--- a/entities/weapons/pocket/shared.lua
+++ b/entities/weapons/pocket/shared.lua
@@ -71,41 +71,49 @@ function SWEP:PrimaryAttack()
 
     if not SERVER then return end
 
-    local ent = self:GetOwner():GetEyeTrace().Entity
-    local canPickup, message = hook.Call("canPocket", GAMEMODE, self:GetOwner(), ent)
+    local Owner = self:GetOwner()
+
+    if not IsValid(Owner) then return end
+    
+    local ent = Owner:GetEyeTrace().Entity
+    local canPickup, message = hook.Call("canPocket", GAMEMODE, Owner, ent)
 
     if not canPickup then
-        if message then DarkRP.notify(self:GetOwner(), 1, 4, message) end
+        if message then DarkRP.notify(Owner, 1, 4, message) end
         return
     end
 
-    self:GetOwner():addPocketItem(ent)
+    Owner:addPocketItem(ent)
 end
 
 function SWEP:SecondaryAttack()
     if not SERVER then return end
 
+    local Owner = self:GetOwner()
+
+    if not IsValid(Owner) then return end
+    
     local maxK = 0
 
-    for k in pairs(self:GetOwner():getPocketItems()) do
+    for k in pairs(Owner:getPocketItems()) do
         if k < maxK then continue end
         maxK = k
     end
 
     if maxK == 0 then
-        DarkRP.notify(self:GetOwner(), 1, 4, DarkRP.getPhrase("pocket_no_items"))
+        DarkRP.notify(Owner, 1, 4, DarkRP.getPhrase("pocket_no_items"))
         return
     end
 
     if SERVER then
-        local canPickup, message = hook.Call("canDropPocketItem", nil, self:GetOwner(), maxK, self:GetOwner().darkRPPocket[maxK])
+        local canPickup, message = hook.Call("canDropPocketItem", nil, Owner, maxK, Owner.darkRPPocket[maxK])
         if canPickup == false then
-            if message then DarkRP.notify(self:GetOwner(), 1, 4, message) end
+            if message then DarkRP.notify(Owner, 1, 4, message) end
             return
         end
     end
 
-    self:GetOwner():dropPocketItem(maxK)
+    Owner:dropPocketItem(maxK)
 end
 
 function SWEP:Reload()

--- a/entities/weapons/stunstick/shared.lua
+++ b/entities/weapons/stunstick/shared.lua
@@ -106,27 +106,31 @@ local entMeta = FindMetaTable("Entity")
 function SWEP:DoAttack(dmg)
     if CLIENT then return end
 
-    self:GetOwner():LagCompensation(true)
-    local trace = util.QuickTrace(self:GetOwner():EyePos(), self:GetOwner():GetAimVector() * 90, {self:GetOwner()})
-    self:GetOwner():LagCompensation(false)
+    local Owner = self:GetOwner()
+
+    if not IsValid(Owner) then return end
+    
+    Owner:LagCompensation(true)
+    local trace = util.QuickTrace(Owner:EyePos(), Owner:GetAimVector() * 90, {Owner})
+    Owner:LagCompensation(false)
 
     local ent = trace.Entity
     if IsValid(ent) and ent.onStunStickUsed then
-        ent:onStunStickUsed(self:GetOwner())
+        ent:onStunStickUsed(Owner)
         return
     elseif IsValid(ent) and ent:GetClass() == "func_breakable_surf" then
         ent:Fire("Shatter")
-        self:GetOwner():EmitSound(self.Hit[math.random(#self.Hit)])
+        Owner:EmitSound(self.Hit[math.random(#self.Hit)])
         return
     end
 
     self.WaitingForAttackEffect = true
 
-    local ent = self:GetOwner():getEyeSightHitEntity(
+    local ent = Owner:getEyeSightHitEntity(
         self.stickRange,
         15,
         fn.FAnd{
-            fp{fn.Neq, self:GetOwner()},
+            fp{fn.Neq, Owner},
             fc{IsValid, entMeta.GetPhysicsObject},
             entMeta.IsSolid
         }
@@ -136,27 +140,27 @@ function SWEP:DoAttack(dmg)
     if ent:IsPlayer() and not ent:Alive() then return end
 
     if not ent:isDoor() then
-        ent:SetVelocity((ent:GetPos() - self:GetOwner():GetPos()) * 7)
+        ent:SetVelocity((ent:GetPos() - Owner:GetPos()) * 7)
     end
 
     if dmg > 0 then
-        ent:TakeDamage(dmg, self:GetOwner(), self)
+        ent:TakeDamage(dmg, Owner, self)
     end
 
     if ent:IsPlayer() or ent:IsNPC() or ent:IsVehicle() then
         self:DoFlash(ent)
-        self:GetOwner():EmitSound(self.FleshHit[math.random(#self.FleshHit)])
+        Owner:EmitSound(self.FleshHit[math.random(#self.FleshHit)])
     else
-        self:GetOwner():EmitSound(self.Hit[math.random(#self.Hit)])
-        if FPP and FPP.plyCanTouchEnt(self:GetOwner(), ent, "EntityDamage") then
-            if ent.SeizeReward and not ent.beenSeized and not ent.burningup and self:GetOwner():isCP() and ent.Getowning_ent and self:GetOwner() ~= ent:Getowning_ent() then
-                local amount = isfunction(ent.SeizeReward) and ent:SeizeReward(self:GetOwner(), dmg) or ent.SeizeReward
+        Owner:EmitSound(self.Hit[math.random(#self.Hit)])
+        if FPP and FPP.plyCanTouchEnt(Owner, ent, "EntityDamage") then
+            if ent.SeizeReward and not ent.beenSeized and not ent.burningup and Owner:isCP() and ent.Getowning_ent and Owner ~= ent:Getowning_ent() then
+                local amount = isfunction(ent.SeizeReward) and ent:SeizeReward(Owner, dmg) or ent.SeizeReward
 
-                self:GetOwner():addMoney(amount)
-                DarkRP.notify(self:GetOwner(), 1, 4, DarkRP.getPhrase("you_received_x", DarkRP.formatMoney(amount), DarkRP.getPhrase("bonus_destroying_entity")))
+                Owner:addMoney(amount)
+                DarkRP.notify(Owner, 1, 4, DarkRP.getPhrase("you_received_x", DarkRP.formatMoney(amount), DarkRP.getPhrase("bonus_destroying_entity")))
                 ent.beenSeized = true
             end
-            ent:TakeDamage(1000-dmg, self:GetOwner(), self) -- for illegal entities
+            ent:TakeDamage(1000-dmg, Owner, self) -- for illegal entities
         end
     end
 end

--- a/entities/weapons/unarrest_stick/shared.lua
+++ b/entities/weapons/unarrest_stick/shared.lua
@@ -59,35 +59,39 @@ function SWEP:PrimaryAttack()
 
     if CLIENT then return end
 
-    self:GetOwner():LagCompensation(true)
-    local trace = util.QuickTrace(self:GetOwner():EyePos(), self:GetOwner():GetAimVector() * 90, {self:GetOwner()})
-    self:GetOwner():LagCompensation(false)
+    local Owner = self:GetOwner()
+
+    if not IsValid(Owner) then return end
+    
+    Owner:LagCompensation(true)
+    local trace = util.QuickTrace(Owner:EyePos(), Owner:GetAimVector() * 90, {Owner})
+    Owner:LagCompensation(false)
 
     local ent = trace.Entity
     if IsValid(ent) and ent.onUnArrestStickUsed then
-        ent:onUnArrestStickUsed(self:GetOwner())
+        ent:onUnArrestStickUsed(Owner)
         return
     end
 
-    ent = self:GetOwner():getEyeSightHitEntity(nil, nil, function(p) return p ~= self:GetOwner() and p:IsPlayer() and p:Alive() and p:IsSolid() end)
+    ent = Owner:getEyeSightHitEntity(nil, nil, function(p) return p ~= Owner and p:IsPlayer() and p:Alive() and p:IsSolid() end)
     if not ent then return end
 
     local stickRange = self.stickRange * self.stickRange
-    if not IsValid(ent) or not ent:IsPlayer() or (self:GetOwner():EyePos():DistToSqr(ent:GetPos()) > stickRange) or not ent:getDarkRPVar("Arrested") then
+    if not IsValid(ent) or not ent:IsPlayer() or (Owner:EyePos():DistToSqr(ent:GetPos()) > stickRange) or not ent:getDarkRPVar("Arrested") then
         return
     end
 
-    local canUnarrest, message = hook.Call("canUnarrest", hookCanUnarrest, self:GetOwner(), ent)
+    local canUnarrest, message = hook.Call("canUnarrest", hookCanUnarrest, Owner, ent)
     if not canUnarrest then
-        if message then DarkRP.notify(self:GetOwner(), 1, 5, message) end
+        if message then DarkRP.notify(Owner, 1, 5, message) end
         return
     end
 
-    ent:unArrest(self:GetOwner())
-    DarkRP.notify(ent, 0, 4, DarkRP.getPhrase("youre_unarrested_by", self:GetOwner():Nick()))
+    ent:unArrest(Owner)
+    DarkRP.notify(ent, 0, 4, DarkRP.getPhrase("youre_unarrested_by", Owner:Nick()))
 
-    if self:GetOwner().SteamName then
-        DarkRP.log(self:GetOwner():Nick() .. " (" .. self:GetOwner():SteamID() .. ") unarrested " .. ent:Nick(), Color(0, 255, 255))
+    if Owner.SteamName then
+        DarkRP.log(Owner:Nick() .. " (" .. Owner:SteamID() .. ") unarrested " .. ent:Nick(), Color(0, 255, 255))
     end
 end
 

--- a/entities/weapons/weapon_cs_base2/shared.lua
+++ b/entities/weapons/weapon_cs_base2/shared.lua
@@ -161,19 +161,23 @@ function SWEP:PrimaryAttack()
 
     if self:GetBurstBulletNum() > 0 and CurTime() < self:GetBurstTime() then return end
 
-    if self.MultiMode and self:GetOwner():KeyDown(IN_USE) then
+    local Owner = self:GetOwner()
+
+    if not IsValid(Owner) then return end
+    
+    if self.MultiMode and Owner:KeyDown(IN_USE) then
         if self:GetFireMode() == "semi" then
             self:SetFireMode("burst")
             self.Primary.Automatic = false
-            self:GetOwner():PrintMessage(HUD_PRINTCENTER, DarkRP.getPhrase("switched_burst"))
+            Owner:PrintMessage(HUD_PRINTCENTER, DarkRP.getPhrase("switched_burst"))
         elseif self:GetFireMode() == "burst" then
             self:SetFireMode("auto")
             self.Primary.Automatic = true
-            self:GetOwner():PrintMessage(HUD_PRINTCENTER, DarkRP.getPhrase("switched_fully_auto"))
+            Owner:PrintMessage(HUD_PRINTCENTER, DarkRP.getPhrase("switched_fully_auto"))
         elseif self:GetFireMode() == "auto" then
             self:SetFireMode("semi")
             self.Primary.Automatic = false
-            self:GetOwner():PrintMessage(HUD_PRINTCENTER, DarkRP.getPhrase("switched_semi_auto"))
+            Owner:PrintMessage(HUD_PRINTCENTER, DarkRP.getPhrase("switched_semi_auto"))
         end
         self:SetNextPrimaryFire(CurTime() + 0.5)
         self:SetNextSecondaryFire(CurTime() + 0.5)
@@ -219,32 +223,35 @@ function SWEP:PrimaryAttack()
 
     self:SetLastPrimaryAttack(CurTime())
 
-    if self:GetOwner():IsNPC() then return end
+    if Owner:IsNPC() then return end
 
     -- Punch the player's view
-    self:GetOwner():ViewPunch(Angle(util.SharedRandom("DarkRP_CSBase" .. self:EntIndex() .. "Mag" .. self:GetTotalUsedMagCount() .. "p" .. self:Clip1(), -1.2, -1.1) * self.Primary.Recoil, util.SharedRandom("DarkRP_CSBase" .. self:EntIndex() .. "Mag" .. self:GetTotalUsedMagCount() .. "y" .. self:Clip1(), -1.1, 1.1) * self.Primary.Recoil, 0))
+    Owner:ViewPunch(Angle(util.SharedRandom("DarkRP_CSBase" .. self:EntIndex() .. "Mag" .. self:GetTotalUsedMagCount() .. "p" .. self:Clip1(), -1.2, -1.1) * self.Primary.Recoil, util.SharedRandom("DarkRP_CSBase" .. self:EntIndex() .. "Mag" .. self:GetTotalUsedMagCount() .. "y" .. self:Clip1(), -1.1, 1.1) * self.Primary.Recoil, 0))
 end
 
 function SWEP:CSShootBullet(dmg, recoil, numbul, cone)
-    if not IsValid(self:GetOwner()) then return end
+     local Owner = self:GetOwner()
+
+    if not IsValid(Owner) then return end
+    
     numbul = numbul or 1
     cone = cone or 0.01
 
     local bullet = {}
     bullet.Num = numbul or 1
-    bullet.Src = self:GetOwner():GetShootPos()   -- Source
-    bullet.Dir = (self:GetOwner():GetAimVector():Angle() + self:GetOwner():GetViewPunchAngles()):Forward() -- Dir of bullet
+    bullet.Src = Owner:GetShootPos()   -- Source
+    bullet.Dir = (Owner:GetAimVector():Angle() + Owner:GetViewPunchAngles()):Forward() -- Dir of bullet
     bullet.Spread = Vector(cone, cone, 0)        -- Aim Cone
     bullet.Tracer = 4                            -- Show a tracer on every x bullets
     bullet.Force = 5                             -- Amount of force to give to phys objects
     bullet.Damage = dmg
 
-    self:GetOwner():FireBullets(bullet)
+    Owner:FireBullets(bullet)
     self:SendWeaponAnim(ACT_VM_PRIMARYATTACK)    -- View model animation
-    self:GetOwner():MuzzleFlash()                -- Crappy muzzle light
-    self:GetOwner():SetAnimation(PLAYER_ATTACK1) -- 3rd Person Animation
+    Owner:MuzzleFlash()                -- Crappy muzzle light
+    Owner:SetAnimation(PLAYER_ATTACK1) -- 3rd Person Animation
 
-    if self:GetOwner():IsNPC() then return end
+    if Owner:IsNPC() then return end
 
     -- Part of workaround, different viewmodel position if shots have been fired
     if CLIENT then self.hasShot = true end

--- a/entities/weapons/weaponchecker/shared.lua
+++ b/entities/weapons/weaponchecker/shared.lua
@@ -152,12 +152,16 @@ function SWEP:PrimaryAttack()
     if self:GetIsWeaponChecking() then return end
     self:SetNextPrimaryFire(CurTime() + 0.3)
 
-    self:GetOwner():LagCompensation(true)
-    local trace = self:GetOwner():GetEyeTrace()
-    self:GetOwner():LagCompensation(false)
+    local Owner = self:GetOwner()
+
+    if not IsValid(Owner) then return end
+    
+    Owner:LagCompensation(true)
+    local trace = Owner:GetEyeTrace()
+    Owner:LagCompensation(false)
 
     local ent = trace.Entity
-    if not IsValid(ent) or not ent:IsPlayer() or ent:GetPos():DistToSqr(self:GetOwner():GetPos()) > 10000 then
+    if not IsValid(ent) or not ent:IsPlayer() or ent:GetPos():DistToSqr(Owner:GetPos()) > 10000 then
         return
     end
 
@@ -171,7 +175,7 @@ function SWEP:PrimaryAttack()
         table.insert(weps, wep)
     end)
 
-    hook.Call("playerWeaponsChecked", nil, self:GetOwner(), ent, weps)
+    hook.Call("playerWeaponsChecked", nil, Owner, ent, weps)
 
     if not CLIENT then return end
 
@@ -182,12 +186,16 @@ function SWEP:SecondaryAttack()
     if self:GetIsWeaponChecking() then return end
     self:SetNextSecondaryFire(CurTime() + 0.3)
 
-    self:GetOwner():LagCompensation(true)
-    local trace = self:GetOwner():GetEyeTrace()
-    self:GetOwner():LagCompensation(false)
+    local Owner = self:GetOwner()
+
+    if not IsValid(Owner) then return end
+    
+    Owner:LagCompensation(true)
+    local trace = Owner:GetEyeTrace()
+    Owner:LagCompensation(false)
 
     local ent = trace.Entity
-    if not IsValid(ent) or not ent:IsPlayer() or ent:GetPos():DistToSqr(self:GetOwner():GetPos()) > 10000 then
+    if not IsValid(ent) or not ent:IsPlayer() or ent:GetPos():DistToSqr(Owner:GetPos()) > 10000 then
         return
     end
 
@@ -208,15 +216,19 @@ function SWEP:Reload()
     if CLIENT or CurTime() < (self.NextReloadTime or 0) then return end
     self.NextReloadTime = CurTime() + 1
 
-    local trace = self:GetOwner():GetEyeTrace()
+    local Owner = self:GetOwner()
+
+    if not IsValid(Owner) then return end
+    
+    local trace = Owner:GetEyeTrace()
 
     local ent = trace.Entity
-    if not IsValid(ent) or not ent:IsPlayer() or ent:GetPos():DistToSqr(self:GetOwner():GetPos()) > 10000 then
+    if not IsValid(ent) or not ent:IsPlayer() or ent:GetPos():DistToSqr(Owner:GetPos()) > 10000 then
         return
     end
 
     if not ent.ConfiscatedWeapons then
-        DarkRP.notify(self:GetOwner(), 1, 4, DarkRP.getPhrase("no_weapons_confiscated", ent:Nick()))
+        DarkRP.notify(Owner, 1, 4, DarkRP.getPhrase("no_weapons_confiscated", ent:Nick()))
         return
     else
         ent:RemoveAllAmmo()
@@ -234,9 +246,9 @@ function SWEP:Reload()
             wep:SetClip2(v.clip2)
 
         end
-        DarkRP.notify(self:GetOwner(), 2, 4, DarkRP.getPhrase("returned_persons_weapons", ent:Nick()))
+        DarkRP.notify(Owner, 2, 4, DarkRP.getPhrase("returned_persons_weapons", ent:Nick()))
 
-        hook.Call("playerWeaponsReturned", nil, self:GetOwner(), ent, ent.ConfiscatedWeapons)
+        hook.Call("playerWeaponsReturned", nil, Owner, ent, ent.ConfiscatedWeapons)
         ent.ConfiscatedWeapons = nil
     end
 end
@@ -299,6 +311,10 @@ function SWEP:Succeed()
 end
 
 function SWEP:PrintWeapons(ent, weaponsFoundPhrase)
+    local Owner = self:GetOwner()
+
+    if not IsValid(Owner) then return end
+    
     local result = {}
     local weps = {}
     self:GetStrippableWeapons(ent, function(wep)
@@ -312,18 +328,18 @@ function SWEP:PrintWeapons(ent, weaponsFoundPhrase)
     result = table.concat(result, ", ")
 
     if result == "" then
-        self:GetOwner():ChatPrint(DarkRP.getPhrase("no_illegal_weapons", ent:Nick()))
+        Owner:ChatPrint(DarkRP.getPhrase("no_illegal_weapons", ent:Nick()))
         return
     end
 
-    self:GetOwner():ChatPrint(weaponsFoundPhrase)
+    Owner:ChatPrint(weaponsFoundPhrase)
     if string.len(result) >= 126 then
         local amount = math.ceil(string.len(result) / 126)
         for i = 1, amount, 1 do
-            self:GetOwner():ChatPrint(string.sub(result, (i-1) * 126, i * 126 - 1))
+            Owner:ChatPrint(string.sub(result, (i-1) * 126, i * 126 - 1))
         end
     else
-        self:GetOwner():ChatPrint(result)
+        Owner:ChatPrint(result)
     end
 end
 
@@ -334,11 +350,15 @@ function SWEP:Fail()
 end
 
 function SWEP:Think()
+    local Owner = self:GetOwner()
+
+    if not IsValid(Owner) then return end
+    
     if self:GetIsWeaponChecking() and self:GetEndCheckTime() ~= 0 then
-        self:GetOwner():LagCompensation(true)
-        local trace = self:GetOwner():GetEyeTrace()
-        self:GetOwner():LagCompensation(false)
-        if not IsValid(trace.Entity) or trace.HitPos:DistToSqr(self:GetOwner():GetShootPos()) > 10000 or not trace.Entity:IsPlayer() then
+        Owner:LagCompensation(true)
+        local trace = Owner:GetEyeTrace()
+        Owner:LagCompensation(false)
+        if not IsValid(trace.Entity) or trace.HitPos:DistToSqr(Owner:GetShootPos()) > 10000 or not trace.Entity:IsPlayer() then
             self:Fail()
         end
         if self:GetEndCheckTime() <= CurTime() then


### PR DESCRIPTION
As done [here](https://github.com/FPtje/DarkRP/commit/a7d7fc31afb221705f3b4a4b7019025c1c21a6bb), other localizations could be made in almost all the weapons included in the DarkRP.
Some areas have been intentionally omitted because I think that `self:GetOwner` is not called enough many times to be localized (<2/3 times) and that they are not present in critical areas of the code.