### PR TITLE
Reduce the Amount of Color and Vector calls in Draw/Think hooks

### DIFF
--- a/entities/entities/darkrp_laws/cl_init.lua
+++ b/entities/entities/darkrp_laws/cl_init.lua
@@ -2,10 +2,16 @@ include("shared.lua")
 
 local Laws = {}
 
+ENT.DrawPos = Vector(1, -111, 58)
+
+local color_navy_200 = Color(0, 0, 70, 200)
+local color_red = Color(255, 0, 0, 255)
+local color_white = color_white
+
 function ENT:Draw()
     self:DrawModel()
 
-    local DrawPos = self:LocalToWorld(Vector(1, -111, 58))
+    local DrawPos = self:LocalToWorld(self.DrawPos)
 
     local DrawAngles = self:GetAngles()
     DrawAngles:RotateAroundAxis(self:GetAngles():Forward(), 90)
@@ -16,14 +22,13 @@ function ENT:Draw()
         surface.SetDrawColor(0, 0, 0, 255)
         surface.DrawRect(0, 0, 558, 290)
 
-        draw.RoundedBox(4, 0, 0, 558, 30, Color(0, 0, 70, 200))
+        draw.RoundedBox(4, 0, 0, 558, 30, color_navy_200)
 
-        draw.DrawNonParsedSimpleText(DarkRP.getPhrase("laws_of_the_land"), "Roboto20", 279, 5, Color(255, 0, 0, 255), TEXT_ALIGN_CENTER)
+        draw.DrawNonParsedSimpleText(DarkRP.getPhrase("laws_of_the_land"), "Roboto20", 279, 5, color_red, TEXT_ALIGN_CENTER)
 
-        local col = Color(255, 255, 255, 255)
         local lastHeight = 0
         for k, v in ipairs(Laws) do
-            draw.DrawNonParsedText(string.format("%u. %s", k, v), "Roboto20", 5, 35 + lastHeight, col)
+            draw.DrawNonParsedText(string.format("%u. %s", k, v), "Roboto20", 5, 35 + lastHeight, color_white)
             lastHeight = lastHeight + (fn.ReverseArgs(string.gsub(v, "\n", "")) + 1) * 21
         end
 

--- a/entities/entities/drug/cl_init.lua
+++ b/entities/entities/drug/cl_init.lua
@@ -3,6 +3,9 @@ include("shared.lua")
 function ENT:Initialize()
 end
 
+local color_red = Color(140, 0, 0, 100)
+local color_white = color_white
+
 function ENT:Draw()
     self:DrawModel()
 
@@ -24,8 +27,8 @@ function ENT:Draw()
     TextAng:RotateAroundAxis(TextAng:Right(), CurTime() * -180)
 
     cam.Start3D2D(Pos + Ang:Right() * -15, TextAng, 0.1)
-        draw.WordBox(2, -TextWidth * 0.5 + 5, -30, text, "HUDNumber5", Color(140, 0, 0, 100), Color(255, 255, 255, 255))
-        draw.WordBox(2, -TextWidth2 * 0.5 + 5, 18, text2, "HUDNumber5", Color(140, 0, 0, 100), Color(255, 255, 255, 255))
+        draw.WordBox(2, -TextWidth * 0.5 + 5, -30, text, "HUDNumber5", color_red, color_white)
+        draw.WordBox(2, -TextWidth2 * 0.5 + 5, 18, text2, "HUDNumber5", color_red, color_white)
     cam.End3D2D()
 end
 

--- a/entities/entities/drug_lab/init.lua
+++ b/entities/entities/drug_lab/init.lua
@@ -5,6 +5,7 @@ include("shared.lua")
 DEFINE_BASECLASS("lab_base")
 
 ENT.SeizeReward = 350
+ENT.SpawnOffset = Vector(0, 0, 35)
 
 function ENT:Initialize()
     BaseClass.Initialize(self)
@@ -24,9 +25,9 @@ function ENT:canUse(activator)
 end
 
 function ENT:createItem(activator)
-    local drugPos = self:GetPos()
+    local drugPos = self:GetPos() + self.SpawnOffset
     local drug = ents.Create("drug")
-    drug:SetPos(Vector(drugPos.x, drugPos.y, drugPos.z + 35))
+    drug:SetPos(drugPos)
     drug:Setowning_ent(activator)
     drug.SID = activator.SID
     drug.nodupe = true

--- a/entities/entities/fadmin_motd/cl_init.lua
+++ b/entities/entities/fadmin_motd/cl_init.lua
@@ -55,6 +55,9 @@ end
 
 local gripTexture = surface.GetTextureID("sprites/grip")
 local ArrowTexture = surface.GetTextureID("gui/arrow")
+local color_white = color_white
+local color_darkgrey = Color(100, 100, 100, 255)
+
 function ENT:Draw()
     self:DrawModel()
 
@@ -89,7 +92,7 @@ function ENT:Draw()
             surface.SetTextPos( TextPosX, 0 )
             surface.DrawNonParsedText("Physgun/use the button to see the MOTD!")
 
-            draw.WordBox(4, -16, 24, "Click!", "default", Color(100, 100, 100, 255), Color(255, 255, 255, 255))
+            draw.WordBox(4, -16, 24, "Click!", "default", color_darkgrey, color_white)
 
             surface.SetDrawColor(255, 255, 255, 255)
             if IsAdmin and HasPhysgun then

--- a/entities/entities/fadmin_motd/shared.lua
+++ b/entities/entities/fadmin_motd/shared.lua
@@ -14,8 +14,8 @@ function ENT:CanTool(ply, trace, tool)
     return false
 end
 
+local PickupPos = Vector(1.8079, -0.6743, -62.3193)
 function ENT:PhysgunPickup(ply)
-    local PickupPos = Vector(1.8079, -0.6743, -62.3193)
     if ply:IsAdmin() and PickupPos:DistToSqr(self:WorldToLocal(ply:GetEyeTrace().HitPos)) < 49 then return true end
     return false
 end

--- a/entities/entities/gunlab/init.lua
+++ b/entities/entities/gunlab/init.lua
@@ -2,14 +2,16 @@ AddCSLuaFile("shared.lua")
 
 include("shared.lua")
 
+ENT.SpawnOffset = Vector(0, 0, 27)
+
 function ENT:createItem()
     local gun = ents.Create("spawned_weapon")
 
     local wep = weapons.Get(GAMEMODE.Config.gunlabweapon)
     gun:SetModel(wep and wep.WorldModel or "models/weapons/w_pist_p228.mdl")
     gun:SetWeaponClass(GAMEMODE.Config.gunlabweapon)
-    local gunPos = self:GetPos()
-    gun:SetPos(Vector(gunPos.x, gunPos.y, gunPos.z + 27))
+    local gunPos = self:GetPos() + self.SpawnOffset
+    gun:SetPos(gunPos)
     gun.nodupe = true
     gun:Spawn()
 end

--- a/entities/entities/lab_base/cl_init.lua
+++ b/entities/entities/lab_base/cl_init.lua
@@ -4,6 +4,9 @@ function ENT:Initialize()
     self:initVars()
 end
 
+local color_red = Color(140, 0, 0, 100)
+local color_white = color_white
+
 function ENT:DrawTranslucent()
     self:DrawModel()
 
@@ -25,7 +28,7 @@ function ENT:DrawTranslucent()
     TextAng:RotateAroundAxis(TextAng:Right(), CurTime() * -180)
 
     cam.Start3D2D(Pos + Ang:Right() * self.camMul, TextAng, 0.2)
-        draw.WordBox(2, -TextWidth * 0.5 + 5, -30, text, "HUDNumber5", Color(140, 0, 0, 100), Color(255, 255, 255, 255))
-        draw.WordBox(2, -TextWidth2 * 0.5 + 5, 18, text2, "HUDNumber5", Color(140, 0, 0, 100), Color(255, 255, 255, 255))
+        draw.WordBox(2, -TextWidth * 0.5 + 5, -30, text, "HUDNumber5", color_red, color_white)
+        draw.WordBox(2, -TextWidth2 * 0.5 + 5, 18, text2, "HUDNumber5", color_red, color_white)
     cam.End3D2D()
 end

--- a/entities/entities/meteor/cl_init.lua
+++ b/entities/entities/meteor/cl_init.lua
@@ -1,8 +1,6 @@
 ENT.Spawnable = false
 ENT.AdminSpawnable = false
 
-ENT.ParticleModel = Model("particles/smokey")
-
 include("shared.lua")
 
 language.Add("meteor", "meteor")
@@ -21,7 +19,7 @@ function ENT:Think()
 
     if not self.emitter then return end
 
-    local particle = self.emitter:Add(self.ParticleModel, vOffset)
+    local particle = self.emitter:Add(Model("particles/smokey"), vOffset)
     particle:SetVelocity(vNormal * math.Rand(10, 30))
     particle:SetDieTime(2.0)
     particle:SetStartAlpha(math.Rand(50, 150))

--- a/entities/entities/meteor/cl_init.lua
+++ b/entities/entities/meteor/cl_init.lua
@@ -1,6 +1,8 @@
 ENT.Spawnable = false
 ENT.AdminSpawnable = false
 
+ENT.ParticleModel = Model("particles/smokey")
+
 include("shared.lua")
 
 language.Add("meteor", "meteor")
@@ -11,20 +13,22 @@ function ENT:Initialize()
     self.emitter = ParticleEmitter(LocalPlayer():GetShootPos())
 end
 
+local color_grey = Color(200, 200, 210)
+
 function ENT:Think()
-    local vOffset = self:LocalToWorld(Vector(math.Rand(-3, 3), math.Rand(-3, 3), math.Rand(-3, 3))) + Vector(math.Rand(-3, 3), math.Rand(-3, 3), math.Rand(-3, 3))
+    local vOffset = self:LocalToWorld(VectorRand(-3, 3)) + VectorRand(-3, 3)
     local vNormal = (vOffset - self:GetPos()):GetNormalized()
 
     if not self.emitter then return end
 
-    local particle = self.emitter:Add(Model("particles/smokey"), vOffset)
+    local particle = self.emitter:Add(self.ParticleModel, vOffset)
     particle:SetVelocity(vNormal * math.Rand(10, 30))
     particle:SetDieTime(2.0)
     particle:SetStartAlpha(math.Rand(50, 150))
     particle:SetStartSize(math.Rand(8, 16))
     particle:SetEndSize(math.Rand(32, 64))
     particle:SetRoll(math.Rand(-0.2, 0.2))
-    particle:SetColor(Color(200, 200, 210))
+    particle:SetColor(color_grey)
 end
 
 function ENT:OnRemove()

--- a/entities/entities/microwave/init.lua
+++ b/entities/entities/microwave/init.lua
@@ -2,6 +2,8 @@ AddCSLuaFile("shared.lua")
 
 include("shared.lua")
 
+ENT.SpawnOffset = Vector(0, 0, 23)
+
 function ENT:canUse(activator)
     if activator.maxFoods and activator.maxFoods >= GAMEMODE.Config.maxfoods then
         DarkRP.notify(activator, 1, 3, DarkRP.getPhrase("limit", self.itemPhrase))
@@ -11,9 +13,9 @@ function ENT:canUse(activator)
 end
 
 function ENT:createItem(activator)
-    local foodPos = self:GetPos()
+    local foodPos = self:GetPos() + self.SpawnOffset
     local food = ents.Create("food")
-    food:SetPos(Vector(foodPos.x, foodPos.y, foodPos.z + 23))
+    food:SetPos(foodPos)
     food:Setowning_ent(activator)
     food.nodupe = true
     food:Spawn()

--- a/entities/entities/money_printer/init.lua
+++ b/entities/entities/money_printer/init.lua
@@ -2,6 +2,8 @@ AddCSLuaFile("cl_init.lua")
 AddCSLuaFile("shared.lua")
 include("shared.lua")
 
+ENT.SpawnOffset = Vector(15, 0, 15)
+
 local function PrintMore(ent)
     if not IsValid(ent) then return end
 
@@ -99,7 +101,7 @@ function ENT:CreateMoneybag()
     local prevent, hookAmount = hook.Run("moneyPrinterPrintMoney", self, amount)
     if prevent == true then return end
 
-    local MoneyPos = self:GetPos()
+    local MoneyPos = self:GetPos() + self.SpawnOffset
     amount = hookAmount or amount
 
     if self.OverheatChance and self.OverheatChance > 0 then
@@ -112,7 +114,7 @@ function ENT:CreateMoneybag()
         if math.random(1, overheatchance) == 3 then self:BurstIntoFlames() end
     end
 
-    local moneybag = DarkRP.createMoneyBag(Vector(MoneyPos.x + 15, MoneyPos.y, MoneyPos.z + 15), amount)
+    local moneybag = DarkRP.createMoneyBag(MoneyPos, amount)
     hook.Run("moneyPrinterPrinted", self, moneybag)
     self.sparking = false
     timer.Simple(math.random(self.MinTimer, self.MaxTimer), function() PrintMore(self) end)

--- a/entities/entities/spawned_shipment/cl_init.lua
+++ b/entities/entities/spawned_shipment/cl_init.lua
@@ -106,6 +106,9 @@ function ENT:drawFloatingGun()
     render.EnableClipping(false)
 end
 
+local color_red = Color(140, 0, 0, 100)
+local color_white = Color(255, 255, 255)
+
 function ENT:drawInfo()
     local Pos = self:GetPos()
     local Ang = self:GetAngles()
@@ -121,8 +124,8 @@ function ENT:drawInfo()
     local TextWidth2 = surface.GetTextSize(contents)
 
     cam.Start3D2D(Pos + Ang:Up() * 25, Ang, 0.2)
-        draw.WordBox(2, -TextWidth * 0.5 + 5, -30, text, "HUDNumber5", Color(140, 0, 0, 100), Color(255, 255, 255, 255))
-        draw.WordBox(2, -TextWidth2 * 0.5 + 5, 18, contents, "HUDNumber5", Color(140, 0, 0, 100), Color(255, 255, 255, 255))
+        draw.WordBox(2, -TextWidth * 0.5 + 5, -30, text, "HUDNumber5", color_red, color_white)
+        draw.WordBox(2, -TextWidth2 * 0.5 + 5, 18, contents, "HUDNumber5", color_red, color_white)
     cam.End3D2D()
 
     Ang:RotateAroundAxis(Ang:Forward(), 90)
@@ -132,8 +135,8 @@ function ENT:drawInfo()
     TextWidth2 = surface.GetTextSize(self:Getcount())
 
     cam.Start3D2D(Pos + Ang:Up() * 17, Ang, 0.14)
-        draw.WordBox(2, -TextWidth * 0.5 + 5, -150, text, "HUDNumber5", Color(140, 0, 0, 100), Color(255, 255, 255, 255))
-        draw.WordBox(2, -TextWidth2 * 0.5 + 0, -102, self:Getcount(), "HUDNumber5", Color(140, 0, 0, 100), Color(255, 255, 255, 255))
+        draw.WordBox(2, -TextWidth * 0.5 + 5, -150, text, "HUDNumber5", color_red, color_white)
+        draw.WordBox(2, -TextWidth2 * 0.5 + 0, -102, self:Getcount(), "HUDNumber5", color_red, color_white)
     cam.End3D2D()
 end
 

--- a/entities/entities/spawned_weapon/cl_init.lua
+++ b/entities/entities/spawned_weapon/cl_init.lua
@@ -1,5 +1,8 @@
 include("shared.lua")
 
+local color_red = Color(140, 0, 0, 100)
+local color_white = Color(255, 255, 255)
+
 function ENT:Draw()
     local ret = hook.Call("onDrawSpawnedWeapon", nil, self)
     if ret ~= nil then return end
@@ -18,13 +21,13 @@ function ENT:Draw()
     Ang:RotateAroundAxis(Ang:Forward(), 90)
 
     cam.Start3D2D(Pos + Ang:Up(), Ang, 0.11)
-        draw.WordBox(2, 0, -40, text, "HUDNumber5", Color(140, 0, 0, 100), Color(255,255,255,255))
+        draw.WordBox(2, 0, -40, text, "HUDNumber5", color_red, color_white)
     cam.End3D2D()
 
     Ang:RotateAroundAxis(Ang:Right(), 180)
 
     cam.Start3D2D(Pos + Ang:Up() * 3, Ang, 0.11)
-        draw.WordBox(2, -TextWidth, -40, text, "HUDNumber5", Color(140, 0, 0, 100), Color(255,255,255,255))
+        draw.WordBox(2, -TextWidth, -40, text, "HUDNumber5", color_red, color_white)
     cam.End3D2D()
 end
 


### PR DESCRIPTION
- Store most static Color calls in local var
- Store most static Vector offsets in local var
- Makes some code more readable
- Cached Model call in Meteor

<details>
    <summary>Other Stuff</summary>
    <p>There were more changes but they were either in FAdmin or changing them made the code worse off either by being less readable, worse performance or were rarely used.</p>
    <p>I have some modification for `entities\entities\meteor\init.lua` but they are for another commit </br>I have some modification for `gamemode\modules\chatindicator\cl_init.lua` but I didn't like the changes.</p>
</details>