### PR TITLE
Removed DarkRP.removeJob ( 'jobCount' (a nil value) )

### DIFF
--- a/gamemode/modules/base/sh_createitems.lua
+++ b/gamemode/modules/base/sh_createitems.lua
@@ -481,7 +481,6 @@ end
 function DarkRP.removeJob(i)
     local job = RPExtraTeams[i]
     jobByCmd[job.command] = nil
-    jobCount = jobCount - 1
 
     DarkRP.removeChatCommand("vote" .. job.command)
     removeCustomItem(RPExtraTeams, "jobs", "onJobRemoved", true, i)


### PR DESCRIPTION
2015'ish changes had a top level jobCount local variable (and used on create/remove functions).
This local variable doesn't exist anymore, yet, the function is trying to reduce the jobCount.

Removed the counter, it's not used anywhere else in the function, and the local variable is not even present anymore