### PR TITLE
CustomShipments table is sequential, so ipairs should be used.

### DIFF
--- a/entities/entities/spawned_shipment/commands.lua
+++ b/entities/entities/spawned_shipment/commands.lua
@@ -22,7 +22,7 @@ local function createShipment(ply, args)
     ent.PlayerUse = false
 
     local shipID
-    for k, v in pairs(CustomShipments) do
+    for k, v in ipairs(CustomShipments) do
         if v.entity == ent:GetWeaponClass() then
             shipID = k
             break

--- a/entities/weapons/weapon_cs_base2/sv_commands.lua
+++ b/entities/weapons/weapon_cs_base2/sv_commands.lua
@@ -2,7 +2,7 @@ local meta = FindMetaTable("Player")
 function meta:dropDRPWeapon(weapon)
     if GAMEMODE.Config.restrictdrop then
         local found = false
-        for k,v in pairs(CustomShipments) do
+        for k,v in ipairs(CustomShipments) do
             if v.entity == weapon:GetClass() then
                 found = true
                 break

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -77,7 +77,7 @@ function GM:canDropWeapon(ply, weapon)
 
     if not GAMEMODE.Config.restrictdrop then return true end
 
-    for _, v in pairs(CustomShipments) do
+    for _, v in ipairs(CustomShipments) do
         if v.entity ~= class then continue end
 
         return true


### PR DESCRIPTION
CustomShipments should always be sequential, so ipairs should be used to iterate it.

```lua
shipByName[string.lower(name or "")] = table.insert(CustomShipments, customShipment)
```