### PR TITLE
Fixed console ban

### DIFF
--- a/gamemode/modules/fadmin/fadmin/playeractions/kickban/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/kickban/sv_init.lua
@@ -128,6 +128,7 @@ local function Ban(ply, cmd, args)
             args[1] = targets[1]
             args[2] = args[6]
             args[3] = args[7]
+            targets = FAdmin.FindPlayer(args[1]) or targets
             for i = 2, #args do
                 if i >= 4 then args[i] = nil end
             end


### PR DESCRIPTION
Fixed FAdmin bug with console ban. When admin using "fadmin ban" with non-quoted steamid, rule breaker isn't getting kicked immediately, This commit fixes it