### PR TITLE
ErrorNoHaltWithStack to alert that a players money was invalid when trying to save

### DIFF
--- a/gamemode/modules/base/sv_data.lua
+++ b/gamemode/modules/base/sv_data.lua
@@ -389,7 +389,17 @@ function DarkRP.createPlayerData(ply, name, wallet, salary)
 end
 
 function DarkRP.storeMoney(ply, amount)
-    if not isnumber(amount) or amount < 0 or amount >= 1 / 0 then ErrorNoHaltWithStack("Trying to save invalid amount of money") return end
+    if not isnumber(amount) or amount < 0 or amount >= 1 / 0 then
+        DarkRP.errorNoHalt("Some addon attempted to store a invalid money amount " .. tostring(amount) .. " for Player " .. ply:Nick() .. " (" .. ply:SteamID() .. ")", 1, {
+            "This money amount will not be stored in the database, but it may be set in the game.",
+            "The database simply stores the last valid, non-negative amount of money.",
+            "Please try to find the very first time this error happened for this player. Then look at the files mentioned in this error.",
+            "That will tell you which addon is causing this.",
+            "IMPORTANT: This is NOT a DarkRP bug!",
+            "Note: The player can simply rejoin to fix their negative money, until whatever causes this happens again."
+        })
+        return
+    end
 
     -- Also keep deprecated UniqueID data at least somewhat up to date
     MySQLite.query([[UPDATE darkrp_player SET wallet = ]] .. amount .. [[ WHERE uid = ]] .. ply:UniqueID() .. [[ OR uid = ]] .. ply:SteamID64())

--- a/gamemode/modules/base/sv_data.lua
+++ b/gamemode/modules/base/sv_data.lua
@@ -389,7 +389,7 @@ function DarkRP.createPlayerData(ply, name, wallet, salary)
 end
 
 function DarkRP.storeMoney(ply, amount)
-    if not isnumber(amount) or amount < 0 or amount >= 1 / 0 then return end
+    if not isnumber(amount) or amount < 0 or amount >= 1 / 0 then ErrorNoHaltWithStack("Trying to save invalid amount of money") return end
 
     -- Also keep deprecated UniqueID data at least somewhat up to date
     MySQLite.query([[UPDATE darkrp_player SET wallet = ]] .. amount .. [[ WHERE uid = ]] .. ply:UniqueID() .. [[ OR uid = ]] .. ply:SteamID64())

--- a/gamemode/modules/base/sv_data.lua
+++ b/gamemode/modules/base/sv_data.lua
@@ -418,6 +418,16 @@ function DarkRP.storeOfflineMoney(sid64, amount)
         })
     end
 
+    if not isnumber(amount) or amount < 0 or amount >= 1 / 0 then
+        DarkRP.errorNoHalt("Some addon attempted to store a invalid money amount " .. tostring(amount) .. " for an offline player with steamID64 " .. sid64, 1, {
+            "This money amount will not be stored in the database.",
+            "Please try to find the very first time this error happened for this player. Then look at the files mentioned in this error.",
+            "That will tell you which addon is causing this.",
+            "IMPORTANT: This is NOT a DarkRP bug!"
+        })
+        return
+    end
+
     -- Also store on deprecated UniqueID
     local uniqueid = util.CRC("gm_" .. string.upper(util.SteamIDFrom64(sid64)) .. "_gm")
     MySQLite.query([[UPDATE darkrp_player SET wallet = ]] .. amount .. [[ WHERE uid = ]] .. uniqueid .. [[ OR uid = ]] .. sid64)

--- a/gamemode/modules/base/sv_data.lua
+++ b/gamemode/modules/base/sv_data.lua
@@ -407,7 +407,7 @@ end
 
 function DarkRP.storeOfflineMoney(sid64, amount)
     if isnumber(sid64) or isstring(sid64) and string.len(sid64) < 17 then -- smaller than 76561197960265728 is not a SteamID64
-        DarkRP.errorNoHalt([[Some addon is giving DarkRP.storeOfflineMoney a UniqueID as its first argument, but this function now expects a SteamID64]], 2, {
+        DarkRP.errorNoHalt([[Some addon is giving DarkRP.storeOfflineMoney a UniqueID as its first argument, but this function now expects a SteamID64]], 1, {
             "The function used to take UniqueIDs, but it does not anymore.",
             "If you are a server owner, please look closely to the files mentioned in this error",
             "After all, these files will tell you WHICH addon is doing it",


### PR DESCRIPTION
Allowing people to go negative fixes 1 of the main methods of duplicating money since.

Currently, DarkRP just fails to save your money if something allowed you to go negative; this isn't inherently a problem with DarkRP as :canAfford exists, but there've been quite a few addons that make tiny mistakes allowing this to occur so we might as well not let them duplicate money

Considerations:
By default, DarkRP doesn't seem to set the "wallet" column to unsigned anywhere so no need to add any alter tables queries (unless there's a really old commit where it did that I didn't look for) 

I also confirmed I was able to do the following w/o having my money reset or unexpected happening:
- leave & immediately rejoin
- restart the server w/o leaving (via _restart specifically)
- leave then restart the server