### PR TITLE
Add more control to spawned entities without overriding

### DIFF
--- a/entities/entities/darkrp_cheque/init.lua
+++ b/entities/entities/darkrp_cheque/init.lua
@@ -21,12 +21,11 @@ function ENT:Initialize()
     hook.Add("PlayerDisconnected", self, self.onPlayerDisconnected)
 end
 
-
 function ENT:Use(activator, caller)
     local canUse, reason = hook.Call("canDarkRPUse", nil, activator, self, caller)
     if canUse == false then
-      if reason then DarkRP.notify(activator, 1, 4, reason) end
-      return
+        if reason then DarkRP.notify(activator, 1, 4, reason) end
+        return
     end
 
     local owner = self:Getowning_ent()

--- a/entities/entities/darkrp_laws/init.lua
+++ b/entities/entities/darkrp_laws/init.lua
@@ -179,7 +179,7 @@ function ENT:OnRemove()
 end
 
 hook.Add("PlayerInitialSpawn", "SendLaws", function(ply)
-    for i, law in pairs(Laws) do
+    for i, law in ipairs(Laws) do
         if FixedLaws[i] then continue end
 
         umsg.Start("DRP_AddLaw", ply)

--- a/entities/entities/darkrp_tip_jar/init.lua
+++ b/entities/entities/darkrp_tip_jar/init.lua
@@ -33,14 +33,14 @@ function ENT:OnTakeDamage(dmg)
     end
 end
 
-function ENT:Use(ply, caller)
-    local canUse, reason = hook.Call("canDarkRPUse", nil, ply, self, caller)
+function ENT:Use(activator, caller)
+    local canUse, reason = hook.Call("canDarkRPUse", nil, activator, self, caller)
     if canUse == false then
-      if reason then DarkRP.notify(ply, 1, 4, reason) end
-      return
+        if reason then DarkRP.notify(activator, 1, 4, reason) end
+        return
     end
 
     net.Start("DarkRP_TipJarUI")
         net.WriteEntity(self)
-    net.Send(ply)
+    net.Send(activator)
 end

--- a/entities/entities/drug/init.lua
+++ b/entities/entities/drug/init.lua
@@ -83,8 +83,8 @@ function ENT:Use(activator, caller)
 
     local canUse, reason = hook.Call("canDarkRPUse", nil, activator, self, caller)
     if canUse == false then
-      if reason then DarkRP.notify(activator, 1, 4, reason) end
-      return
+        if reason then DarkRP.notify(activator, 1, 4, reason) end
+        return
     end
 
     if activator ~= Owner then

--- a/entities/entities/food/init.lua
+++ b/entities/entities/food/init.lua
@@ -34,7 +34,13 @@ function ENT:OnTakeDamage(dmg)
 end
 
 function ENT:Use(activator, caller)
-    caller:setSelfDarkRPVar("Energy", math.Clamp((caller:getDarkRPVar("Energy") or 0) + 100, 0, 100))
+    local canUse, reason = hook.Call("canDarkRPUse", nil, activator, self, caller)
+    if canUse == false then
+        if reason then DarkRP.notify(activator, 1, 4, reason) end
+        return
+    end
+
+    caller:setSelfDarkRPVar("Energy", 100)
     umsg.Start("AteFoodIcon", caller)
     umsg.End()
 

--- a/entities/entities/spawned_ammo/init.lua
+++ b/entities/entities/spawned_ammo/init.lua
@@ -18,6 +18,8 @@ function ENT:Use(activator, caller)
         return
     end
 
+    hook.Call("playerPickedUpAmmo", nil, activator, self.amountGiven, self.ammoType, self)
+
     activator:GiveAmmo(self.amountGiven, self.ammoType)
     self:Remove()
 end
@@ -41,3 +43,32 @@ function ENT:StartTouch(ent)
 
     ent:Remove()
 end
+
+DarkRP.hookStub{
+    name = "playerPickedUpAmmo",
+    description = "When a player picks up ammo.",
+    parameters = {
+        {
+            name = "ply",
+            description = "The player who picked up ammo.",
+            type = "Player"
+        },
+        {
+            name = "amount",
+            description = "Ammo amount.",
+            type = "number"
+        },
+        {
+            name = "type",
+            description = "Ammo type.",
+            type = "number"
+        },
+        {
+            name = "spawnedAmmo",
+            description = "Entity of spawned ammo.",
+            type = "Entity"
+        }
+    },
+    returns = {
+    },
+}

--- a/entities/entities/spawned_food/init.lua
+++ b/entities/entities/spawned_food/init.lua
@@ -22,8 +22,8 @@ end
 function ENT:Use(activator, caller)
     local canUse, reason = hook.Call("canDarkRPUse", nil, activator, self, caller)
     if canUse == false then
-      if reason then DarkRP.notify(activator, 1, 4, reason) end
-      return
+        if reason then DarkRP.notify(activator, 1, 4, reason) end
+        return
     end
 
     local override = self.foodItem.onEaten and self.foodItem.onEaten(self, activator, self.foodItem)
@@ -33,9 +33,36 @@ function ENT:Use(activator, caller)
         return
     end
 
-    activator:setSelfDarkRPVar("Energy", math.Clamp((activator:getDarkRPVar("Energy") or 100) + (self:GetTable().FoodEnergy or 1), 0, 100))
+    hook.Call("playerAteFood", nil, activator, self.foodItem, self)
+
+    activator:setSelfDarkRPVar("Energy", math.Clamp((activator:getDarkRPVar("Energy") or 100) + (self.FoodEnergy or 1), 0, 100))
     umsg.Start("AteFoodIcon", activator)
     umsg.End()
+
     self:Remove()
     activator:EmitSound("vo/sandwicheat09.mp3", 100, 100)
 end
+
+DarkRP.hookStub{
+    name = "playerAteFood",
+    description = "When a player eats food.",
+    parameters = {
+        {
+            name = "ply",
+            description = "The player who ate food.",
+            type = "Player"
+        },
+        {
+            name = "food",
+            description = "Food table.",
+            type = "table"
+        },
+        {
+            name = "spawnedfood",
+            description = "Entity of spawned food.",
+            type = "Entity"
+        },
+    },
+    returns = {
+    },
+}

--- a/entities/entities/spawned_money/init.lua
+++ b/entities/entities/spawned_money/init.lua
@@ -25,8 +25,8 @@ function ENT:Use(activator, caller)
 
     local canUse, reason = hook.Call("canDarkRPUse", nil, activator, self, caller)
     if canUse == false then
-      if reason then DarkRP.notify(activator, 1, 4, reason) end
-      return
+        if reason then DarkRP.notify(activator, 1, 4, reason) end
+        return
     end
 
     self.USED = true

--- a/entities/entities/spawned_shipment/init.lua
+++ b/entities/entities/spawned_shipment/init.lua
@@ -92,9 +92,11 @@ function ENT:Use(activator, caller)
 
     local canUse, reason = hook.Call("canDarkRPUse", nil, activator, self, caller)
     if canUse == false then
-      if reason then DarkRP.notify(activator, 1, 4, reason) end
-      return
+        if reason then DarkRP.notify(activator, 1, 4, reason) end
+        return
     end
+
+    hook.Call("playerOpenedShipment", nil, activator, self)
 
     self.locked = true -- One activation per second
     self.USED = true
@@ -232,3 +234,22 @@ function ENT:StartTouch(ent)
 
     ent:Remove()
 end
+
+DarkRP.hookStub{
+    name = "playerOpenedShipment",
+    description = "When a player opens a shipment.",
+    parameters = {
+        {
+            name = "player",
+            description = "The player who opens a shipment.",
+            type = "Player"
+        },
+        {
+            name = "entity",
+            description = "Entity of spawned shipment.",
+            type = "Entity"
+        }
+    },
+    returns = {
+    },
+}

--- a/entities/entities/spawned_weapon/init.lua
+++ b/entities/entities/spawned_weapon/init.lua
@@ -59,6 +59,8 @@ function ENT:Use(activator, caller)
         return
     end
 
+    hook.Call("playerPickedUpWeapon", nil, activator, self)
+
     weapon:Remove()
 
     weapon = activator:Give(class, true)
@@ -135,3 +137,22 @@ function ENT:StartTouch(ent)
     self:Setamount(totalAmount)
     ent:Remove()
 end
+
+DarkRP.hookStub{
+    name = "playerPickedUpWeapon",
+    description = "When a player picks up a weapon.",
+    parameters = {
+        {
+            name = "player",
+            description = "The player who picks up the weapon.",
+            type = "Player"
+        },
+        {
+            name = "entity",
+            description = "Entity of spawned weapon.",
+            type = "Entity"
+        }
+    },
+    returns = {
+    },
+}


### PR DESCRIPTION
**Original request:**
> It would be nice for new modders to add hooks when a player interacts with a DarkRP entity (detouring the `Use` function in entity tables is not easy). It would typically be called after the hook `canDarkRPUse`. The [money entity](https://github.com/FPtje/DarkRP/blob/aa0dc11eb1a9018be17f7fb262180e386d28861e/entities/entities/spawned_money/init.lua#L35) already has that and could be extended to other `spawned_*` entities or all default entities if possible.

**Note**: the [PlayerUse](https://wiki.facepunch.com/gmod/GM:PlayerUse) hook is called before `canDarkRPUse`, so this is not really possible without overriding entities through the darkrp modification.

**Here are the changes**:
* Add `playerPickedUpAmmo` hook when a player picks up spawned ammo.
* Add `playerAteFood` hook when a player eats food.
* Add `playerOpenedShipment` hook when a player opens a spawned shipment.
* Add `playerPickedUpWeapon` hook when a player picks up a spawned weapon.
* Add a `canDarkRPUse` hook check in **food** entity.
* Changes the way of adding energy in **food** entity (reduces unnecessary operations).
* Fix spaces inconsistencies.
* Fix function arguments inconsistencies.

This closes #3063.