### PR TITLE
Fixed question answer for another player

### DIFF
--- a/gamemode/modules/voting/sv_questions.lua
+++ b/gamemode/modules/voting/sv_questions.lua
@@ -2,10 +2,12 @@ local Question = {}
 local Questions = {}
 
 local function ccDoQuestion(ply, cmd, args)
-    if not Questions[args[1]] then return end
+    local q = Questions[args[1]]
+    if not q then return end
     if not tonumber(args[2]) then return end
+    if q.Ent and q.Ent ~= ply then return end
 
-    Questions[args[1]]:handleNewQuestion(tonumber(args[2]))
+    q:handleNewQuestion(tonumber(args[2]))
 end
 concommand.Add("ans", ccDoQuestion)
 


### PR DESCRIPTION
Every player could answer on other player's question by using "ans" concommand with unique questionID. For example I used command "ans lottery1 1" and first player in player.GetAll() table entered lottery. This PR fixes that