### PR TITLE
Add canGiveLicense hook

### DIFF
--- a/gamemode/modules/police/sv_commands.lua
+++ b/gamemode/modules/police/sv_commands.lua
@@ -297,30 +297,16 @@ end
 DarkRP.defineChatCommand("requestlicense", RequestLicense)
 
 local function GiveLicense(ply)
-    local noMayorExists = fn.Compose{fn.Null, fn.Curry(fn.Filter, 2)(ply.isMayor), player.GetAll}
-    local noChiefExists = fn.Compose{fn.Null, fn.Curry(fn.Filter, 2)(ply.isChief), player.GetAll}
-
     local LookingAt = ply:GetEyeTrace().Entity
     if not IsValid(LookingAt) or not LookingAt:IsPlayer() or LookingAt:GetPos():DistToSqr(ply:GetPos()) > 10000 then
         DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("player")))
         return ""
     end
 
-    local canGive, cantGiveReason = hook.Call("canGiveLicense", GAMEMODE, ply, LookingAt)
+    local canGive, cantGiveReason = hook.Call("canGiveLicense", DarkRP.hooks, ply, LookingAt)
     if canGive == false then
-        cantGiveReason = isstring(cantGiveReason) and cantGiveReason or ""
-        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("unable", "/givelicense", cantGiveReason))
-        return ""
-    end
-
-    local canGiveLicense = fn.FOr{
-        ply.isMayor, -- Mayors can hand out licenses
-        fn.FAnd{ply.isChief, noMayorExists}, -- Chiefs can if there is no mayor
-        fn.FAnd{ply.isCP, noChiefExists, noMayorExists} -- CP's can if there are no chiefs nor mayors
-    }
-
-    if not canGiveLicense(ply) then
-        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("incorrect_job", "/givelicense"))
+        cantGiveReason = isstring(cantGiveReason) and cantGiveReason or DarkRP.getPhrase("unable", "/givelicense", "")
+        DarkRP.notify(ply, 1, 4, cantGiveReason)
         return ""
     end
 

--- a/gamemode/modules/police/sv_commands.lua
+++ b/gamemode/modules/police/sv_commands.lua
@@ -300,6 +300,19 @@ local function GiveLicense(ply)
     local noMayorExists = fn.Compose{fn.Null, fn.Curry(fn.Filter, 2)(ply.isMayor), player.GetAll}
     local noChiefExists = fn.Compose{fn.Null, fn.Curry(fn.Filter, 2)(ply.isChief), player.GetAll}
 
+    local LookingAt = ply:GetEyeTrace().Entity
+    if not IsValid(LookingAt) or not LookingAt:IsPlayer() or LookingAt:GetPos():DistToSqr(ply:GetPos()) > 10000 then
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("player")))
+        return ""
+    end
+
+    local canGive, cantGiveReason = hook.Call("canGiveLicense", GAMEMODE, ply, LookingAt)
+    if canGive == false then
+        cantGiveReason = isstring(cantGiveReason) and cantGiveReason or ""
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("unable", "/givelicense", cantGiveReason))
+        return ""
+    end
+
     local canGiveLicense = fn.FOr{
         ply.isMayor, -- Mayors can hand out licenses
         fn.FAnd{ply.isChief, noMayorExists}, -- Chiefs can if there is no mayor
@@ -308,12 +321,6 @@ local function GiveLicense(ply)
 
     if not canGiveLicense(ply) then
         DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("incorrect_job", "/givelicense"))
-        return ""
-    end
-
-    local LookingAt = ply:GetEyeTrace().Entity
-    if not IsValid(LookingAt) or not LookingAt:IsPlayer() or LookingAt:GetPos():DistToSqr(ply:GetPos()) > 10000 then
-        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("must_be_looking_at", DarkRP.getPhrase("player")))
         return ""
     end
 

--- a/gamemode/modules/police/sv_init.lua
+++ b/gamemode/modules/police/sv_init.lua
@@ -392,3 +392,24 @@ hook.Add("PlayerInitialSpawn", "Arrested", function(ply)
     end)
     DarkRP.notify(ply, 0, 5, DarkRP.getPhrase("jail_punishment", time))
 end)
+
+function DarkRP.hooks:canGiveLicense(ply, target)
+    -- Mayors can hand out licenses
+    if ply:isMayor() then return true end
+
+    local reason = DarkRP.getPhrase("incorrect_job", "/givelicense")
+
+    -- Chiefs can if there is no mayor
+    local mayorExists = #fn.Filter(plyMeta.isMayor, player.GetAll()) > 0
+    if mayorExists then return false, reason end
+
+    if ply:isChief() then return true end
+
+    -- CPs can if there are no chiefs nor mayors
+    local chiefExists = #fn.Filter(plyMeta.isChief, player.GetAll()) > 0
+    if chiefExists then return false, reason end
+
+    if ply:isCP() then return true end
+
+    return false, reason
+end

--- a/gamemode/modules/police/sv_interface.lua
+++ b/gamemode/modules/police/sv_interface.lua
@@ -423,3 +423,33 @@ DarkRP.hookStub{
         returns = {
         }
 }
+
+
+DarkRP.hookStub{
+    name = "canGiveLicense",
+    description = "Whether a player is allowed to give another player a license.",
+    parameters = {
+            {
+                    name = "ply",
+                    description = "The player who tries to give the license.",
+                    type = "Player"
+            },
+            {
+                    name = "target",
+                    description = "The player who should receive the license.",
+                    type = "Player"
+            }
+    },
+    returns = {
+        {
+            name = "canGiveLicense",
+            description = "Whether the player is allowed to give the target a license.",
+            type = "boolean"
+        },
+        {
+            name = "cantGiveReason",
+            description = "Why the target is not allowed to receive a license from the player.",
+            type = "string"
+        },
+    }
+}


### PR DESCRIPTION
This hook would be useful to further restrict giving a gun license.
Currently, it is only possible to use the `police = true` property in a job to allow giving a license, leaving it out / setting it not `false` disallows it. In my case, I would like to restrict it to a specific police job because there are several of them in my case.

Of course, using the `canChatCommand` hook is possible, but I think a `canGiveLicense` hook makes the whole thing easier and more obvious, I only came across the existence of this hook when I wrote a commit message from this pull request because it's not necessarily something you think of when wanting to restrict these cases.

A small note about the `LookingAt` stuff, I moved it to the beginning of the function to make it accessible to the hook, I don't think it will cause any issues.