### PR TITLE
GM.NoLicense is empty on the client

### DIFF
--- a/gamemode/cl_init.lua
+++ b/gamemode/cl_init.lua
@@ -38,6 +38,7 @@ include("libraries/fn.lua")
 include("libraries/tablecheck.lua")
 include("libraries/interfaceloader.lua")
 include("libraries/disjointset.lua")
+include("config/licenseweapons.lua")
 
 include("libraries/modificationloader.lua")
 

--- a/gamemode/init.lua
+++ b/gamemode/init.lua
@@ -22,6 +22,7 @@ AddCSLuaFile("config/config.lua")
 AddCSLuaFile("config/addentities.lua")
 AddCSLuaFile("config/jobrelated.lua")
 AddCSLuaFile("config/ammotypes.lua")
+AddCSLuaFile("config/licenseweapons.lua")
 
 AddCSLuaFile("cl_init.lua")
 


### PR DESCRIPTION
weaponchecker prints GM.NoLicense weapons because its not shared and PrintWeapons() runs only on clients