### PR TITLE
findPlayer should search by 1 type at a time (bug/exploit fix)

### DIFF
--- a/gamemode/modules/base/sh_util.lua
+++ b/gamemode/modules/base/sh_util.lua
@@ -56,6 +56,17 @@ end
 
 --[[---------------------------------------------------------------------------
 Find a player based on given information
+
+Note that there is a searching priority:
+  * UserID
+  * SteamID64
+  * SteamID
+  * Nick
+  * SteamName
+
+Note also that there are _separate_ loops. This is to make sure the function
+gives the same result, regardless of the order in which players are iterated
+over.
 ---------------------------------------------------------------------------]]
 function DarkRP.findPlayer(info)
     if not info or info == "" then return nil end
@@ -63,18 +74,19 @@ function DarkRP.findPlayer(info)
 
     local count = #pls
     local numberInfo = tonumber(info)
-    local lowerInfo = string.lower(tostring(info))
 
-    if numberInfo then -- since we'll be doing alot of scanning, need to make sure 
+    -- First check if the input matches a player by UserID or SteamID64. This is
+    -- only necessary if the input can be parsed as a number.
+    if numberInfo then
         for k = 1, count do
             local v = pls[k]
 
-            if numberInfo == v:UserID() then -- darkrp relies on this being first
+            if numberInfo == v:UserID() then
                 return v
             end
         end
 
-        for k = 1, count do -- this loop could likely be combined with the above loop
+        for k = 1, count do
             local v = pls[k]
 
             if info == v:SteamID64() then
@@ -83,6 +95,7 @@ function DarkRP.findPlayer(info)
         end
     end
 
+    local lowerInfo = string.lower(tostring(info))
     if string.StartsWith(lowerInfo, "steam_") then
         for k = 1, count do
             local v = pls[k]

--- a/gamemode/modules/base/sh_util.lua
+++ b/gamemode/modules/base/sh_util.lua
@@ -61,24 +61,54 @@ function DarkRP.findPlayer(info)
     if not info or info == "" then return nil end
     local pls = player.GetAll()
 
-    for k = 1, #pls do -- Proven to be faster than pairs loop.
+    local count = #pls
+    local numberInfo = tonumber(info)
+    local lowerInfo = string.lower(tostring(info))
+
+    if numberInfo then -- since we'll be doing alot of scanning, need to make sure 
+        for k = 1, count do
+            local v = pls[k]
+
+            if numberInfo == v:UserID() then -- darkrp relies on this being first
+                return v
+            end
+        end
+
+        for k = 1, count do -- this loop could likely be combined with the above loop
+            local v = pls[k]
+
+            if info == v:SteamID64() then
+                return v
+            end
+        end
+    end
+
+    if string.StartsWith(lowerInfo, "steam_") then
+        for k = 1, count do
+            local v = pls[k]
+
+            if info == v:SteamID() then
+                return v
+            end
+        end
+    end
+
+    for k = 1, count do
         local v = pls[k]
-        if tonumber(info) == v:UserID() then
-            return v
-        end
 
-        if info == v:SteamID() then
-            return v
-        end
-
-        if string.find(string.lower(v:Nick()), string.lower(tostring(info)), 1, true) ~= nil then
-            return v
-        end
-
-        if string.find(string.lower(v:SteamName()), string.lower(tostring(info)), 1, true) ~= nil then
+        if string.find(string.lower(v:Nick()), lowerInfo, 1, true) ~= nil then
             return v
         end
     end
+
+    for k = 1, count do
+        local v = pls[k]
+
+        if string.find(string.lower(v:SteamName()), lowerInfo, 1, true) ~= nil then
+            return v
+        end
+    end
+
     return nil
 end
 


### PR DESCRIPTION
Someone noticed that setting your steam name to someone else's in game name (or a portion of it) can goof up targeting due to the order that it scans

example:
```
player 1's nickname is "bob", steamname is "ABC123 OtherWords"
player 2's nickname is "123xyz", steamname is "The Crush Inator (idk)"
doing "/pm 123 AHHHHHH!" would target player1 as their steamname has 123 in it
```

I threw on some extra conditionals to avoid ever doing 4 loops of player.GetAll(), worst case is gonna be 3

could throw in a length check as 33 characters is too long for any of them and steam64s have a fixed length (or at least a minimum length)