### PR TITLE
Change the behavior with the "FAdmin_StoreBan" hook

### DIFF
--- a/gamemode/modules/fadmin/fadmin/playeractions/kickban/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/kickban/sv_init.lua
@@ -93,6 +93,7 @@ end)
 
 local function SaveBan(SteamID, Nick, Duration, Reason, AdminName, Admin_steam)
     local StoreBans = hook.Call("FAdmin_StoreBan", nil, SteamID, Nick, Duration, Reason, AdminName, Admin_steam)
+    if StoreBans == true then return end
 
     if tonumber(Duration) == 0 then
         FAdmin.BANS[SteamID] = {}
@@ -109,8 +110,6 @@ local function SaveBan(SteamID, Nick, Duration, Reason, AdminName, Admin_steam)
         FAdmin.BANS[SteamID].adminname = AdminName
         FAdmin.BANS[SteamID].adminsteam = Admin_steam
     end
-
-    if StoreBans == true then return end
 end
 
 local function Ban(ply, cmd, args)

--- a/gamemode/modules/fadmin/sv_fadmin_sql.lua
+++ b/gamemode/modules/fadmin/sv_fadmin_sql.lua
@@ -27,8 +27,6 @@ hook.Add("FAdmin_StoreBan", "MySQLBans", function(SteamID, Nick, Duration, Reaso
     end
 
     MySQLite.query("REPLACE INTO FAdminBans VALUES(" .. steam .. ", " .. nick .. ", " .. bandate .. ", " .. duration .. ", " .. reason .. ", " .. admin .. ", " .. adminsteam .. ");")
-
-    return true
 end)
 
 --[[---------------------------------------------------------------------------


### PR DESCRIPTION
Currently, it is possible to return a value in the `FAdmin_StoreBan` hook, but this is totally useless because it has no effect. With these changes it will be possible to stop the ban from being saved. However, I wonder if this is not too much since the introduction of the `FAdmin_CanBan` hook, considering that `FAdmin_StoreBan` is used for the registration and not the "**action**" of the ban.
If you consider this change to be unnecessary then you should simply remove the return value from the `FAdmin_StoreBan` hook.