### PR TITLE
Minor optimisations to spawn and death code

### DIFF
--- a/gamemode/modules/afk/sv_afk.lua
+++ b/gamemode/modules/afk/sv_afk.lua
@@ -19,10 +19,8 @@ local function SetAFK(ply)
     local rpname = ply:getDarkRPVar("rpname")
     ply:setSelfDarkRPVar("AFK", not ply:getDarkRPVar("AFK"))
 
-    if not ply.blackScreen then
-        ply.blackScreen = ply:getDarkRPVar("AFK")
-        SendUserMessage("blackScreen", ply, ply:getDarkRPVar("AFK"))
-    end
+    ply.blackScreen = ply:getDarkRPVar("AFK")
+    SendUserMessage("blackScreen", ply, ply:getDarkRPVar("AFK"))
 
     if ply:getDarkRPVar("AFK") then
         DarkRP.retrieveSalary(ply, function(amount) ply.OldSalary = amount end)

--- a/gamemode/modules/afk/sv_afk.lua
+++ b/gamemode/modules/afk/sv_afk.lua
@@ -19,7 +19,10 @@ local function SetAFK(ply)
     local rpname = ply:getDarkRPVar("rpname")
     ply:setSelfDarkRPVar("AFK", not ply:getDarkRPVar("AFK"))
 
-    SendUserMessage("blackScreen", ply, ply:getDarkRPVar("AFK"))
+    if not ply.blackScreen then
+        ply.blackScreen = ply:getDarkRPVar("AFK")
+        SendUserMessage("blackScreen", ply, ply:getDarkRPVar("AFK"))
+    end
 
     if ply:getDarkRPVar("AFK") then
         DarkRP.retrieveSalary(ply, function(amount) ply.OldSalary = amount end)

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -434,7 +434,8 @@ function GM:PlayerDeath(ply, weapon, killer)
         jobTable.PlayerDeath(ply, weapon, killer)
     end
 
-    if GAMEMODE.Config.deathblack then
+    if GAMEMODE.Config.deathblack and not ply.blackScreen then
+        ply.blackScreen = true
         SendUserMessage("blackScreen", ply, true)
     end
 
@@ -745,7 +746,10 @@ function GM:PlayerSpawn(ply)
     ply:UnSpectate()
 
     -- Kill any colormod
-    SendUserMessage("blackScreen", ply, false)
+    if ply.blackScreen then
+        ply.blackScreen = false
+        SendUserMessage("blackScreen", ply, false)
+    end
 
     if GAMEMODE.Config.babygod and not ply.IsSleeping and not ply.Babygod then
         enableBabyGod(ply)
@@ -754,13 +758,9 @@ function GM:PlayerSpawn(ply)
 
     ply:Extinguish()
 
-    local activeWeapon = ply:GetActiveWeapon()
-    if activeWeapon:IsValid() then
-        activeWeapon:Extinguish()
-    end
-
-    for _, v in ipairs(ents.FindByClass("predicted_viewmodel")) do -- Money printer ignite fix
-        v:Extinguish()
+    local vm = ply:GetViewModel()
+    if IsValid(vm) then
+        vm:Extinguish()
     end
 
     if ply.demotedWhileDead then

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -758,9 +758,12 @@ function GM:PlayerSpawn(ply)
 
     ply:Extinguish()
 
-    local vm = ply:GetViewModel()
-    if IsValid(vm) then
-        vm:Extinguish()
+    for i=0, 2 do
+        local vm = ply:GetViewModel(i)
+
+        if IsValid(vm) then
+            vm:Extinguish()
+        end
     end
 
     if ply.demotedWhileDead then

--- a/gamemode/modules/sleep/sv_sleep.lua
+++ b/gamemode/modules/sleep/sv_sleep.lua
@@ -107,7 +107,10 @@ function DarkRP.toggleSleep(player, command)
             player:Lock()
         end
 
-        SendUserMessage("blackScreen", player, false)
+        if ply.blackScreen then
+            ply.blackScreen = false
+            SendUserMessage("blackScreen", player, false)
+        end
 
         if command == true then
             player:arrest()
@@ -168,7 +171,10 @@ function DarkRP.toggleSleep(player, command)
         --Make sure noone can pick it up:
         ragdoll:CPPISetOwner(player)
 
-        SendUserMessage("blackScreen", player, true)
+        if not ply.blackScreen then
+            ply.blackScreen = true
+            SendUserMessage("blackScreen", player, true)
+        end
 
         player.SleepSound = CreateSound(ragdoll, "npc/ichthyosaur/water_breath.wav")
         player.SleepSound:PlayEx(0.10, 100)


### PR DESCRIPTION
* Don't do a ents.FindByClass loop (internal ents.GetAll loop, which are extremely expensive) just to extinguish all viewmodels, especially because we only want to extinguish our own viewmodel.
(Viewmodels cant be ignited by the printer anymore anyways...)

* It is unnecessary to send a usermessage to every player respawning, if the player never had blackscreen enabled upon.

* Use ipairs instead of pairs for ents.FindIn* loop for money_printer.

1 major optimisations and 2 minor optimisations sqashed into a single commit, I hope you like it.