### PR TITLE
Disable sv_allowcslua by default

### DIFF
--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -74,7 +74,7 @@ GM.Config.deathpov                      = false
 -- decalcleaner - Enable/Disable clearing every player's decals.
 GM.Config.decalcleaner                  = false
 -- disallowClientsideScripts - Clientside scripts can be very useful for customizing the HUD or to aid in building. This option bans those scripts.
-GM.Config.disallowClientsideScripts     = false
+GM.Config.disallowClientsideScripts     = true
 -- doorwarrants - Enable/disable Warrant requirement to enter property.
 GM.Config.doorwarrants                  = true
 -- dropmoneyondeath - Enable/disable whether people drop money on death.


### PR DESCRIPTION
The amount of servers with this enabled without knowing this is a feature is laughable. There are no benefits to allowing people load scripts without the acknowledgement of the owners. If they want to be able to run scripts then they can change this themselves.

Thats my opinion anyway.