### PR TITLE
Fix clip size bug

### DIFF
--- a/entities/entities/spawned_shipment/init.lua
+++ b/entities/entities/spawned_shipment/init.lua
@@ -122,7 +122,7 @@ local function calculateAmmo(class, shipment)
     -- If the clip is undefined (default behaviour), default it to a full clip
     -- But remove the bullets used for it.
     if not clip1 then
-        clip1 = (ammoadd > 0) and math.min(clipSize, ammoadd) or 0
+        clip1 = math.min(clipSize, ammoadd)
         ammoadd = ammoadd - clip1
     end
     return ammoadd, clip1

--- a/entities/entities/spawned_shipment/init.lua
+++ b/entities/entities/spawned_shipment/init.lua
@@ -108,26 +108,6 @@ function ENT:Use(activator, caller)
     end)
 end
 
-local function calculateAmmo(class, shipment)
-    local clip1, ammoadd = shipment.clip1, shipment.ammoadd
-
-    local defaultClip, clipSize = 0, 0
-    local wep_tbl = weapons.Get(class)
-    if wep_tbl and istable(wep_tbl.Primary) then
-        defaultClip = wep_tbl.Primary.DefaultClip or -1
-        clipSize = wep_tbl.Primary.ClipSize or -1
-    end
-    ammoadd = ammoadd or defaultClip
-
-    -- If the clip is undefined (default behaviour), default it to a full clip
-    -- But remove the bullets used for it.
-    if not clip1 then
-        clip1 = (ammoadd > 0) and math.min(clipSize, ammoadd) or 0
-        ammoadd = ammoadd - clip1
-    end
-    return ammoadd, clip1
-end
-
 function ENT:SpawnItem()
     timer.Remove(self:EntIndex() .. "crate")
     self.sparking = false
@@ -152,10 +132,17 @@ function ENT:SpawnItem()
     local class = CustomShipments[contents].entity
     local model = CustomShipments[contents].model
 
+    local defaultClip, clipSize
+    local wep_tbl = weapons.Get(class)
+    if wep_tbl and wep_tbl.Primary then
+        defaultClip = wep_tbl.Primary.DefaultClip
+        clipSize = wep_tbl.Primary.ClipSize
+    end
+
     weapon:SetWeaponClass(class)
     weapon:SetModel(model)
-
-    weapon.ammoadd, weapon.clip1 = calculateAmmo(class, self)
+    weapon.ammoadd = self.ammoadd or defaultClip
+    weapon.clip1 = self.clip1 or clipSize
     weapon.clip2 = self.clip2
     weapon:SetPos(self:GetPos() + weaponPos)
     weapon:SetAngles(weaponAng)
@@ -195,11 +182,19 @@ function ENT:Destruct()
         return
     end
 
+    local defaultClip, clipSize
+    local wep_tbl = weapons.Get(class)
+    if wep_tbl and wep_tbl.Primary then
+        defaultClip = wep_tbl.Primary.DefaultClip
+        clipSize = wep_tbl.Primary.ClipSize
+    end
+
     local weapon = ents.Create("spawned_weapon")
     weapon:SetModel(model)
     weapon:SetWeaponClass(class)
     weapon:SetPos(Vector(vPoint.x, vPoint.y, vPoint.z + 5))
-    weapon.ammoadd, weapon.clip1 = calculateAmmo(class, self)
+    weapon.ammoadd = self.ammoadd or defaultClip
+    weapon.clip1 = self.clip1 or clipSize
     weapon.clip2 = self.clip2
     weapon.nodupe = true
     weapon:Spawn()

--- a/entities/entities/spawned_shipment/init.lua
+++ b/entities/entities/spawned_shipment/init.lua
@@ -119,11 +119,8 @@ local function calculateAmmo(class, shipment)
     end
     ammoadd = ammoadd or defaultClip
 
-    -- If the clip is undefined (default behaviour), default it to a full clip
-    -- But remove the bullets used for it.
     if not clip1 then
-        clip1 = math.min(clipSize, ammoadd)
-        ammoadd = ammoadd - clip1
+        clip1 = clipSize
     end
     return ammoadd, clip1
 end


### PR DESCRIPTION
This is unexpected behaviour, and broke some stuff on my server. It is not necessary (particularly if it breaks things) to return 0, if ammoadd is not higher than 0.
Ammoadd is spareammo in createShipment. Some people did spareammo = 0. So this code will literally remove the first clip entirely, eventough ClipSize and DefaultClip are correct.