### PR TITLE
Use glualint-1.17.2 on ubuntu-20.04

### DIFF
--- a/.github/workflows/run-glualint.yml
+++ b/.github/workflows/run-glualint.yml
@@ -6,9 +6,9 @@ on:
   pull_request:
 jobs:
   run-glualint:
-    runs-on: ubuntu-18.04 # 20.04 lacks libffi6, which is used by glualint.
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - run: wget https://github.com/FPtje/GLuaFixer/releases/download/1.17.1/glualint-1.17.1-linux-stripped.zip
+      - run: wget https://github.com/FPtje/GLuaFixer/releases/download/1.17.2/glualint-1.17.2-linux-stripped.zip
       - run: unzip glualint-*.zip
       - run: ./glualint --output-format github lint .


### PR DESCRIPTION
The latest version should fix the libffi.so.6 issue described in the comment.

See https://github.com/FPtje/GLuaFixer/issues/96