### PR TITLE
Allow opening the pocket menu via reload in singleplayer mode.

### DIFF
--- a/entities/weapons/pocket/cl_menu.lua
+++ b/entities/weapons/pocket/cl_menu.lua
@@ -61,7 +61,7 @@ function DarkRP.openPocketMenu()
     reload()
     frame:SetSkin(GAMEMODE.Config.DarkRPSkin)
 end
-
+usermessage.Hook("PocketMenu", DarkRP.openPocketMenu)
 
 --[[---------------------------------------------------------------------------
 UI

--- a/entities/weapons/pocket/cl_menu.lua
+++ b/entities/weapons/pocket/cl_menu.lua
@@ -61,9 +61,7 @@ function DarkRP.openPocketMenu()
     reload()
     frame:SetSkin(GAMEMODE.Config.DarkRPSkin)
 end
-net.Receive( "DarkRP_PocketMenu", function( len, pl )
-    DarkRP.openPocketMenu()
-end )
+net.Receive("DarkRP_PocketMenu", DarkRP.openPocketMenu)
 
 --[[---------------------------------------------------------------------------
 UI

--- a/entities/weapons/pocket/cl_menu.lua
+++ b/entities/weapons/pocket/cl_menu.lua
@@ -62,9 +62,7 @@ function DarkRP.openPocketMenu()
     frame:SetSkin(GAMEMODE.Config.DarkRPSkin)
 end
 net.Receive( "DarkRP_PocketMenu", function( len, pl )
-	if not ( IsValid( pl ) and pl:IsPlayer() ) then
-		DarkRP.openPocketMenu()
-	end
+    DarkRP.openPocketMenu()
 end )
 
 --[[---------------------------------------------------------------------------

--- a/entities/weapons/pocket/cl_menu.lua
+++ b/entities/weapons/pocket/cl_menu.lua
@@ -61,7 +61,11 @@ function DarkRP.openPocketMenu()
     reload()
     frame:SetSkin(GAMEMODE.Config.DarkRPSkin)
 end
-usermessage.Hook("PocketMenu", DarkRP.openPocketMenu)
+net.Receive( "DarkRP_PocketMenu", function( len, pl )
+	if not ( IsValid( pl ) and pl:IsPlayer() ) then
+		DarkRP.openPocketMenu()
+	end
+end )
 
 --[[---------------------------------------------------------------------------
 UI

--- a/entities/weapons/pocket/shared.lua
+++ b/entities/weapons/pocket/shared.lua
@@ -118,13 +118,13 @@ function SWEP:SecondaryAttack()
 end
 
 function SWEP:Reload()
-    if CLIENT then 
-      DarkRP.openPocketMenu() 
+    if CLIENT then
+      DarkRP.openPocketMenu()
     end
 
     if SERVER then
-        umsg.Start("PocketMenu", self:GetOwner())
-        umsg.End()
+        net.Start("DarkRP_PocketMenu")
+        net.Send(self:GetOwner())
     end
 end
 

--- a/entities/weapons/pocket/shared.lua
+++ b/entities/weapons/pocket/shared.lua
@@ -118,9 +118,14 @@ function SWEP:SecondaryAttack()
 end
 
 function SWEP:Reload()
-    if not CLIENT then return end
+    if CLIENT then 
+      DarkRP.openPocketMenu() 
+    end
 
-    DarkRP.openPocketMenu()
+    if SERVER then
+        umsg.Start("PocketMenu", self:GetOwner())
+        umsg.End()
+    end
 end
 
 local meta = FindMetaTable("Player")

--- a/entities/weapons/pocket/shared.lua
+++ b/entities/weapons/pocket/shared.lua
@@ -122,7 +122,7 @@ function SWEP:Reload()
       DarkRP.openPocketMenu()
     end
 
-    if SERVER then
+    if SERVER and game.SinglePlayer() then
         net.Start("DarkRP_PocketMenu")
         net.Send(self:GetOwner())
     end

--- a/entities/weapons/pocket/sv_init.lua
+++ b/entities/weapons/pocket/sv_init.lua
@@ -242,6 +242,8 @@ local function sendPocketItems(ply)
     net.Send(ply)
 end
 
+util.AddNetworkString("DarkRP_PocketMenu")
+
 --[[---------------------------------------------------------------------------
 Interface functions
 ---------------------------------------------------------------------------]]


### PR DESCRIPTION
Because you couldn't, previously. Uses the same workaround that keys use.