### PR TITLE
Use ipairs instead of pairs in PLAYER:GetWeapons()

### DIFF
--- a/entities/weapons/weaponchecker/shared.lua
+++ b/entities/weapons/weaponchecker/shared.lua
@@ -131,8 +131,7 @@ end
 
 function SWEP:GetStrippableWeapons(ent, callback)
     CAMI.PlayerHasAccess(ent, "DarkRP_GetAdminWeapons", function(access)
-        for _, v in pairs(ent:GetWeapons()) do
-            if not v:IsValid() then continue end
+        for _, v in ipairs(ent:GetWeapons()) do
             local class = v:GetClass()
 
             if GAMEMODE.Config.weaponCheckerHideDefault and (table.HasValue(GAMEMODE.Config.DefaultWeapons, class) or

--- a/gamemode/modules/fadmin/fadmin/playeractions/cloak/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/cloak/sv_init.lua
@@ -8,7 +8,7 @@ local function Cloak(ply, cmd, args)
         if IsValid(target) and not target:FAdmin_GetGlobal("FAdmin_cloaked") then
             target:FAdmin_SetGlobal("FAdmin_cloaked", true)
             target:SetNoDraw(true)
-            for _, v in pairs(target:GetWeapons()) do
+            for _, v in ipairs(target:GetWeapons()) do
                 v:SetNoDraw(true)
             end
 
@@ -36,7 +36,7 @@ local function UnCloak(ply, cmd, args)
 
             target:SetNoDraw(false)
 
-            for _, v in pairs(target:GetWeapons()) do
+            for _, v in ipairs(target:GetWeapons()) do
                 v:SetNoDraw(false)
             end
 

--- a/gamemode/modules/sleep/sv_sleep.lua
+++ b/gamemode/modules/sleep/sv_sleep.lua
@@ -132,7 +132,7 @@ function DarkRP.toggleSleep(player, command)
 
         if not player:isArrested() then
             player.WeaponsForSleep = {}
-            for k, v in pairs(player:GetWeapons()) do
+            for k, v in ipairs(player:GetWeapons()) do
                 player.WeaponsForSleep[k] = {v:GetClass(), player:GetAmmoCount(v:GetPrimaryAmmoType()),
                 v:GetPrimaryAmmoType(), player:GetAmmoCount(v:GetSecondaryAmmoType()), v:GetSecondaryAmmoType(),
                 v:Clip1(), v:Clip2()}


### PR DESCRIPTION
Since [September 2019 update](https://gmod.facepunch.com/blog/september-2019-update) (**see below**), `PLAYER:GetWeapons` returns always a sequential table, so we can use without any problem `ipairs` instead of `pairs` for better performance.

![image](https://user-images.githubusercontent.com/26360935/90315343-16ed8f80-df1b-11ea-92d1-2c2fac5c5b1d.png)

**Note**: This is a revert of [this](https://github.com/FPtje/DarkRP/commit/93a4afb7afe953aea88cb4c77d1e2ef9e1e36309) commit.


 