### PR TITLE
Expose arrestedPlayers table globally

### DIFF
--- a/gamemode/modules/police/sv_init.lua
+++ b/gamemode/modules/police/sv_init.lua
@@ -1,6 +1,6 @@
 local plyMeta = FindMetaTable("Player")
 local finishWarrantRequest
-local arrestedPlayers = {}
+arrestedPlayers = {}
 
 --[[---------------------------------------------------------------------------
 Interface functions

--- a/gamemode/modules/police/sv_init.lua
+++ b/gamemode/modules/police/sv_init.lua
@@ -115,6 +115,42 @@ function plyMeta:unArrest(unarrester, teleportOverride)
     hook.Call("playerUnArrested", DarkRP.hooks, self, unarrester, teleportOverride)
 end
 
+function DarkRP.iterateArrestedPlayers()
+    local index = nil
+    local function iterator()
+        local found_player = nil
+        index = next(arrestedPlayers, index)
+
+        if index == nil then return end
+
+        found_player = player.GetBySteamID(index)
+        -- player.GetBySteamID returns false when the player is not in the
+        -- server. In that case, skip the player.
+        if not found_player then return iterator() end
+
+        return found_player
+    end
+    return iterator
+end
+
+function DarkRP.arrestedPlayers()
+    local result = {}
+    for ply in DarkRP.iterateArrestedPlayers() do
+        table.insert(result, ply)
+    end
+
+    return result
+end
+
+
+function DarkRP.arrestedPlayerCount()
+    local count = 0
+
+    for _ in DarkRP.iterateArrestedPlayers() do count = count + 1 end
+
+    return count
+end
+
 --[[---------------------------------------------------------------------------
 Chat commands
 ---------------------------------------------------------------------------]]

--- a/gamemode/modules/police/sv_init.lua
+++ b/gamemode/modules/police/sv_init.lua
@@ -1,6 +1,6 @@
 local plyMeta = FindMetaTable("Player")
 local finishWarrantRequest
-arrestedPlayers = {}
+local arrestedPlayers = {}
 
 --[[---------------------------------------------------------------------------
 Interface functions

--- a/gamemode/modules/police/sv_interface.lua
+++ b/gamemode/modules/police/sv_interface.lua
@@ -188,6 +188,54 @@ DarkRP.PLAYER.unArrest = DarkRP.stub{
     metatable = DarkRP.PLAYER
 }
 
+DarkRP.iterateArrestedPlayers = DarkRP.stub{
+    name = "iterateArrestedPlayers",
+    description = "An iterator that walks over the arrested players. Use as follows: for arrestedPlayer in DarkRP.iterateArrestedPlayers() do print(arrestedPlayer) end",
+    parameters = {
+    },
+    returns = {
+        {
+            name = "arrestedPlayer",
+            description = "Much like the next function, this returns the next arrested player until the table is fully iterated.",
+            type = "Player"
+        }
+    },
+    metatable = DarkRP,
+    realm = "Server"
+}
+
+DarkRP.arrestedPlayers = DarkRP.stub{
+    name = "arrestedPlayers",
+    description = "Returns a table that contains all arrested players. NOTE: This function is defined using DarkRP.iterateArrestedPlayers. It might be more efficient to use that function instead, because this function builds the table anew.",
+    parameters = {
+    },
+    returns = {
+        {
+            name = "arrestedPlayers",
+            description = "An array of arrested players, in no particular order.",
+            type = "table"
+        }
+    },
+    metatable = DarkRP,
+    realm = "Server"
+}
+
+DarkRP.arrestedPlayerCount = DarkRP.stub{
+    name = "arrestedPlayerCount",
+    description = "Returns the amount of players that are currently arrested.",
+    parameters = {
+    },
+    returns = {
+        {
+            name = "arrestedPlayerCount",
+            description = "The amount of arrested players.",
+            type = "number"
+        }
+    },
+    metatable = DarkRP,
+    realm = "Server"
+}
+
 DarkRP.hookStub{
     name = "playerArrested",
     description = "When a player is arrested.",


### PR DESCRIPTION
I would like to expose this table globally to allow for more efficient usage. Right now, if you want a table of all arrested players you must do one of the following:
1) Loop through all players and check if they're arrested. This obviously wastes performance when we can simply get a table with all the arrested players instantly.
2) Get a reference to arrestedPlayers using debug.getupvalue on a function where the table is an upvalue. This works fine for me, but I feel like most glua developers are not too familiar with the debug library or how to use it. So if we expose the table globally then everyone will have access to it.

Additionally, we can also make a function which returns the arrestedPlayers table and keep it local or rename it to something more unique like arrestedPlayersDarkRP or something. I'd be happy to make changes, just let me know.