### PR TITLE
Fix tooltip errors with the DarkRP derma skin

### DIFF
--- a/gamemode/modules/dermaskin/cl_dermaskin.lua
+++ b/gamemode/modules/dermaskin/cl_dermaskin.lua
@@ -174,6 +174,8 @@ SKIN.tex.CategoryList.Outer     = GWEN.CreateTextureBorder(256, 384, 63, 63, 8, 
 SKIN.tex.CategoryList.Inner     = GWEN.CreateTextureBorder(256 + 64, 384, 63, 63, 8, 21, 8, 8)
 SKIN.tex.CategoryList.Header    = GWEN.CreateTextureBorder(320, 352, 63, 31, 8, 8, 8, 8)
 
+SKIN.tex.Tooltip                = GWEN.CreateTextureBorder(384, 64, 31, 31, 8, 8, 8, 8)
+
 SKIN.Colours = {}
 
 SKIN.Colours.Window = {}


### PR DESCRIPTION
This is a possible fix for the issue #3131.

Here is the in-game result:
![image](https://user-images.githubusercontent.com/26360935/123242903-c5227800-d4e2-11eb-941d-2444d109b019.png)
