### PR TITLE
Allow newer version of tmysql

### DIFF
--- a/gamemode/libraries/mysqlite/mysqlite.lua
+++ b/gamemode/libraries/mysqlite/mysqlite.lua
@@ -98,7 +98,6 @@
     DatabaseInitialized
         Called when a successful connection to the database has been made.
 ]]
-
 local debug = debug
 local error = error
 local ErrorNoHalt = ErrorNoHalt
@@ -113,35 +112,38 @@ local tostring = tostring
 local mysqlOO
 local TMySQL
 local _G = _G
-
 local multistatements
-
 local MySQLite_config = MySQLite_config or RP_MySQLConfig or FPP_MySQLConfig
 local moduleLoaded
 
 local function loadMySQLModule()
     if moduleLoaded or not MySQLite_config or not MySQLite_config.EnableMySQL then return end
-
     local moo, tmsql = file.Exists("bin/gmsv_mysqloo_*.dll", "LUA"), file.Exists("bin/gmsv_tmysql4_*.dll", "LUA")
 
     if not moo and not tmsql then
         error("Could not find a suitable MySQL module. Supported modules are MySQLOO and tmysql4.")
     end
+
     moduleLoaded = true
-
-    require(moo and tmsql and MySQLite_config.Preferred_module or
-            moo and "mysqloo"                                  or
-            "tmysql4")
-
+    require(moo and tmsql and MySQLite_config.Preferred_module or moo and "mysqloo" or "tmysql4")
     multistatements = CLIENT_MULTI_STATEMENTS
-
     mysqlOO = mysqloo
     TMySQL = tmysql
+
+    if (MySQLite_config.Preferred_module == "tmysql4") then
+        if (not tmysql.Version or tmysql.Version < 4.1) then
+            MsgC(Color(255, 0, 0), "Using older tmysql version, please consider updating!\n")
+            MsgC(Color(255, 0, 0), "Newer Version: https://github.com/SuperiorServers/gm_tmysql4\n")
+        end
+
+        -- Turns tmysql.Connect into tmysql.Initialize if they're using an older version.
+        TMySQL.Connect = (tmysql.Version and tmysql.Version >= 4.1 and TMySQL.Connect or TMySQL.initialize)
+        TMySQL.SetOption = (tmysql.Version and tmysql.Version >= 4.1 and TMySQL.SetOption or TMySQL.Option)
+    end
 end
+
 loadMySQLModule()
-
 module("MySQLite")
-
 
 function initialize(config)
     MySQLite_config = config or MySQLite_config
@@ -165,7 +167,6 @@ end
 local CONNECTED_TO_MYSQL = false
 local msOOConnect
 databaseObject = nil
-
 local queuedQueries
 local cachedQueries
 
@@ -181,6 +182,7 @@ function begin()
             debug.Trace()
             error("Transaction ongoing!")
         end
+
         queuedQueries = {}
     end
 end
@@ -188,7 +190,11 @@ end
 function commit(onFinished)
     if not CONNECTED_TO_MYSQL then
         sql.Commit()
-        if onFinished then onFinished() end
+
+        if onFinished then
+            onFinished()
+        end
+
         return
     end
 
@@ -198,14 +204,17 @@ function commit(onFinished)
 
     if #queuedQueries == 0 then
         queuedQueries = nil
-        if onFinished then onFinished() end
+
+        if onFinished then
+            onFinished()
+        end
+
         return
     end
 
     -- Copy the table so other scripts can create their own queue
     local queue = table.Copy(queuedQueries)
     queuedQueries = nil
-
     -- Handle queued queries in order
     local queuePos = 0
     local call
@@ -220,7 +229,11 @@ function commit(onFinished)
 
         -- Base case, end of the queue
         if queuePos + 1 > #queue then
-            if onFinished then onFinished() end -- All queries have finished
+            -- All queries have finished
+            if onFinished then
+                onFinished()
+            end
+
             return
         end
 
@@ -234,9 +247,15 @@ end
 
 function queueQuery(sqlText, callback, errorCallback)
     if CONNECTED_TO_MYSQL then
-        table.insert(queuedQueries, {query = sqlText, callback = callback, onError = errorCallback})
+        table.insert(queuedQueries, {
+            query = sqlText,
+            callback = callback,
+            onError = errorCallback
+        })
+
         return
     end
+
     -- SQLite is instantaneous, simply running the query is equal to queueing it
     query(sqlText, callback, errorCallback)
 end
@@ -244,6 +263,7 @@ end
 local function msOOQuery(sqlText, callback, errorCallback, queryValue)
     local queryObject = databaseObject:query(sqlText)
     local data
+
     queryObject.onData = function(Q, D)
         data = data or {}
         data[#data + 1] = D
@@ -255,32 +275,52 @@ local function msOOQuery(sqlText, callback, errorCallback, queryValue)
 
             -- Immediately try reconnecting
             msOOConnect(MySQLite_config.Host, MySQLite_config.Username, MySQLite_config.Password, MySQLite_config.Database_name, MySQLite_config.Database_port)
+
             return
         end
 
         local supp = errorCallback and errorCallback(E, sqlText)
-        if not supp then error(E .. " (" .. sqlText .. ")") end
+
+        if not supp then
+            error(E .. " (" .. sqlText .. ")")
+        end
     end
 
     queryObject.onSuccess = function()
         local res = queryValue and data and data[1] and table.GetFirstValue(data[1]) or not queryValue and data or nil
-        if callback then callback(res, queryObject:lastInsert()) end
+
+        if callback then
+            callback(res, queryObject:lastInsert())
+        end
     end
+
     queryObject:start()
 end
 
 local function tmsqlQuery(sqlText, callback, errorCallback, queryValue)
     local call = function(res)
         res = res[1] -- For now only support one result set
+
         if not res.status then
             local supp = errorCallback and errorCallback(res.error, sqlText)
-            if not supp then error(res.error .. " (" .. sqlText .. ")") end
+
+            if not supp then
+                error(res.error .. " (" .. sqlText .. ")")
+            end
+
             return
         end
 
-        if not res.data or #res.data == 0 then res.data = nil end -- compatibility with other backends
+        -- compatibility with other backends
+        if not res.data or #res.data == 0 then
+            res.data = nil
+        end
+
         if queryValue and callback then return callback(res.data and res.data[1] and table.GetFirstValue(res.data[1]) or nil) end
-        if callback then callback(res.data, res.lastid) end
+
+        if callback then
+            callback(res.data, res.lastid)
+        end
     end
 
     databaseObject:Query(sqlText, call)
@@ -288,28 +328,36 @@ end
 
 local function SQLiteQuery(sqlText, callback, errorCallback, queryValue)
     sql.m_strError = "" -- reset last error
-
     local lastError = sql.LastError()
     local Result = queryValue and sql.QueryValue(sqlText) or sql.Query(sqlText)
 
     if sql.LastError() and sql.LastError() ~= lastError then
         local err = sql.LastError()
         local supp = errorCallback and errorCallback(err, sqlText)
-        if supp == false then error(err .. " (" .. sqlText .. ")", 2) end
+
+        if supp == false then
+            error(err .. " (" .. sqlText .. ")", 2)
+        end
+
         return
     end
 
-    if callback then callback(Result) end
+    if callback then
+        callback(Result)
+    end
+
     return Result
 end
 
 function query(sqlText, callback, errorCallback)
     local qFunc = (CONNECTED_TO_MYSQL and ((mysqlOO and msOOQuery) or (TMySQL and tmsqlQuery))) or SQLiteQuery
+
     return qFunc(sqlText, callback, errorCallback, false)
 end
 
 function queryValue(sqlText, callback, errorCallback)
     local qFunc = (CONNECTED_TO_MYSQL and ((mysqlOO and msOOQuery) or (TMySQL and tmsqlQuery))) or SQLiteQuery
+
     return qFunc(sqlText, callback, errorCallback, true)
 end
 
@@ -319,41 +367,53 @@ local function onConnected()
     -- Run the queries that were called before the connection was made
     for k, v in pairs(cachedQueries or {}) do
         cachedQueries[k] = nil
+
         if v[3] then
             queryValue(v[1], v[2])
         else
             query(v[1], v[2])
         end
     end
+
     cachedQueries = {}
     local GM = _G.GAMEMODE or _G.GM
-
     hook.Call("DatabaseInitialized", GM.DatabaseInitialized and GM or nil)
 end
 
 msOOConnect = function(host, username, password, database_name, database_port)
     databaseObject = mysqlOO.connect(host, username, password, database_name, database_port)
 
-    if timer.Exists("darkrp_check_mysql_status") then timer.Remove("darkrp_check_mysql_status") end
+    if timer.Exists("darkrp_check_mysql_status") then
+        timer.Remove("darkrp_check_mysql_status")
+    end
 
     databaseObject.onConnectionFailed = function(_, msg)
         timer.Simple(5, function()
             msOOConnect(MySQLite_config.Host, MySQLite_config.Username, MySQLite_config.Password, MySQLite_config.Database_name, MySQLite_config.Database_port)
         end)
-        error("Connection failed! " .. tostring(msg) ..  "\nTrying again in 5 seconds.")
+
+        error("Connection failed! " .. tostring(msg) .. "\nTrying again in 5 seconds.")
     end
 
     databaseObject.onConnected = onConnected
-
     databaseObject:connect()
 end
 
 local function tmsqlConnect(host, username, password, database_name, database_port)
-    local db, err = TMySQL.initialize(host, username, password, database_name, database_port, nil, MySQLite_config.MultiStatements and multistatements or nil)
-    if err then error("Connection failed! " .. err ..  "\n") end
+    local db, err = TMySQL.Connect(host, username, password, database_name, database_port, nil, MySQLite_config.MultiStatements and multistatements or nil)
+
+    if err then
+        error("Connection failed! " .. err .. "\n")
+    end
 
     databaseObject = db
     onConnected()
+
+    if (TMySQL.Version and TMySQL.Version >= 4.1) then
+        hook.Add("Think", "MySQLite:tmysqlPoll", function()
+            db:Poll()
+        end)
+    end
 end
 
 function connectToMySQL(host, username, password, database_name, database_port)
@@ -363,10 +423,7 @@ function connectToMySQL(host, username, password, database_name, database_port)
 end
 
 function SQLStr(sqlStr)
-    local escape =
-        not CONNECTED_TO_MYSQL and sql.SQLStr or
-        mysqlOO                and function(str) return "\"" .. databaseObject:escape(tostring(str)) .. "\"" end or
-        TMySQL                 and function(str) return "\"" .. databaseObject:Escape(tostring(str)) .. "\"" end
+    local escape = not CONNECTED_TO_MYSQL and sql.SQLStr or mysqlOO and function(str) return "\"" .. databaseObject:escape(tostring(str)) .. "\"" end or TMySQL and function(str) return "\"" .. databaseObject:Escape(tostring(str)) .. "\"" end
 
     return escape(sqlStr)
 end

--- a/gamemode/libraries/mysqlite/mysqlite.lua
+++ b/gamemode/libraries/mysqlite/mysqlite.lua
@@ -98,6 +98,7 @@
     DatabaseInitialized
         Called when a successful connection to the database has been made.
 ]]
+
 local debug = debug
 local error = error
 local ErrorNoHalt = ErrorNoHalt
@@ -112,38 +113,47 @@ local tostring = tostring
 local mysqlOO
 local TMySQL
 local _G = _G
+
 local multistatements
+
 local MySQLite_config = MySQLite_config or RP_MySQLConfig or FPP_MySQLConfig
 local moduleLoaded
 
 local function loadMySQLModule()
     if moduleLoaded or not MySQLite_config or not MySQLite_config.EnableMySQL then return end
+
     local moo, tmsql = file.Exists("bin/gmsv_mysqloo_*.dll", "LUA"), file.Exists("bin/gmsv_tmysql4_*.dll", "LUA")
 
     if not moo and not tmsql then
         error("Could not find a suitable MySQL module. Supported modules are MySQLOO and tmysql4.")
     end
-
     moduleLoaded = true
-    require(moo and tmsql and MySQLite_config.Preferred_module or moo and "mysqloo" or "tmysql4")
+
+    require(moo and tmsql and MySQLite_config.Preferred_module or
+            moo and "mysqloo"                                  or
+            "tmysql4")
+
     multistatements = CLIENT_MULTI_STATEMENTS
+
     mysqlOO = mysqloo
     TMySQL = tmysql
 
-    if (MySQLite_config.Preferred_module == "tmysql4") then
-        if (not tmysql.Version or tmysql.Version < 4.1) then
+    if MySQLite_config.Preferred_module == "tmysql4" then
+
+        if not tmysql.Version or tmysql.Version < 4.1 then
             MsgC(Color(255, 0, 0), "Using older tmysql version, please consider updating!\n")
             MsgC(Color(255, 0, 0), "Newer Version: https://github.com/SuperiorServers/gm_tmysql4\n")
         end
-
+        
         -- Turns tmysql.Connect into tmysql.Initialize if they're using an older version.
         TMySQL.Connect = (tmysql.Version and tmysql.Version >= 4.1 and TMySQL.Connect or TMySQL.initialize)
         TMySQL.SetOption = (tmysql.Version and tmysql.Version >= 4.1 and TMySQL.SetOption or TMySQL.Option)
     end
 end
-
 loadMySQLModule()
+
 module("MySQLite")
+
 
 function initialize(config)
     MySQLite_config = config or MySQLite_config
@@ -167,6 +177,7 @@ end
 local CONNECTED_TO_MYSQL = false
 local msOOConnect
 databaseObject = nil
+
 local queuedQueries
 local cachedQueries
 
@@ -182,7 +193,6 @@ function begin()
             debug.Trace()
             error("Transaction ongoing!")
         end
-
         queuedQueries = {}
     end
 end
@@ -190,11 +200,7 @@ end
 function commit(onFinished)
     if not CONNECTED_TO_MYSQL then
         sql.Commit()
-
-        if onFinished then
-            onFinished()
-        end
-
+        if onFinished then onFinished() end
         return
     end
 
@@ -204,17 +210,14 @@ function commit(onFinished)
 
     if #queuedQueries == 0 then
         queuedQueries = nil
-
-        if onFinished then
-            onFinished()
-        end
-
+        if onFinished then onFinished() end
         return
     end
 
     -- Copy the table so other scripts can create their own queue
     local queue = table.Copy(queuedQueries)
     queuedQueries = nil
+
     -- Handle queued queries in order
     local queuePos = 0
     local call
@@ -229,11 +232,7 @@ function commit(onFinished)
 
         -- Base case, end of the queue
         if queuePos + 1 > #queue then
-            -- All queries have finished
-            if onFinished then
-                onFinished()
-            end
-
+            if onFinished then onFinished() end -- All queries have finished
             return
         end
 
@@ -247,15 +246,9 @@ end
 
 function queueQuery(sqlText, callback, errorCallback)
     if CONNECTED_TO_MYSQL then
-        table.insert(queuedQueries, {
-            query = sqlText,
-            callback = callback,
-            onError = errorCallback
-        })
-
+        table.insert(queuedQueries, {query = sqlText, callback = callback, onError = errorCallback})
         return
     end
-
     -- SQLite is instantaneous, simply running the query is equal to queueing it
     query(sqlText, callback, errorCallback)
 end
@@ -263,7 +256,6 @@ end
 local function msOOQuery(sqlText, callback, errorCallback, queryValue)
     local queryObject = databaseObject:query(sqlText)
     local data
-
     queryObject.onData = function(Q, D)
         data = data or {}
         data[#data + 1] = D
@@ -275,52 +267,32 @@ local function msOOQuery(sqlText, callback, errorCallback, queryValue)
 
             -- Immediately try reconnecting
             msOOConnect(MySQLite_config.Host, MySQLite_config.Username, MySQLite_config.Password, MySQLite_config.Database_name, MySQLite_config.Database_port)
-
             return
         end
 
         local supp = errorCallback and errorCallback(E, sqlText)
-
-        if not supp then
-            error(E .. " (" .. sqlText .. ")")
-        end
+        if not supp then error(E .. " (" .. sqlText .. ")") end
     end
 
     queryObject.onSuccess = function()
         local res = queryValue and data and data[1] and table.GetFirstValue(data[1]) or not queryValue and data or nil
-
-        if callback then
-            callback(res, queryObject:lastInsert())
-        end
+        if callback then callback(res, queryObject:lastInsert()) end
     end
-
     queryObject:start()
 end
 
 local function tmsqlQuery(sqlText, callback, errorCallback, queryValue)
     local call = function(res)
         res = res[1] -- For now only support one result set
-
         if not res.status then
             local supp = errorCallback and errorCallback(res.error, sqlText)
-
-            if not supp then
-                error(res.error .. " (" .. sqlText .. ")")
-            end
-
+            if not supp then error(res.error .. " (" .. sqlText .. ")") end
             return
         end
 
-        -- compatibility with other backends
-        if not res.data or #res.data == 0 then
-            res.data = nil
-        end
-
+        if not res.data or #res.data == 0 then res.data = nil end -- compatibility with other backends
         if queryValue and callback then return callback(res.data and res.data[1] and table.GetFirstValue(res.data[1]) or nil) end
-
-        if callback then
-            callback(res.data, res.lastid)
-        end
+        if callback then callback(res.data, res.lastid) end
     end
 
     databaseObject:Query(sqlText, call)
@@ -328,36 +300,28 @@ end
 
 local function SQLiteQuery(sqlText, callback, errorCallback, queryValue)
     sql.m_strError = "" -- reset last error
+
     local lastError = sql.LastError()
     local Result = queryValue and sql.QueryValue(sqlText) or sql.Query(sqlText)
 
     if sql.LastError() and sql.LastError() ~= lastError then
         local err = sql.LastError()
         local supp = errorCallback and errorCallback(err, sqlText)
-
-        if supp == false then
-            error(err .. " (" .. sqlText .. ")", 2)
-        end
-
+        if supp == false then error(err .. " (" .. sqlText .. ")", 2) end
         return
     end
 
-    if callback then
-        callback(Result)
-    end
-
+    if callback then callback(Result) end
     return Result
 end
 
 function query(sqlText, callback, errorCallback)
     local qFunc = (CONNECTED_TO_MYSQL and ((mysqlOO and msOOQuery) or (TMySQL and tmsqlQuery))) or SQLiteQuery
-
     return qFunc(sqlText, callback, errorCallback, false)
 end
 
 function queryValue(sqlText, callback, errorCallback)
     local qFunc = (CONNECTED_TO_MYSQL and ((mysqlOO and msOOQuery) or (TMySQL and tmsqlQuery))) or SQLiteQuery
-
     return qFunc(sqlText, callback, errorCallback, true)
 end
 
@@ -367,44 +331,39 @@ local function onConnected()
     -- Run the queries that were called before the connection was made
     for k, v in pairs(cachedQueries or {}) do
         cachedQueries[k] = nil
-
         if v[3] then
             queryValue(v[1], v[2])
         else
             query(v[1], v[2])
         end
     end
-
     cachedQueries = {}
     local GM = _G.GAMEMODE or _G.GM
+
     hook.Call("DatabaseInitialized", GM.DatabaseInitialized and GM or nil)
+
 end
 
 msOOConnect = function(host, username, password, database_name, database_port)
     databaseObject = mysqlOO.connect(host, username, password, database_name, database_port)
 
-    if timer.Exists("darkrp_check_mysql_status") then
-        timer.Remove("darkrp_check_mysql_status")
-    end
+    if timer.Exists("darkrp_check_mysql_status") then timer.Remove("darkrp_check_mysql_status") end
 
     databaseObject.onConnectionFailed = function(_, msg)
         timer.Simple(5, function()
             msOOConnect(MySQLite_config.Host, MySQLite_config.Username, MySQLite_config.Password, MySQLite_config.Database_name, MySQLite_config.Database_port)
         end)
-
-        error("Connection failed! " .. tostring(msg) .. "\nTrying again in 5 seconds.")
+        error("Connection failed! " .. tostring(msg) ..  "\nTrying again in 5 seconds.")
     end
 
     databaseObject.onConnected = onConnected
+
     databaseObject:connect()
 end
 
 local function tmsqlConnect(host, username, password, database_name, database_port)
     local db, err = TMySQL.Connect(host, username, password, database_name, database_port, nil, MySQLite_config.MultiStatements and multistatements or nil)
-
-    if err then
-        error("Connection failed! " .. err .. "\n")
-    end
+    if err then error("Connection failed! " .. err ..  "\n") end
 
     databaseObject = db
     onConnected()
@@ -423,7 +382,10 @@ function connectToMySQL(host, username, password, database_name, database_port)
 end
 
 function SQLStr(sqlStr)
-    local escape = not CONNECTED_TO_MYSQL and sql.SQLStr or mysqlOO and function(str) return "\"" .. databaseObject:escape(tostring(str)) .. "\"" end or TMySQL and function(str) return "\"" .. databaseObject:Escape(tostring(str)) .. "\"" end
+    local escape =
+        not CONNECTED_TO_MYSQL and sql.SQLStr or
+        mysqlOO                and function(str) return "\"" .. databaseObject:escape(tostring(str)) .. "\"" end or
+        TMySQL                 and function(str) return "\"" .. databaseObject:Escape(tostring(str)) .. "\"" end
 
     return escape(sqlStr)
 end


### PR DESCRIPTION
If you used a newer version of tmysql from SuperiorServer's github (https://github.com/SuperiorServers/gm_tmysql4), MySQLite.query() would return no data, and tmysql.initialize() is no longer a function so that would error too.

Changed tmysql.initialize to tmysql.Connect, but made tmysql.Connect use tmysql.Initialize if they're using an older version of tmysql.

Newer version of tmysql4 requires you to have tmysql:Poll() in a think hook also (https://github.com/SuperiorServers/dash/blob/master/lua/dash/libraries/server/mysql.lua#L85-L87)

Tested on these versions of tmysql, and working:
https://github.com/SuperiorServers/gm_tmysql4 (Newer version)
https://github.com/bkacjios/gm_tmysql4/ (Older version)