### PR TITLE
Add a category for the gamemode

### DIFF
--- a/darkrp.txt
+++ b/darkrp.txt
@@ -1,10 +1,11 @@
 "darkrp"
 {
-	"base"		"sandbox"
-    "title"  "DarkRP"
-    "version"   "2.7.0"
-    "menusystem"	"1"
-    "workshopid"	"248302805"
+    "base"          "sandbox"
+    "title"         "DarkRP"
+    "version"       "2.7.0"
+    "category"      "rp"
+    "menusystem"    "1"
+    "workshopid"    "248302805"
 
     "author_name"   "FPtje Falco et al."
     "author_email"  ""


### PR DESCRIPTION
In the next update, the gamemodes can be categorized. With this change, players will be able to hide DarkRP and derived gamemodes under a `roleplay` category if they wish.

 More informations:
- https://steamcommunity.com/games/garrysmod/announcements/detail/2988675197234811881
- https://wiki.facepunch.com/gmod/Gamemode_Creation#gamemodetextfile