### PR TITLE
Move tremor hook.Add to the file scope

### DIFF
--- a/gamemode/modules/events/sv_events.lua
+++ b/gamemode/modules/events/sv_events.lua
@@ -101,9 +101,10 @@ local function createTremor()
     tremor:Spawn()
 end
 
+hook.Add("PostCleanupMap", "DarkRP_events", createTremor)
+
 hook.Add("InitPostEntity", "DarkRP_SetupTremor", function()
     createTremor()
-    hook.Add("PostCleanupMap", "DarkRP_events", createTremor)
 end)
 
 local function TremorReport()


### PR DESCRIPTION
Moving createTremor to inside InitPostEntity is a reasonable fix, but there is 0 reason for the cleanup hook to be inside of another function. Map cleanup should not be done before InitPostEntity and this was only implemented this way because some bad addons call game.CleanUpMap() before entities have initialised which is what should be fixed. There are many other things that break (not necessarily in DarkRP) from this incorrect call and this is a bandaid on a gash to only cause InitPostEntity errors to have even greater detrimental effects.