### PR TITLE
Stop people from dropping weapons they spawn with by default.

### DIFF
--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -86,7 +86,7 @@ GM.Config.droppocketdeath               = true
 -- dropweapondeath - Enable/disable whether people drop their current weapon when they die.
 GM.Config.dropweapondeath               = false
 -- Whether players can drop the weapons they spawn with.
-GM.Config.dropspawnedweapons            = true
+GM.Config.dropspawnedweapons            = false
 -- dynamicvoice - Enable/disable whether only people in the same room as you can hear your mic.
 GM.Config.dynamicvoice                  = true
 -- earthquakes - Enable/disable earthquakes.


### PR DESCRIPTION
I still see new server owners leaving this on without even noticing it. This would erase that issue. This pretty much allows duping of weapons you spawn with if the server has an inventory system. Even though most servers have it disabled, some people forget or don't know to disable it. This would also require a pull request to darkrpmodification to disable it in that config file but Ill do that if this one is accepted.