### PR TITLE
Fix job indices registered in categories

### DIFF
--- a/gamemode/modules/base/sh_createitems.lua
+++ b/gamemode/modules/base/sh_createitems.lua
@@ -408,7 +408,7 @@ plyMeta.getJobTable = function(ply)
     end
     return tbl
 end
-local jobCount = 0
+
 function DarkRP.createJob(Name, colorOrTable, model, Description, Weapons, command, maximum_amount_of_this_class, Salary, admin, Vote, Haslicense, NeedToChangeFrom, CustomCheck)
     local tableSyntaxUsed = not IsColor(colorOrTable)
 
@@ -428,7 +428,8 @@ function DarkRP.createJob(Name, colorOrTable, model, Description, Weapons, comma
 
     if not (GM or GAMEMODE):CustomObjFitsMap(CustomTeam) then return end
 
-    jobCount = jobCount + 1
+    local jobCount = #RPExtraTeams + 1
+
     CustomTeam.team = jobCount
 
     CustomTeam.salary = math.floor(CustomTeam.salary)
@@ -450,8 +451,8 @@ function DarkRP.createJob(Name, colorOrTable, model, Description, Weapons, comma
 
     jobByCmd[CustomTeam.command] = table.insert(RPExtraTeams, CustomTeam)
     DarkRP.addToCategory(CustomTeam, "jobs", CustomTeam.category)
-    local Team = #RPExtraTeams
-    team.SetUp(Team, Name, CustomTeam.color)
+
+    team.SetUp(jobCount, Name, CustomTeam.color)
 
     timer.Simple(0, function()
         declareTeamCommands(CustomTeam)

--- a/gamemode/modules/base/sh_createitems.lua
+++ b/gamemode/modules/base/sh_createitems.lua
@@ -426,6 +426,8 @@ function DarkRP.createJob(Name, colorOrTable, model, Description, Weapons, comma
     local valid, err, hints = DarkRP.validateJob(CustomTeam)
     if not valid then DarkRP.error(string.format("Corrupt team: %s!\n%s", CustomTeam.name or "", err), 2, hints) end
 
+    if not (GM or GAMEMODE):CustomObjFitsMap(CustomTeam) then return end
+
     jobCount = jobCount + 1
     CustomTeam.team = jobCount
 
@@ -445,8 +447,6 @@ function DarkRP.createJob(Name, colorOrTable, model, Description, Weapons, comma
     CustomTeam.ShowSpare1            = CustomTeam.ShowSpare1            and fp{DarkRP.simplerrRun, CustomTeam.ShowSpare1}
     CustomTeam.ShowSpare2            = CustomTeam.ShowSpare2            and fp{DarkRP.simplerrRun, CustomTeam.ShowSpare2}
     CustomTeam.canStartVote          = CustomTeam.canStartVote          and fp{DarkRP.simplerrRun, CustomTeam.canStartVote}
-
-    if not (GM or GAMEMODE):CustomObjFitsMap(CustomTeam) then return end
 
     jobByCmd[CustomTeam.command] = table.insert(RPExtraTeams, CustomTeam)
     DarkRP.addToCategory(CustomTeam, "jobs", CustomTeam.category)


### PR DESCRIPTION
A few weeks ago I created a custom scoreboard using the `DarkRP.getCategories` function to make my job easier. However, while trying it out on a public server I found that players in some jobs were simply not displayed or appeared in the wrong category.

At the beginning, I thought for a long time there was a mistake on my side, but when I tried to compare the index of some jobs taken by players and those reported by the `DarkRP.getCategories` function, I realized that there was a problem.

After some tests, I concluded that jobs restricted by the `map` field were **still "counted"** by the function but did not appear in the `RPExtraTeams` table (which is normal). 

Looking at the job creation code, I quickly realized that the map verification function was executed too late and the job was still "counted", which can create an offset with the following creations.

To illustrate my point, here is an example. I used the latest version of DarkRP on GitHub (also tested with the workshop one) and added a few extra jobs including one that was restricted in a map that was not the one I tested (so it should be disabled).

```lua
1: /// "Citizens" category, no issue
2: /// "Civil Protection" category, no issue
3: /// "Gangsters" category, no issue
4: /// "Others"/"Or whatever you want" category, some issues

		canSee	=	function: 0x4490f2b0
		categorises	=	jobs
		color:
				a	=	255
				b	=	0
				g	=	107
				r	=	0
		members:
				1:
						admin	=	0
						candemote	=	false
						category	=	Other
						color:
								a	=	253
								b	=	153
								g	=	0
								r	=	0
						command	=	base
						description	=	 ... 
						hasLicense	=	false
						max	=	0
						model:
								1	=	models/player/Group01/male_02.mdl
						name	=	Base
						salary	=	3
						team	=	11 <----- THIS LINE IS RIGHT!
						vote	=	false
						weapons:
								1	=	base
				2:
						admin	=	0
						candemote	=	true
						category	=	Other
						color:
								a	=	255
								b	=	99
								g	=	99
								r	=	238
						command	=	cook
						cook	=	true
						default	=	true
						description	=	As a cook, it is your responsibility to feed the other members of your city.
            You can spawn a microwave and sell the food you make:
            /buymicrowave
						hasLicense	=	false
						max	=	2
						model	=	models/player/mossman.mdl
						name	=	Cook
						salary	=	45
						team	=	10 <----- THIS LINE IS RIGHT! (Default job)
						vote	=	false
						weapons:
				3:
						admin	=	0
						candemote	=	false
						category	=	Other
						color:
								a	=	253
								b	=	153
								g	=	0
								r	=	0
						command	=	yellow
						description	=	 ... 
						hasLicense	=	false
						max	=	0
						model:
								1	=	...
						name	=	Yellow
						salary	=	3
						team	=	16 <----- THIS LINE IS WRONG!
						vote	=	false
						weapons:
								1	=	yellow
				4:
						admin	=	0
						candemote	=	false
						category	=	Other
						color:
								a	=	253
								b	=	153
								g	=	0
								r	=	0
						command	=	orange
						description	=	 ... 
						hasLicense	=	false
						max	=	0
						model:
								1	=	...
						name	=	Orange
						salary	=	3
						team	=	15 <----- THIS LINE IS WRONG!
						vote	=	false
						weapons:
								1	=	orange
				5:
						admin	=	0
						candemote	=	false
						category	=	Other
						color:
								a	=	253
								b	=	153
								g	=	0
								r	=	0
						command	=	pink
						description	=	 ... 
						hasLicense	=	false
						max	=	0
						model:
								1	=	...
						name	=	Pink
						salary	=	3
						team	=	17 <----- THIS LINE IS WRONG!
						vote	=	false
						weapons:
								1	=	pink
				6:
						admin	=	0
						candemote	=	false
						category	=	Other
						color:
								a	=	253
								b	=	153
								g	=	0
								r	=	0
						command	=	red
						description	=	 ... 
						hasLicense	=	false
						max	=	0
						model:
								1	=	...
						name	=	Red
						salary	=	3
						team	=	14 <----- THIS LINE IS WRONG!
						vote	=	false
						weapons:
								1	=	red
				7:
						admin	=	0
						candemote	=	false
						category	=	Other
						color:
								a	=	253
								b	=	153
								g	=	0
								r	=	0
						command	=	green
						description	=	 ... 
						hasLicense	=	false
						max	=	0
						model:
								1	=	...
						name	=	Green
						salary	=	3
						team	=	13 <----- THIS LINE IS WRONG!
						vote	=	false
						weapons:
								1	=	green
		name	=	Other
		sortOrder	=	255
		startExpanded	=	true
```

As you can see the disabled job (which is normally called `Blue`) is not present but however the indices shown above are mostly wrong and take into account this disabled job. I'm currently in the job called `Green` (it's the last one on the list) and it says it's index `13`, so I'm trying to see if that's accurate.

```
] lua_run print(Entity(1):Team(), Entity(1):Team() == TEAM_GREEN, Entity(1):Team() == 13)
> print(Entity(1):Team(), Entity(1):Team() == TEAM_GREEN, Entity(1):Team() == 13)...
12	true	false
```

And as you can see, this is totally wrong. With this change, this problem has completely disappeared without any side effects.