### PR TITLE
Change weapon cloak method

### DIFF
--- a/gamemode/modules/fadmin/fadmin/playeractions/cloak/cl_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/cloak/cl_init.lua
@@ -24,3 +24,9 @@ FAdmin.StartHooks["zz_Cloak"] = function()
         button:GetParent():InvalidateLayout()
     end)
 end
+
+hook.Add("DrawPhysgunBeam", "FAdmin_Cloak", function(ply)
+    if not ply:FAdmin_GetGlobal("FAdmin_cloaked") then return end
+
+    return false
+end)

--- a/gamemode/modules/fadmin/fadmin/playeractions/cloak/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/cloak/sv_init.lua
@@ -1,5 +1,3 @@
-local CloakThink
-
 local function Cloak(ply, cmd, args)
     local targets = FAdmin.FindPlayer(args[1]) or {ply}
 
@@ -8,19 +6,10 @@ local function Cloak(ply, cmd, args)
         if IsValid(target) and not target:FAdmin_GetGlobal("FAdmin_cloaked") then
             target:FAdmin_SetGlobal("FAdmin_cloaked", true)
             target:SetNoDraw(true)
+
             for _, v in ipairs(target:GetWeapons()) do
                 v:SetNoDraw(true)
             end
-
-            local children = target:GetChildren()
-            for i = 1, #children do
-                if children[i]:GetClass() == "physgun_beam" then
-                    children[i]:SetNoDraw(true)
-                    break
-                end
-            end
-
-            hook.Add("Think", "FAdmin_Cloak", CloakThink)
         end
     end
     FAdmin.Messages.ActionMessage(ply, targets, "You have cloaked %s", "You were cloaked by %s", "Cloaked %s")
@@ -41,25 +30,6 @@ local function UnCloak(ply, cmd, args)
             for _, v in ipairs(target:GetWeapons()) do
                 v:SetNoDraw(false)
             end
-
-            local children = target:GetChildren()
-            for i = 1, #children do
-                if children[i]:GetClass() == "physgun_beam" then
-                    children[i]:SetNoDraw(false)
-                    break
-                end
-            end
-
-            target.FAdmin_CloakWeapon = nil
-
-            local RemoveThink = true
-            for _, v in ipairs(player.GetAll()) do
-                if v:FAdmin_GetGlobal("FAdmin_cloaked") then
-                    RemoveThink = false
-                    break
-                end
-            end
-            if RemoveThink then hook.Remove("Think", "FAdmin_Cloak") end
         end
     end
     FAdmin.Messages.ActionMessage(ply, targets, "You have uncloaked %s", "You were uncloaked by %s", "Uncloaked %s")
@@ -74,22 +44,7 @@ FAdmin.StartHooks["Cloak"] = function()
     FAdmin.Access.AddPrivilege("Cloak", 2)
 end
 
-function CloakThink()
-    for _, v in ipairs(player.GetAll()) do
-        local ActiveWeapon = v:GetActiveWeapon()
-        if v:FAdmin_GetGlobal("FAdmin_cloaked") and ActiveWeapon:IsValid() and ActiveWeapon ~= v.FAdmin_CloakWeapon then
-            v.FAdmin_CloakWeapon = ActiveWeapon
-            ActiveWeapon:SetNoDraw(true)
-
-            if ActiveWeapon:GetClass() == "weapon_physgun" then
-                local children = v:GetChildren()
-                for i = 1, #children do
-                    if children[i]:GetClass() == "physgun_beam" then
-                        children[i]:SetNoDraw(true)
-                        break
-                    end
-                end
-            end
-        end
-    end
-end
+hook.Add("PlayerSwitchWeapon", "FAdmin_Cloak", function(ply, _, weapon)
+    if not ply:FAdmin_GetGlobal("FAdmin_cloaked") or not IsValid(weapon) then return end
+    weapon:SetNoDraw(true)
+end)

--- a/gamemode/modules/fadmin/fadmin/playeractions/cloak/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/cloak/sv_init.lua
@@ -1,5 +1,3 @@
-local CloakThink
-
 local function Cloak(ply, cmd, args)
     local targets = FAdmin.FindPlayer(args[1]) or {ply}
 
@@ -12,13 +10,13 @@ local function Cloak(ply, cmd, args)
                 v:SetNoDraw(true)
             end
 
-            for _, v in ipairs(ents.FindByClass("physgun_beam")) do
-                if v:GetParent() == target then
-                    v:SetNoDraw(true)
+            local children = target:GetChildren()
+            for i = 1, #children do
+                if children[i]:GetClass() == "physgun_beam" then
+                    children[i]:SetNoDraw(true)
+                    break
                 end
             end
-
-            hook.Add("Think", "FAdmin_Cloak", CloakThink)
         end
     end
     FAdmin.Messages.ActionMessage(ply, targets, "You have cloaked %s", "You were cloaked by %s", "Cloaked %s")
@@ -40,9 +38,11 @@ local function UnCloak(ply, cmd, args)
                 v:SetNoDraw(false)
             end
 
-            for _, v in pairs(ents.FindByClass("physgun_beam")) do
-                if v:GetParent() == target then
-                    v:SetNoDraw(false)
+            local children = target:GetChildren()
+            for i = 1, #children do
+                if children[i]:GetClass() == "physgun_beam" then
+                    children[i]:SetNoDraw(true)
+                    break
                 end
             end
 
@@ -70,20 +70,17 @@ FAdmin.StartHooks["Cloak"] = function()
     FAdmin.Access.AddPrivilege("Cloak", 2)
 end
 
-function CloakThink()
-    for _, v in ipairs(player.GetAll()) do
-        local ActiveWeapon = v:GetActiveWeapon()
-        if v:FAdmin_GetGlobal("FAdmin_cloaked") and ActiveWeapon:IsValid() and ActiveWeapon ~= v.FAdmin_CloakWeapon then
-            v.FAdmin_CloakWeapon = ActiveWeapon
-            ActiveWeapon:SetNoDraw(true)
+hook.Add("PlayerSwitchWeapon", "FAdmin_Cloak", function(ply, _, weapon)
+    if not ply:FAdmin_GetGlobal("FAdmin_cloaked") or not IsValid(weapon) then return end
+    weapon:SetNoDraw(true)
 
-            if ActiveWeapon:GetClass() == "weapon_physgun" then
-                for a,b in ipairs(ents.FindByClass("physgun_beam")) do
-                    if b:GetParent() == v then
-                        b:SetNoDraw(true)
-                    end
-                end
-            end
+    if weapon:GetClass() ~= "weapon_physgun" then return end
+
+    local children = ply:GetChildren()
+    for i = 1, #children do
+        if children[i]:GetClass() == "physgun_beam" then
+            children[i]:SetNoDraw(true)
+            break
         end
     end
-end
+end)

--- a/gamemode/modules/fadmin/fadmin/playeractions/cloak/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/cloak/sv_init.lua
@@ -1,3 +1,5 @@
+local CloakThink
+
 local function Cloak(ply, cmd, args)
     local targets = FAdmin.FindPlayer(args[1]) or {ply}
 
@@ -17,6 +19,8 @@ local function Cloak(ply, cmd, args)
                     break
                 end
             end
+
+            hook.Add("Think", "FAdmin_Cloak", CloakThink)
         end
     end
     FAdmin.Messages.ActionMessage(ply, targets, "You have cloaked %s", "You were cloaked by %s", "Cloaked %s")
@@ -41,7 +45,7 @@ local function UnCloak(ply, cmd, args)
             local children = target:GetChildren()
             for i = 1, #children do
                 if children[i]:GetClass() == "physgun_beam" then
-                    children[i]:SetNoDraw(true)
+                    children[i]:SetNoDraw(false)
                     break
                 end
             end
@@ -70,17 +74,22 @@ FAdmin.StartHooks["Cloak"] = function()
     FAdmin.Access.AddPrivilege("Cloak", 2)
 end
 
-hook.Add("PlayerSwitchWeapon", "FAdmin_Cloak", function(ply, _, weapon)
-    if not ply:FAdmin_GetGlobal("FAdmin_cloaked") or not IsValid(weapon) then return end
-    weapon:SetNoDraw(true)
+function CloakThink()
+    for _, v in ipairs(player.GetAll()) do
+        local ActiveWeapon = v:GetActiveWeapon()
+        if v:FAdmin_GetGlobal("FAdmin_cloaked") and ActiveWeapon:IsValid() and ActiveWeapon ~= v.FAdmin_CloakWeapon then
+            v.FAdmin_CloakWeapon = ActiveWeapon
+            ActiveWeapon:SetNoDraw(true)
 
-    if weapon:GetClass() ~= "weapon_physgun" then return end
-
-    local children = ply:GetChildren()
-    for i = 1, #children do
-        if children[i]:GetClass() == "physgun_beam" then
-            children[i]:SetNoDraw(true)
-            break
+            if ActiveWeapon:GetClass() == "weapon_physgun" then
+                local children = v:GetChildren()
+                for i = 1, #children do
+                    if children[i]:GetClass() == "physgun_beam" then
+                        children[i]:SetNoDraw(true)
+                        break
+                    end
+                end
+            end
         end
     end
-end)
+end


### PR DESCRIPTION
Actual cloak works like this :
loop for all targets > SetNoDraw(true) > loop trough ents.GetAll for phys_beam > SetNoDraw(true)
\+ do that every tick

My method :
loop for all targets > SetNoDraw(true) > loop trough target:GetChildren() for phys_beam > SetNoDraw(true)
\+ do that every PlayerSwitchWeapon hook

I think that is better