### PR TITLE
Added DrawChatIndicator hook

### DIFF
--- a/gamemode/modules/chatindicator/cl_init.lua
+++ b/gamemode/modules/chatindicator/cl_init.lua
@@ -7,6 +7,9 @@ local function drawIndicator(ply)
         return
     end
 
+    local chatIndicator = hook.Call("DrawChatIndicator", nil, ply)
+    if chatIndicator == true then return end
+
     local indicator = ply.indicator
     if not IsValid(indicator) then
         indicator = ClientsideModel("models/extras/info_speech.mdl", RENDERGROUP_OPAQUE)

--- a/gamemode/modules/chatindicator/cl_interface.lua
+++ b/gamemode/modules/chatindicator/cl_interface.lua
@@ -1,0 +1,18 @@
+DarkRP.hookStub{
+    name = "DrawChatIndicator",
+    description = "Call when the Chat Indicator is drawn. Return to overwrite.",
+    parameters = {
+        {
+            name = "ply",
+            description = "The player the indicator should be drawn for.",
+            type = "Player"
+        }
+    },
+    returns = {
+        {
+            name = "override",
+            description = "Return true in your hook to disable the default drawing.",
+            type = "boolean"
+        }
+    }
+}


### PR DESCRIPTION
Added a hook to disable the chat indicator.
While you can disable it via DarkRP modification, said method doesn't allow it to be activated or deactivated again on the fly.