### PR TITLE
Optimise server's side of entityvars.lua

### DIFF
--- a/gamemode/modules/base/sv_entityvars.lua
+++ b/gamemode/modules/base/sv_entityvars.lua
@@ -88,7 +88,7 @@ function meta:sendDarkRPVars()
 
             local vars = {}
             for var, value in pairs(DarkRPVars[target] or {}) do
-                if self ~= target and (privateDRPVars[target] or {})[var] then continue end
+                if self ~= target and (privateDarkRPVars[target] or {})[var] then continue end
                 table.insert(vars, var)
             end
 

--- a/gamemode/modules/base/sv_entityvars.lua
+++ b/gamemode/modules/base/sv_entityvars.lua
@@ -255,12 +255,16 @@ function meta:customEntityCount(entTable)
 end
 
 hook.Add("PlayerDisconnected", "DarkRP_VarRemoval", function(ply)
-    DarkRPVars[ply] = nil
-    privateDarkRPVars[ply] = nil
-
     maxEntities[ply] = nil
 
     net.Start("DarkRP_DarkRPVarDisconnect")
         net.WriteUInt(ply:UserID(), 16)
     net.Broadcast()
+end)
+
+hook.Add("EntityRemoved", "DarkRP_VarRemoval", function(ent) -- We use EntityRemoved to clear players of tables, because it is always called after the PlayerDisconnected hook
+    if ent:IsPlayer() then
+        DarkRPVars[ent] = nil
+        privateDarkRPVars[ent] = nil
+    end
 end)

--- a/gamemode/modules/base/sv_entityvars.lua
+++ b/gamemode/modules/base/sv_entityvars.lua
@@ -1,5 +1,8 @@
 local meta = FindMetaTable("Player")
 
+local DarkRPVars = {}
+local privateDarkRPVars = {}
+
 --[[---------------------------------------------------------------------------
 Pooled networking strings
 ---------------------------------------------------------------------------]]
@@ -16,7 +19,7 @@ Player vars
 Remove a player's DarkRPVar
 ---------------------------------------------------------------------------]]
 function meta:removeDarkRPVar(var, target)
-    local vars = self.DarkRPVars
+    local vars = DarkRPVars[self]
     hook.Call("DarkRPVarChanged", nil, self, var, (vars and vars[var]) or nil, nil)
     target = target or player.GetAll()
     vars = vars or {}
@@ -35,7 +38,8 @@ function meta:setDarkRPVar(var, value, target)
     target = target or player.GetAll()
 
     if value == nil then return self:removeDarkRPVar(var, target) end
-    local vars = self.DarkRPVars
+
+    local vars = DarkRPVars[self]
     hook.Call("DarkRPVarChanged", nil, self, var, (vars and vars[var]) or nil, value)
 
     vars = vars or {}
@@ -51,7 +55,7 @@ end
 Set a private DarkRPVar
 ---------------------------------------------------------------------------]]
 function meta:setSelfDarkRPVar(var, value)
-    local vars = self.privateDRPVars
+    local vars = privateDarkRPVars[self]
 
     vars = vars or {}
     vars[var] = true
@@ -63,7 +67,7 @@ end
 Get a DarkRPVar
 ---------------------------------------------------------------------------]]
 function meta:getDarkRPVar(var)
-    local vars = self.DarkRPVars
+    local vars = DarkRPVars[self]
 
     vars = vars or {}
     return vars[var]
@@ -251,8 +255,12 @@ function meta:customEntityCount(entTable)
     return entities
 end
 
-hook.Add("PlayerDisconnected", "removeLimits", function(ply)
+hook.Add("PlayerDisconnected", "DarkRP_VarRemoval", function(ply)
+	DarkRPVars[ply] = nil
+	privateDarkRPVars[ply] = nil
+
     maxEntities[ply] = nil
+
     net.Start("DarkRP_DarkRPVarDisconnect")
         net.WriteUInt(ply:UserID(), 16)
     net.Broadcast()

--- a/gamemode/modules/base/sv_entityvars.lua
+++ b/gamemode/modules/base/sv_entityvars.lua
@@ -86,16 +86,16 @@ function meta:sendDarkRPVars()
         for _, target in ipairs(plys) do
             net.WriteUInt(target:UserID(), 16)
 
-            local DarkRPVars = {}
-            for var, value in pairs(target.DarkRPVars) do
-                if self ~= target and (target.privateDRPVars or {})[var] then continue end
-                table.insert(DarkRPVars, var)
+            local vars = {}
+            for var, value in pairs(DarkRPVars[target]) do
+                if self ~= target and (privateDRPVars[target] or {})[var] then continue end
+                table.insert(vars, var)
             end
 
-            local vars_cnt = #DarkRPVars
+            local vars_cnt = #vars
             net.WriteUInt(vars_cnt, DarkRP.DARKRP_ID_BITS + 2) -- Allow for three times as many unknown DarkRPVars than the limit
             for i = 1, vars_cnt, 1 do
-                DarkRP.writeNetDarkRPVar(DarkRPVars[i], target.DarkRPVars[DarkRPVars[i]])
+                DarkRP.writeNetDarkRPVar(vars[i], DarkRPVars[target][vars[i]])
             end
         end
     net.Send(self)
@@ -256,8 +256,8 @@ function meta:customEntityCount(entTable)
 end
 
 hook.Add("PlayerDisconnected", "DarkRP_VarRemoval", function(ply)
-	DarkRPVars[ply] = nil
-	privateDarkRPVars[ply] = nil
+    DarkRPVars[ply] = nil
+    privateDarkRPVars[ply] = nil
 
     maxEntities[ply] = nil
 

--- a/gamemode/modules/base/sv_entityvars.lua
+++ b/gamemode/modules/base/sv_entityvars.lua
@@ -20,10 +20,11 @@ Remove a player's DarkRPVar
 ---------------------------------------------------------------------------]]
 function meta:removeDarkRPVar(var, target)
     local vars = DarkRPVars[self]
-    hook.Call("DarkRPVarChanged", nil, self, var, (vars and vars[var]) or nil, nil)
+    hook.Call("DarkRPVarChanged", nil, self, var, vars and vars[var], nil)
     target = target or player.GetAll()
-    vars = vars or {}
-    vars[var] = nil
+
+    DarkRPVars[self] = DarkRPVars[self] or {}
+    DarkRPVars[self][var] = nil
 
     net.Start("DarkRP_PlayerVarRemoval")
         net.WriteUInt(self:UserID(), 16)
@@ -40,10 +41,10 @@ function meta:setDarkRPVar(var, value, target)
     if value == nil then return self:removeDarkRPVar(var, target) end
 
     local vars = DarkRPVars[self]
-    hook.Call("DarkRPVarChanged", nil, self, var, (vars and vars[var]) or nil, value)
+    hook.Call("DarkRPVarChanged", nil, self, var, vars and vars[var], value)
 
-    vars = vars or {}
-    vars[var] = value
+    DarkRPVars[self] = DarkRPVars[self] or {}
+    DarkRPVars[self][var] = value
 
     net.Start("DarkRP_PlayerVar")
         net.WriteUInt(self:UserID(), 16)
@@ -55,10 +56,8 @@ end
 Set a private DarkRPVar
 ---------------------------------------------------------------------------]]
 function meta:setSelfDarkRPVar(var, value)
-    local vars = privateDarkRPVars[self]
-
-    vars = vars or {}
-    vars[var] = true
+    privateDarkRPVars[self] = privateDarkRPVars[self] or {}
+    privateDarkRPVars[self][var] = true
 
     self:setDarkRPVar(var, value, self)
 end

--- a/gamemode/modules/base/sv_entityvars.lua
+++ b/gamemode/modules/base/sv_entityvars.lua
@@ -87,7 +87,7 @@ function meta:sendDarkRPVars()
             net.WriteUInt(target:UserID(), 16)
 
             local vars = {}
-            for var, value in pairs(DarkRPVars[target]) do
+            for var, value in pairs(DarkRPVars[target] or {}) do
                 if self ~= target and (privateDRPVars[target] or {})[var] then continue end
                 table.insert(vars, var)
             end


### PR DESCRIPTION
- The client already has this optimisation in place and this results in much faster access time
FProfiler has shown, that "getDarkRPVar" is one of the most expensive bottlenecks

- Renamed unnamed hook
This hook fooled me a few times already into searching for it, because I didn't know what it did, while working with hook.GetTable()[index] to find a hook returning something

This PR resolves this.

Fixing this problem ALONE is not possible without modifying DarkRP core files.