### PR TITLE
Unclamp the Respawn Time

### DIFF
--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -449,7 +449,7 @@ function GM:PlayerDeath(ply, weapon, killer)
         DarkRP.notify(ply, 4, 4, DarkRP.getPhrase("dead_in_jail"))
     else
         -- Normal death, respawning.
-        ply.NextSpawnTime = CurTime() + math.Clamp(GAMEMODE.Config.respawntime, 0, 10)
+        ply.NextSpawnTime = CurTime() + GAMEMODE.Config.respawntime
     end
     ply.DeathPos = ply:GetPos()
 


### PR DESCRIPTION
Not sure why this is clamped, would make sense to let server owners freely change the respawn time to whatever they want.