### PR TITLE
Fix getDarkRPVar returning nil when the var is false

### DIFF
--- a/gamemode/modules/base/cl_entityvars.lua
+++ b/gamemode/modules/base/cl_entityvars.lua
@@ -9,7 +9,7 @@ local pmeta = FindMetaTable("Player")
 local get_user_id = pmeta.UserID
 function pmeta:getDarkRPVar(var)
     local vars = DarkRPVars[get_user_id(self)]
-    if vars == nil return nil end
+    if vars == nil then return nil end
     return vars[var]
 end
 

--- a/gamemode/modules/base/cl_entityvars.lua
+++ b/gamemode/modules/base/cl_entityvars.lua
@@ -9,7 +9,8 @@ local pmeta = FindMetaTable("Player")
 local get_user_id = pmeta.UserID
 function pmeta:getDarkRPVar(var)
     local vars = DarkRPVars[get_user_id(self)]
-    return vars and vars[var] or nil
+    if vars == nil return nil end
+    return vars[var]
 end
 
 --[[---------------------------------------------------------------------------


### PR DESCRIPTION
Ternary-assumption bug. Probably went unnoticed since most cases that check bool vars do something like `if (not ply:getDarkRPVar("some_bool")) then`.

![image](https://user-images.githubusercontent.com/4593679/211033076-c938bbb6-b549-467f-ac21-ceae46e5df18.png)
