### PR TITLE
Updated action version

### DIFF
--- a/.github/workflows/check-modified-subtree.yml
+++ b/.github/workflows/check-modified-subtree.yml
@@ -5,7 +5,7 @@ on:
       - master
 jobs:
   check-modified-subtree:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The ubuntu version that is currently configured for the check-modified-subtree workflow, is deprecated. That is why said workflow only outputs "Waiting for a runner to pick up this job... " and doesn't work.
Optionally, it could be put to `ubuntu-latest` to always stay "up-to-date", which is currently 22.04.