### PR TITLE
use an assert on storeMoney amount check

### DIFF
--- a/gamemode/modules/base/sv_data.lua
+++ b/gamemode/modules/base/sv_data.lua
@@ -389,7 +389,7 @@ function DarkRP.createPlayerData(ply, name, wallet, salary)
 end
 
 function DarkRP.storeMoney(ply, amount)
-    if not isnumber(amount) or amount < 0 or amount >= 1 / 0 then return end
+    assert(isnumber(amount) and amount > 0 and amount < 1 / 0, "Invalid amount of money, something has gone wrong")
 
     -- Also keep deprecated UniqueID data at least somewhat up to date
     MySQLite.query([[UPDATE darkrp_player SET wallet = ]] .. amount .. [[ WHERE uid = ]] .. ply:UniqueID() .. [[ OR uid = ]] .. ply:SteamID64())

--- a/gamemode/modules/money/sv_money.lua
+++ b/gamemode/modules/money/sv_money.lua
@@ -246,7 +246,7 @@ DarkRP.defineChatCommand("check", CreateCheque, 0.3) -- for those of you who can
 local function ccSetMoney(ply, args)
     local amount = DarkRP.toInt(args[2])
 
-    if not amount then
+    if not amount or amount < 0 or amount >= 1 / 0 then
         DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("invalid_x", DarkRP.getPhrase("arguments"), ""))
         return
     end


### PR DESCRIPTION
If we don't allow people to go into the negatives, we should throw an error when something goes wrong.

It'd likely be worthwhile to remove the "amount > 0" check entirely as this is 1 of the 2 main methods of duping money in DarkRP (IE: going into the negatives then rejoining) though this commit is just meant to give a stack trace when something has gone wrong

also corrected allowing setmoney letting them go negative when that's not an option here

I should note, this doesn't technically "fix" any issues with DarkRP itself other than /setmoney allowing people to temporarily go negative