### PR TITLE
getDarkRPVar optimisation

### DIFF
--- a/gamemode/modules/base/cl_entityvars.lua
+++ b/gamemode/modules/base/cl_entityvars.lua
@@ -4,8 +4,9 @@ local DarkRPVars = {}
 interface"someString"
 ---------------------------------------------------------------------------]]
 local pmeta = FindMetaTable("Player")
+local get_user_id = pmeta.UserID
 function pmeta:getDarkRPVar(var)
-    local vars = DarkRPVars[self:UserID()]
+    local vars = DarkRPVars[get_user_id(self)]
     return vars and vars[var] or nil
 end
 


### PR DESCRIPTION
Indexing the player table in getDarkRPVar has proven to be expensive due to the amount of times this function is called every frame. I suggest localizing Player.UserID to improve performance.

Before the change:
![image](https://user-images.githubusercontent.com/27732530/210859825-109cfbf4-f1f1-4a85-91f1-8e3ef3588a9c.png)
After:
![image](https://user-images.githubusercontent.com/27732530/210859917-2c391fd9-90ac-4535-9f49-5a15f2df9f87.png)
