### PR TITLE
Fix earthquake tremor setup

### DIFF
--- a/gamemode/modules/events/sv_events.lua
+++ b/gamemode/modules/events/sv_events.lua
@@ -100,8 +100,11 @@ local function createTremor()
     tremor.nodupe = true
     tremor:Spawn()
 end
-createTremor()
-hook.Add("PostCleanupMap", "DarkRP_events", createTremor)
+
+hook.Add("InitPostEntity", "DarkRP_SetupTremor", function()
+    createTremor()
+    hook.Add("PostCleanupMap", "DarkRP_events", createTremor)
+end)
 
 local function TremorReport()
     local mag = table.remove(lastmagnitudes, 1)


### PR DESCRIPTION
This has bothered me for awhile. By default, DarkRP creates a `env_physexplosion` immediately when it's loaded.
This isn't a big deal, it doesn't break anything, but gmod reports an error because DarkRP creates an entity too early.
```
Trying to create entities too early! (env_physexplosion)
```

This PR just delays the initial function call (and `PostCleanupMap` hook because some addons run that hook too early) until `InitPostEntity`, making sure the game is ready for new entities.

After testing, it appears earthquakes still work as expected and the error is absent from the startup logs.
![gmod_CVqwCSjjpM](https://user-images.githubusercontent.com/7936439/163891914-f399ceff-a3d2-43e5-bd73-d573b1b4aa26.png)