### PR TITLE
Restrict vehicle spawning to superadmin instead of RCON-Only

### DIFF
--- a/gamemode/config/config.lua
+++ b/gamemode/config/config.lua
@@ -182,11 +182,11 @@ GM.Config.weaponCheckerHideNoLicense    = false
 Value settings
 ]]
 -- adminnpcs - Whether or not NPCs should be admin only. 0 = everyone, 1 = admin or higher, 2 = superadmin or higher, 3 = rcon only
-GM.Config.adminnpcs                     = 3
+GM.Config.adminnpcs                     = 2
 -- adminsents - Whether or not SENTs should be admin only. 0 = everyone, 1 = admin or higher, 2 = superadmin or higher, 3 = rcon only
 GM.Config.adminsents                    = 1
 -- adminvehicles - Whether or not vehicles should be admin only. 0 = everyone, 1 = admin or higher, 2 = superadmin or higher, 3 = rcon only
-GM.Config.adminvehicles                 = 3
+GM.Config.adminvehicles                 = 2
 -- adminweapons - Who can spawn weapons: 0: admins only, 1: supadmins only, 2: no one, 3: everyone
 GM.Config.adminweapons                  = 1
 -- arrestspeed - Sets the max arrest speed.


### PR DESCRIPTION
**This is mainly quality of life.**

DarkRP by default enables RCON-only spawning of Vehicles, and NPCs. This pull requests changes this requirement to Superadmins by default.

### Why is this better
1. Mainly development servers, I'm not thinking about DarkRP when quickly prototyping addons. Needing to restart after forgetting about this setting is annoying and _shouldn't be needed in the first place_.
2. Many people look at the big picture when looking through DarkRP's configuration, and skim over this. I've been using DarkRP for almost two years and I made this mistake the other day. Unlike Minecraft, Garry's Mod servers take litteral days to restart (with a decent amount of addons), Again, _this shouldn't be needed_.
3. RCON by default just causes frustration and time loss, it's that simple

### Why not `admin` by default
1. Admins abuse, this is probobly why it was RCON by default in the first place.

Once people become Superadmin, they _should be able to do whatever the hell they want to do, for better or worse_.