### PR TITLE
GM.Config.allowPickupEquippedWeapons

### DIFF
--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -33,6 +33,8 @@ GM.Config.allowsprays                   = true
 GM.Config.allowvehicleowning            = true
 -- allowvnocollide - Enable/disable the ability to no-collide a vehicle (for security).
 GM.Config.allowvnocollide               = false
+-- allowPickupEquippedWeapons - Enable/disable whether players can pick up weapons they already have.
+GM.Config.allowPickupEquippedWeapons    = true
 -- alltalk - Enable for global chat, disable for local chat.
 GM.Config.alltalk                       = false
 -- antimultirun - Disallow people joining your server(s) twice on the same account.

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -585,7 +585,7 @@ local adminCopWeapons = {
 function GM:PlayerCanPickupWeapon(ply, weapon)
     if ply:isArrested() then return false end
     if weapon.PlayerUse == false then return false end
-    
+
     local weaponClass = weapon:GetClass()
     if ply:HasWeapon(weaponClass) and not GAMEMODE.Config.allowPickupEquippedWeapons then return false end
     if ply:IsAdmin() and GAMEMODE.Config.AdminsCopWeapons and adminCopWeapons[weaponClass] then return true end

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -585,7 +585,9 @@ local adminCopWeapons = {
 function GM:PlayerCanPickupWeapon(ply, weapon)
     if ply:isArrested() then return false end
     if weapon.PlayerUse == false then return false end
+    
     local weaponClass = weapon:GetClass()
+    if ply:HasWeapon(weaponClass) and not GAMEMODE.Config.allowPickupEquippedWeapons then return false end
     if ply:IsAdmin() and GAMEMODE.Config.AdminsCopWeapons and adminCopWeapons[weaponClass] then return true end
 
     local jobTable = ply:getJobTable()

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -587,7 +587,7 @@ function GM:PlayerCanPickupWeapon(ply, weapon)
     if weapon.PlayerUse == false then return false end
 
     local weaponClass = weapon:GetClass()
-    if ply:HasWeapon(weaponClass) and not GAMEMODE.Config.allowPickupEquippedWeapons then return false end
+    if not GAMEMODE.Config.allowPickupEquippedWeapons and ply:HasWeapon(weaponClass) then return false end
     if ply:IsAdmin() and GAMEMODE.Config.AdminsCopWeapons and adminCopWeapons[weaponClass] then return true end
 
     local jobTable = ply:getJobTable()


### PR DESCRIPTION
Added a config bool to enable/disable whether players can pick up weapons they already have. It's really annoying when you accidentally press +use and lose an entire weapon.