### PR TITLE
Create GitHub workflow to run glualint on the DarkRP repository

### DIFF
--- a/.github/workflows/run-glualint.yml
+++ b/.github/workflows/run-glualint.yml
@@ -1,0 +1,14 @@
+name: run-glualint
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+jobs:
+  run-glualint:
+    runs-on: ubuntu-18.04 # 20.04 lacks libffi6, which is used by glualint.
+    steps:
+      - uses: actions/checkout@v2
+      - run: wget https://github.com/FPtje/GLuaFixer/releases/download/1.17.1/glualint-1.17.1-linux-stripped.zip
+      - run: unzip glualint-*.zip
+      - run: ./glualint --output-format github lint .

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DarkRP
+# DarkRP ![run-glualint](https://github.com/FPtje/DarkRP/workflows/run-glualint/badge.svg?branch=master)
 A roleplay gamemode for Garry's Mod.
 
 ## Getting DarkRP
@@ -29,5 +29,3 @@ Just whatever you do, don't touch DarkRP's core files.
 Please head to the official Discord!
 
 https://darkrp.page.link/discord
-
-

--- a/glualint.json
+++ b/glualint.json
@@ -18,8 +18,8 @@
     "lint_unusedParameters": false,
     "lint_unusedLoopVars": false,
     "lint_ignoreFiles": [
-        "**/gamemode/modules/fpp/pp/**.lua",
-        "**/gamemode/libraries/simplerr.lua"
+        "./gamemode/modules/fpp/pp/**.lua",
+        "./gamemode/libraries/simplerr.lua"
     ],
     "prettyprint_spaceAfterParens": false,
     "prettyprint_spaceAfterBrackets": false,


### PR DESCRIPTION
This is mostly a test PR to see what happens when there are warnings/errors in a PR.

The given warnings are from files that should be ignored, because they are in the ignore list of `.glualint.json`. Due to a bug in glualint the warnings are thrown anyways. That has been fixed in the latest master of glualint, but for now I'll use it to test warnings.