### PR TITLE
Remove the SteamID64/AccountID workaround

### DIFF
--- a/gamemode/modules/workarounds/sh_workarounds.lua
+++ b/gamemode/modules/workarounds/sh_workarounds.lua
@@ -86,26 +86,6 @@ timer.Simple(3, function()
 ]])
 end)
 
-if game.SinglePlayer() or GetConVar("sv_lan"):GetBool() and
-   not DarkRP.disabledDefaults["workarounds"]["nil SteamID64 and AccountID local server fix"] then
-    local plyMeta = FindMetaTable("Player")
-
-    if SERVER then
-        local sid64 = plyMeta.SteamID64
-
-        function plyMeta:SteamID64(...)
-            return sid64(self, ...) or "0"
-        end
-    end
-
-    local aid = plyMeta.AccountID
-
-    function plyMeta:AccountID(...)
-        return aid(self, ...) or 0
-    end
-end
-
-
 if CLIENT and not DarkRP.disabledDefaults["workarounds"]["Cam function descriptive errors"] then
     local cams3D, cams2D = 0, 0
     local cam_Start = cam.Start


### PR DESCRIPTION
In the next update (scheduled for **June 9**) and currently implemented in the development branches, this issue is fixed.

Sources:
- https://github.com/Facepunch/garrysmod-issues/issues/2614
- https://commits.facepunch.com/381723
- https://docs.google.com/document/u/1/d/e/2PACX-1vTzEJEpdEje8e-FgsbyWGydu_Ez7p82MwOUPmRlUAAJ-KpkNJhHctyadZosfUYjVTz26KGip7bI7M9T/pub

**Note**: If this pull request is merge, then [this](https://github.com/FPtje/darkrpmodification/blob/b57df6bc662a3b1dad92aac773f100d737749018/lua/darkrp_config/disabled_defaults.lua#L179) line should also be deleted.