### PR TITLE
Hashing player positions into a grid in O(N) before computing every interaction for proximity chat

### DIFF
--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -292,6 +292,8 @@ GM.Config.falldamageamount              = 10
 GM.Config.printeroverheatchance         = 22
 -- printerreward - Reward for destroying a money printer.
 GM.Config.printerreward                 = 950
+-- voiceCheckTimeDelay - Sets how frequently to recalculate how frequently people can talk to each other
+GM.Config.voiceCheckTimeDelay           = 0.3
 
 --[[---------------------------------------------------------------------------
 Chat distance settings

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -334,11 +334,13 @@ timer.Create("DarkRPCanHearPlayersVoice", timeDelay, 0, function()
     grid = {}
 
     local plyPos = {}
+    local eyePos = {}
 
     -- Get the grid position of every player O(N)
     for _, ply in ipairs(players) do
         local pos = ply:GetPos()
         plyPos[ply] = pos
+        eyePos[ply] = ply:EyePos()
         local x = floor(pos.x / gridSize)
         local y = floor(pos.y / gridSize)
 
@@ -359,7 +361,8 @@ timer.Create("DarkRPCanHearPlayersVoice", timeDelay, 0, function()
     for _, ply1 in ipairs(players) do
         local gridX = plyToGrid[1][ply1]
         local gridY = plyToGrid[2][ply1]
-        local ply1Pos
+        local ply1Pos = plyPos[ply1]
+        local ply1EyePos = eyePos[ply1]
 
         for x = gridX, gridX + 1 do   -- Get every neighbouring cell (including the actual cell) (x axis)
             local row = grid[x]
@@ -372,11 +375,9 @@ timer.Create("DarkRPCanHearPlayersVoice", timeDelay, 0, function()
 
                 -- Check if every player can talk
                 for _, ply2 in ipairs(cell) do
-                    ply1Pos = ply1Pos or plyPos[ply1]
-                    local ply2Pos = plyPos[ply2]
                     local canTalk = not vrad or -- Voiceradius is off, everyone can hear everyone
-                        (ply1ShootPos:DistToSqr(ply2Pos) < voiceDistance and -- voiceradius is on and the two are within hearing distance
-                            (not dynv or IsInRoom(ply1Pos, ply2Pos, ply2))) -- Dynamic voice is on and players are in the same room
+                        (ply1Pos:DistToSqr(plyPos[ply2]) < voiceDistance and -- voiceradius is on and the two are within hearing distance
+                            (not dynv or IsInRoom(ply1EyePos, eyePos[ply2], ply2))) -- Dynamic voice is on and players are in the same room
 
                     DrpCanHear[ply1][ply2] = canTalk and (deadv or ply2:Alive())
                     DrpCanHear[ply2][ply1] = canTalk and (deadv or ply1:Alive()) -- Take advantage of the symmetry
@@ -393,11 +394,9 @@ timer.Create("DarkRPCanHearPlayersVoice", timeDelay, 0, function()
             for i = 1, count do
                 for j = i + 1, count do
                     local ply1, ply2 = cell[i], cell[j]
-                    local ply1Pos, ply2Pos = plyPos[ply1], plyPos[ply2]
-
                     local canTalk = not vrad or -- Voiceradius is off, everyone can hear everyone
-                        (ply1ShootPos:DistToSqr(ply2Pos) < voiceDistance and -- voiceradius is on and the two are within hearing distance
-                            (not dynv or IsInRoom(ply1Pos, ply2Pos, ply2))) -- Dynamic voice is on and players are in the same room
+                        (plyPos[ply1]:DistToSqr(plyPos[ply2]) < voiceDistance and -- voiceradius is on and the two are within hearing distance
+                            (not dynv or IsInRoom(eyePos[ply1], eyePos[ply2], ply2))) -- Dynamic voice is on and players are in the same room
 
                     DrpCanHear[ply1][ply2] = canTalk and (deadv or ply2:Alive())
                     DrpCanHear[ply2][ply1] = canTalk and (deadv or ply1:Alive()) -- Take advantage of the symmetry

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -364,24 +364,25 @@ timer.Create("DarkRPCanHearPlayersVoice", timeDelay, 0, function()
         local ply1Pos = plyPos[ply1]
         local ply1EyePos = eyePos[ply1]
 
-        for x = gridX, gridX + 1 do   -- Get every neighbouring cell (including the actual cell) (x axis)
+        for i = 0, 3 do
+            local vOffset = 1 - ((i >= 3) and 1 or 0)
+            local hOffset = -(i % 3-1)
+            local x = gridX + hOffset
+            local y = gridY + vOffset
+
             local row = grid[x]
             if not row then continue end
 
-            for y = gridY, gridY + 1 do   -- Get every neighbouring cell (including the actual cell) (y axis)
-                if x == gridX and y == gridY then continue end -- Exclude the actual cell as it needs a separate computation
-                local cell = row[y]
-                if not cell then continue end -- Check that values exist
+            local cell = row[y]
+            if not cell then continue end
 
-                -- Check if every player can talk
-                for _, ply2 in ipairs(cell) do
-                    local canTalk = not vrad or -- Voiceradius is off, everyone can hear everyone
-                        (ply1Pos:DistToSqr(plyPos[ply2]) < voiceDistance and -- voiceradius is on and the two are within hearing distance
-                            (not dynv or IsInRoom(ply1EyePos, eyePos[ply2], ply2))) -- Dynamic voice is on and players are in the same room
+            for _, ply2 in ipairs(cell) do
+                local canTalk = not vrad or -- Voiceradius is off, everyone can hear everyone
+                    (ply1Pos:DistToSqr(plyPos[ply2]) < voiceDistance and -- voiceradius is on and the two are within hearing distance
+                        (not dynv or IsInRoom(ply1EyePos, eyePos[ply2], ply2))) -- Dynamic voice is on and players are in the same room
 
-                    DrpCanHear[ply1][ply2] = canTalk and (deadv or ply2:Alive())
-                    DrpCanHear[ply2][ply1] = canTalk and (deadv or ply1:Alive()) -- Take advantage of the symmetry
-                end
+                DrpCanHear[ply1][ply2] = canTalk and (deadv or ply2:Alive())
+                DrpCanHear[ply2][ply1] = canTalk and (deadv or ply1:Alive()) -- Take advantage of the symmetry
             end
         end
     end

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -329,8 +329,8 @@ timer.Create("DarkRPCanHearPlayersVoice", timeDelay, 0, function()
 
 
     -- Clear old values
-    plyToGrid[0] = {}
     plyToGrid[1] = {}
+    plyToGrid[2] = {}
     grid = {}
 
     -- Get the grid position of every player O(N)

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -333,9 +333,12 @@ timer.Create("DarkRPCanHearPlayersVoice", timeDelay, 0, function()
     plyToGrid[2] = {}
     grid = {}
 
+    local plyPos = {}
+
     -- Get the grid position of every player O(N)
     for _, ply in ipairs(players) do
         local pos = ply:GetPos()
+        plyPos[ply] = pos
         local x = floor(pos.x / gridSize)
         local y = floor(pos.y / gridSize)
 
@@ -369,8 +372,8 @@ timer.Create("DarkRPCanHearPlayersVoice", timeDelay, 0, function()
 
                 -- Check if every player can talk
                 for _, ply2 in ipairs(cell) do
-                    ply1Pos = ply1Pos or ply1:GetPos()
-                    local ply2Pos = ply2:GetPos()
+                    ply1Pos = ply1Pos or plyPos[ply1]
+                    local ply2Pos = plyPos[ply2]
                     local canTalk = not vrad or -- Voiceradius is off, everyone can hear everyone
                         (ply1ShootPos:DistToSqr(ply2Pos) < voiceDistance and -- voiceradius is on and the two are within hearing distance
                             (not dynv or IsInRoom(ply1Pos, ply2Pos, ply2))) -- Dynamic voice is on and players are in the same room
@@ -390,7 +393,7 @@ timer.Create("DarkRPCanHearPlayersVoice", timeDelay, 0, function()
             for i = 1, count do
                 for j = i + 1, count do
                     local ply1, ply2 = cell[i], cell[j]
-                    local ply1Pos, ply2Pos = ply1:GetPos(), ply2:GetPos()
+                    local ply1Pos, ply2Pos = plyPos[ply1], plyPos[ply2]
 
                     local canTalk = not vrad or -- Voiceradius is off, everyone can hear everyone
                         (ply1ShootPos:DistToSqr(ply2Pos) < voiceDistance and -- voiceradius is on and the two are within hearing distance

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -392,8 +392,9 @@ timer.Create("DarkRPCanHearPlayersVoice", timeDelay, 0, function()
         for _, cell in pairs(row) do
             local count = #cell
             for i = 1, count do
+                local ply1 = cell[i]
                 for j = i + 1, count do
-                    local ply1, ply2 = cell[i], cell[j]
+                    local ply2 = cell[j]
                     local canTalk = not vrad or -- Voiceradius is off, everyone can hear everyone
                         (plyPos[ply1]:DistToSqr(plyPos[ply2]) < voiceDistance and -- voiceradius is on and the two are within hearing distance
                             (not dynv or IsInRoom(eyePos[ply1], eyePos[ply2], ply2))) -- Dynamic voice is on and players are in the same room

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -356,7 +356,7 @@ timer.Create("DarkRPCanHearPlayersVoice", timeDelay, 0, function()
     for _, ply1 in ipairs(players) do
         local gridX = plyToGrid[1][ply1]
         local gridY = plyToGrid[2][ply1]
-        local ply1ShootPos
+        local ply1Pos
 
         for x = gridX, gridX + 1 do   -- Get every neighbouring cell (including the actual cell) (x axis)
             local row = grid[x]
@@ -389,8 +389,9 @@ timer.Create("DarkRPCanHearPlayersVoice", timeDelay, 0, function()
             local count = #cell
             for i = 1, count do
                 for j = i + 1, count do
-                    ply1Pos = ply1Pos or ply1:GetPos()
-                    local ply2Pos = ply2:GetPos()
+                    local ply1, ply2 = cell[i], cell[j]
+                    local ply1Pos, ply2Pos = ply1:GetPos(), ply2:GetPos()
+
                     local canTalk = not vrad or -- Voiceradius is off, everyone can hear everyone
                         (ply1ShootPos:DistToSqr(ply2Pos) < voiceDistance and -- voiceradius is on and the two are within hearing distance
                             (not dynv or IsInRoom(ply1Pos, ply2Pos, ply2))) -- Dynamic voice is on and players are in the same room


### PR DESCRIPTION
This implementation aims to help the voice radius implementation scaling by separating each player into a grid (based on a hash). There is no reason why we should check if two players can talk to each other if they are on opposite sides of the map, this method ensures that by clustering. Additionally, if there are two clusters of 10 people, there would be less computation as only 10^2+10^2=200 would be checked instead of 20^2=400 without considering symmetry.