### PR TITLE
Remove the SteamID64/AccountID workaround

### DIFF
--- a/gamemode/modules/workarounds/sh_workarounds.lua
+++ b/gamemode/modules/workarounds/sh_workarounds.lua
@@ -86,25 +86,6 @@ timer.Simple(3, function()
 ]])
 end)
 
-if game.SinglePlayer() or GetConVar("sv_lan"):GetBool() and
-   not DarkRP.disabledDefaults["workarounds"]["nil SteamID64 and AccountID local server fix"] then
-    local plyMeta = FindMetaTable("Player")
-
-    if SERVER then
-        local sid64 = plyMeta.SteamID64
-
-        function plyMeta:SteamID64(...)
-            return sid64(self, ...) or "0"
-        end
-    end
-
-    local aid = plyMeta.AccountID
-
-    function plyMeta:AccountID(...)
-        return aid(self, ...) or 0
-    end
-end
-
 if SERVER and not DarkRP.disabledDefaults["workarounds"]["Error on edict limit"] then
     -- https://github.com/FPtje/DarkRP/issues/2640
     local entsCreate = ents.Create


### PR DESCRIPTION
This pull request is basically inherited from #3127, but this time these two functions will always return a value whatever the situation (even in a `-multirun` environment) since yesterday's last update:
- https://store.steampowered.com/news/app/4000/view/3664293140704541926
- https://wiki.facepunch.com/gmod/Player:SteamID64~diff:551389
- https://wiki.facepunch.com/gmod/Player:AccountID~diff:551390

I did some testing with these changes and didn't see any issues as everything is now done internally by Garry's Mod, so it's pretty much a transparent change.