### PR TITLE
Don't clear the original owner nw var unless they're the one that reconnected

### DIFF
--- a/gamemode/modules/fpp/pp/server/core.lua
+++ b/gamemode/modules/fpp/pp/server/core.lua
@@ -671,7 +671,7 @@ function FPP.PlayerInitialSpawn(ply)
                 v:CPPISetOwner(ply)
                 table.insert(entities, v)
 
-                if v:GetNW2String("FPP_OriginalOwner", "") ~= "" then
+                if v:GetNW2String("FPP_OriginalOwner") == SteamID then -- only clear this when we've given it back to the original owner
                     v:SetNW2String("FPP_OriginalOwner", "")
                 end
             end


### PR DESCRIPTION
Fixes:
Person A fallback to Person B, disconnects
Person B fallback to Person C, disconnect
Person B reconnects gets full ownership with no trace of A

edit: I completely forgot fpp had its own repo, cheers
