### PR TITLE
Fix 'Attempt to index camEnd3D2D (A nil value)'

### DIFF
--- a/entities/entities/money_printer/cl_init.lua
+++ b/entities/entities/money_printer/cl_init.lua
@@ -8,6 +8,7 @@ function ENT:Initialize()
 end
 
 local camStart3D2D = cam.Start3D2D
+local camEnd3D2D = cam.End3D2D
 local drawWordBox = draw.WordBox
 local IsValid = IsValid
 


### PR DESCRIPTION
Currently camEnd3D2D() is a nil value, which breaks printers