### PR TITLE
don't call player.GetAll twice

### DIFF
--- a/gamemode/modules/police/sv_init.lua
+++ b/gamemode/modules/police/sv_init.lua
@@ -411,7 +411,6 @@ function DarkRP.hooks:canGiveLicense(ply, target)
     local reason = DarkRP.getPhrase("incorrect_job", "/givelicense")
 
     local players = player.GetAll()
-    
     -- Chiefs can if there is no mayor
     local mayorExists = #fn.Filter(plyMeta.isMayor, players) > 0
     if mayorExists then return false, reason end

--- a/gamemode/modules/police/sv_init.lua
+++ b/gamemode/modules/police/sv_init.lua
@@ -410,14 +410,16 @@ function DarkRP.hooks:canGiveLicense(ply, target)
 
     local reason = DarkRP.getPhrase("incorrect_job", "/givelicense")
 
+    local players = player.GetAll()
+    
     -- Chiefs can if there is no mayor
-    local mayorExists = #fn.Filter(plyMeta.isMayor, player.GetAll()) > 0
+    local mayorExists = #fn.Filter(plyMeta.isMayor, players) > 0
     if mayorExists then return false, reason end
 
     if ply:isChief() then return true end
 
     -- CPs can if there are no chiefs nor mayors
-    local chiefExists = #fn.Filter(plyMeta.isChief, player.GetAll()) > 0
+    local chiefExists = #fn.Filter(plyMeta.isChief, players) > 0
     if chiefExists then return false, reason end
 
     if ply:isCP() then return true end


### PR DESCRIPTION
noticed this while reading some of the code, might as well only call it once here