### PR TITLE
Add message for /unownalldoors with no doors owned

### DIFF
--- a/gamemode/modules/doorsystem/sv_doors.lua
+++ b/gamemode/modules/doorsystem/sv_doors.lua
@@ -461,7 +461,7 @@ local function UnOwnAll(ply, cmd, args)
         cost = cost + GiveMoneyBack
     end
 
-    if amount == 0 then return "" end
+    if amount == 0 then DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("no_doors_owned")) return "" end
 
     ply:addMoney(math.floor(cost))
 

--- a/gamemode/modules/language/sh_english.lua
+++ b/gamemode/modules/language/sh_english.lua
@@ -175,6 +175,7 @@ local my_language = {
     door_group_set = "Door group set successfully.",
     sold_x_doors_for_y = "You have sold %d doors for %s%d!", -- backwards compatibility
     sold_x_doors = "You have sold %d doors for %s!",
+    no_doors_found = "You don't own any doors!"
 
     -- Entities
     drugs = "drugs",

--- a/gamemode/modules/language/sh_english.lua
+++ b/gamemode/modules/language/sh_english.lua
@@ -175,7 +175,7 @@ local my_language = {
     door_group_set = "Door group set successfully.",
     sold_x_doors_for_y = "You have sold %d doors for %s%d!", -- backwards compatibility
     sold_x_doors = "You have sold %d doors for %s!",
-    no_doors_found = "You don't own any doors!"
+    no_doors_owned = "You don't own any doors!",
 
     -- Entities
     drugs = "drugs",


### PR DESCRIPTION
I noticed when you use /unownalldoors it won't say anything if you don't have any doors which made me think I typed the command wrong. Now it will notify you that you don't have any doors instead of doing nothing.