### PR TITLE
Fix: Workaround for localized texts in DarkRP not loading correctly

### DIFF
--- a/gamemode/modules/animations/sh_animations.lua
+++ b/gamemode/modules/animations/sh_animations.lua
@@ -1,7 +1,7 @@
 local Anims = {}
 
 -- Load animations after the languages for translation purposes
-hook.Add("loadCustomDarkRPItems", "loadAnimations", function()
+hook.Add("Think", "loadAnimations", function()
     Anims[ACT_GMOD_GESTURE_BOW] = DarkRP.getPhrase("bow")
     Anims[ACT_GMOD_TAUNT_MUSCLE] = DarkRP.getPhrase("sexy_dance")
     Anims[ACT_GMOD_GESTURE_BECON] = DarkRP.getPhrase("follow_me")
@@ -11,6 +11,7 @@ hook.Add("loadCustomDarkRPItems", "loadAnimations", function()
     Anims[ACT_GMOD_GESTURE_AGREE] = DarkRP.getPhrase("thumbs_up")
     Anims[ACT_GMOD_GESTURE_WAVE] = DarkRP.getPhrase("wave")
     Anims[ACT_GMOD_TAUNT_DANCE] = DarkRP.getPhrase("dance")
+    hook.Remove("Think", "loadAnimations")
 end)
 
 function DarkRP.addPlayerGesture(anim, text)

--- a/gamemode/modules/animations/sh_animations.lua
+++ b/gamemode/modules/animations/sh_animations.lua
@@ -1,7 +1,7 @@
 local Anims = {}
 
 -- Load animations after the languages for translation purposes
-hook.Add("Think", "loadAnimations", function()
+hook.Add("loadCustomDarkRPItems", "loadAnimations", function()
     Anims[ACT_GMOD_GESTURE_BOW] = DarkRP.getPhrase("bow")
     Anims[ACT_GMOD_TAUNT_MUSCLE] = DarkRP.getPhrase("sexy_dance")
     Anims[ACT_GMOD_GESTURE_BECON] = DarkRP.getPhrase("follow_me")
@@ -11,7 +11,6 @@ hook.Add("Think", "loadAnimations", function()
     Anims[ACT_GMOD_GESTURE_AGREE] = DarkRP.getPhrase("thumbs_up")
     Anims[ACT_GMOD_GESTURE_WAVE] = DarkRP.getPhrase("wave")
     Anims[ACT_GMOD_TAUNT_DANCE] = DarkRP.getPhrase("dance")
-    hook.Remove("Think", "loadAnimations")
 end)
 
 function DarkRP.addPlayerGesture(anim, text)

--- a/gamemode/modules/language/sh_language.lua
+++ b/gamemode/modules/language/sh_language.lua
@@ -1,5 +1,5 @@
 local rp_languages = {}
-local selectedLanguage = "en" -- Switch language by setting gmod_language to another language
+local selectedLanguage = GetConVar("gmod_language"):GetString() -- Switch language by setting gmod_language to another language
 
 cvars.AddChangeCallback("gmod_language", function(cv, old, new)
     selectedLanguage = new

--- a/gamemode/modules/language/sh_language.lua
+++ b/gamemode/modules/language/sh_language.lua
@@ -5,12 +5,13 @@ cvars.AddChangeCallback("gmod_language", function(cv, old, new)
     selectedLanguage = new
 end)
 
-hook.Add("Think", "DarkRPSetLanguage", function()
-    gmodLanguage = GetConVar("gmod_language"):GetString()
-    if gmodLanguage != "" then
+-- Some server owners experience that the language is not set correctly on
+-- startup. This provides a failsafe in case that happens.
+timer.Simple(0, function()
+    local gmodLanguage = GetConVar("gmod_language"):GetString()
+    if gmodLanguage ~= "" and selectedLanguage ~= gmodLanguage then
         selectedLanguage = gmodLanguage
     end
-    hook.Remove("Think", "DarkRPSetLanguage")
 end)
 
 function DarkRP.addLanguage(name, tbl)

--- a/gamemode/modules/language/sh_language.lua
+++ b/gamemode/modules/language/sh_language.lua
@@ -1,8 +1,16 @@
 local rp_languages = {}
-local selectedLanguage = GetConVar("gmod_language"):GetString() -- Switch language by setting gmod_language to another language
+local selectedLanguage = "en" -- Switch language by setting gmod_language to another language
 
 cvars.AddChangeCallback("gmod_language", function(cv, old, new)
     selectedLanguage = new
+end)
+
+hook.Add("Think", "DarkRPSetLanguage", function()
+    gmodLanguage = GetConVar("gmod_language"):GetString()
+    if gmodLanguage != "" then
+        selectedLanguage = gmodLanguage
+    end
+    hook.Remove("Think", "DarkRPSetLanguage")
 end)
 
 function DarkRP.addLanguage(name, tbl)


### PR DESCRIPTION
In DarkRP, some in-game notifications are localized and sent from the server.

However, during server initialization, the convar `gmod_language` doesn't get read correctly. Even if we set `gmod_language [geo code]` in server.cfg, it returns an empty string at that time, causing all server-side localized texts to be in English instead of the desired language.

To fix this, I've proposed a workaround that delays reading the convar until the server is fully loaded.

And there's a minor concern that the client's language might still be different from the server, leading to incorrect localized texts. I think all localized texts should be handled on the client-side, not the server.