### PR TITLE
Don't put bots in AFK-Mode

### DIFF
--- a/gamemode/modules/afk/sv_afk.lua
+++ b/gamemode/modules/afk/sv_afk.lua
@@ -17,6 +17,7 @@ end
 
 local function SetAFK(ply)
     if ply:IsBot() then return end
+    
     local rpname = ply:getDarkRPVar("rpname")
     ply:setSelfDarkRPVar("AFK", not ply:getDarkRPVar("AFK"))
 

--- a/gamemode/modules/afk/sv_afk.lua
+++ b/gamemode/modules/afk/sv_afk.lua
@@ -16,6 +16,7 @@ local function AFKDemote(ply)
 end
 
 local function SetAFK(ply)
+    if ply:IsBot() then return end
     local rpname = ply:getDarkRPVar("rpname")
     ply:setSelfDarkRPVar("AFK", not ply:getDarkRPVar("AFK"))
 


### PR DESCRIPTION
Except bots from afk system because they don't trigger "KeyPress" hook.