### PR TITLE
Check edits to subtrees

### DIFF
--- a/.github/scripts/check-modified-subtree.sh
+++ b/.github/scripts/check-modified-subtree.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+# This script will print GitHub errors when files from subtrees have been edited.
+# Those files should be edited in their respective repositories.
+
+MASTER_REVISION=$(git rev-list --first-parent origin/master | head -n 1)
+DIFFED_FILES=$(git diff --name-only "$MASTER_REVISION")
+
+FAILED=false
+
+if echo "$DIFFED_FILES" | grep -qP "^gamemode/modules/fpp/pp/"; then
+    echo "::error::Files from Falco's Prop Protection have been edited. Please submit a PR to https://github.com/fptje/falcos-Prop-protection instead!"
+    FAILED=true
+fi
+
+if echo "$DIFFED_FILES" | grep -qP "^gamemode/libraries/fn.lua"; then
+    echo "::error::The fn library has been edited. Please submit a PR to https://github.com/fptje/GModFunctional instead!"
+    FAILED=true
+fi
+
+if echo "$DIFFED_FILES" | grep -qP "^gamemode/libraries/mysqlite/mysqlite.lua"; then
+    echo "::error::The MySQLite library has been edited. Please submit a PR to https://github.com/fptje/MySQLite instead!"
+    FAILED=true
+fi
+
+if echo "$DIFFED_FILES" | grep -qP "^gamemode/libraries/simplerr.lua"; then
+    echo "::error::The Simplerr library has been edited. Please submit a PR to https://github.com/fptje/simplerr instead!"
+    FAILED=true
+fi
+
+if echo "$DIFFED_FILES" | grep -qP "^gamemode/libraries/sh_cami.lua"; then
+    echo "::error::The CAMI library has been edited. Please submit a PR to https://github.com/glua/CAMI instead!"
+    FAILED=true
+fi
+
+if echo "$DIFFED_FILES" | grep -qP "^gamemode/modules/fspectate/"; then
+    echo "::error::Files from FSpectate have been edited. Please submit a PR to https://github.com/fptje/FSpectate instead!"
+    FAILED=true
+fi
+
+if [[ "$FAILED" = true ]]; then
+    exit 1
+fi

--- a/.github/workflows/check-modified-subtree.yml
+++ b/.github/workflows/check-modified-subtree.yml
@@ -1,0 +1,15 @@
+name: check-modified-subtree
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  check-modified-subtree:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Make sure there is access to the master branch
+          fetch-depth: 0
+          clean: false
+      - run: ./.github/scripts/check-modified-subtree.sh


### PR DESCRIPTION
Some pull requests in the past have edited files that are imported from other repositories. Merging those will cause them to get lost when I update them through git. This adds a GitHub action that fails when any of those files have been edited in a pull request.