### PR TITLE
Delay removal of Players' DarkRP Vars

### DIFF
--- a/gamemode/modules/base/cl_entityvars.lua
+++ b/gamemode/modules/base/cl_entityvars.lua
@@ -81,7 +81,9 @@ timer.Simple(0, fp{RunConsoleCommand, "_sendDarkRPvars"})
 
 net.Receive("DarkRP_DarkRPVarDisconnect", function(len)
     local userID = net.ReadUInt(16)
-    DarkRP.ClientsideDarkRPVars[userID] = nil
+    timer.Simple(10, function()
+        DarkRP.ClientsideDarkRPVars[userID] = nil
+    end)
 end)
 
 --[[---------------------------------------------------------------------------

--- a/gamemode/modules/base/cl_entityvars.lua
+++ b/gamemode/modules/base/cl_entityvars.lua
@@ -81,7 +81,7 @@ timer.Simple(0, fp{RunConsoleCommand, "_sendDarkRPvars"})
 
 net.Receive("DarkRP_DarkRPVarDisconnect", function(len)
     local userID = net.ReadUInt(16)
-    timer.Simple(10, function()
+    timer.Simple(5, function()
         DarkRP.ClientsideDarkRPVars[userID] = nil
     end)
 end)

--- a/gamemode/modules/base/cl_entityvars.lua
+++ b/gamemode/modules/base/cl_entityvars.lua
@@ -12,6 +12,7 @@ function pmeta:getDarkRPVar(var, fallback)
 
     -- Special case: when in the EntityRemoved hook, UserID returns -1. In this
     -- case, hope that we still have a stored userID lying around somewhere.
+    -- See https://github.com/FPtje/DarkRP/pull/3270
     if user_id == -1 then
         user_id = self._darkrp_stored_user_id_for_entity_removed_hook
     end
@@ -111,15 +112,12 @@ net.Receive("DarkRP_DarkRPVarDisconnect", function(len)
     end
 
     hook.Add("EntityRemoved", hook_name, function(ent)
-        -- NOTE: ent:UserID() will return -1 in this hook, so there is no use to
-        -- compare UserIDs. That also means that getting DarkRPVars in the
-        -- EntityRemoved hook is futile, as the lookup of -1 in
-        -- DarkRP.ClientsideDarkRPVars wil fail.
         if ent ~= ply then return end
         hook.Remove("EntityRemoved", hook_name)
 
         -- Placing this in a timer allows for the rest of the hook runners to
         -- still use the DarkRPVars until the entity is _really_ gone.
+        -- See https://github.com/FPtje/DarkRP/pull/3270
         timer.Simple(0, function()
             DarkRP.ClientsideDarkRPVars[userID] = nil
         end)

--- a/gamemode/modules/base/sv_entityvars.lua
+++ b/gamemode/modules/base/sv_entityvars.lua
@@ -279,7 +279,9 @@ end)
 
 hook.Add("EntityRemoved", "DarkRP_VarRemoval", function(ent) -- We use EntityRemoved to clear players of tables, because it is always called after the PlayerDisconnected hook
     if ent:IsPlayer() then
-        DarkRP.ServerDarkRPVars[ent] = nil
-        DarkRP.ServerPrivateDarkRPVars[ent] = nil
+        timer.Simple(0, function()
+            DarkRP.ServerDarkRPVars[ent] = nil
+            DarkRP.ServerPrivateDarkRPVars[ent] = nil
+        end)
     end
 end)

--- a/gamemode/modules/base/sv_gamemode_functions.lua
+++ b/gamemode/modules/base/sv_gamemode_functions.lua
@@ -242,6 +242,12 @@ function GM:EntityRemoved(ent)
     local owner = ent.Getowning_ent and ent:Getowning_ent() or Player(ent.SID or 0)
     if ent.DarkRPItem and IsValid(owner) and not ent.IsPocketing then owner:removeCustomEntity(ent.DarkRPItem) end
     if ent.isKeysOwnable and ent:isKeysOwnable() then ent:removeDoorData() end
+
+    -- Quick workaround for the fact that we don't have a hook ordering system
+    -- built into gmod.
+    if self.DarkRPPostEntityRemoved then
+        self.DarkRPPostEntityRemoved(self, ent)
+    end
 end
 
 function GM:ShowSpare1(ply)


### PR DESCRIPTION
On server-side `EntityRemoved` the player entity is still valid, not having the delay makes some hooks not work with `ply:getDarkRPVar` inside it.

On client-side it will always fail because `PlayerDisconnected` and `EntityRemoved` are called on the same tick but the former runs first so when it reaches the client, any `EntityRemoved` hook that calls `ply:getDarkRPVar` will just return `nil`

5 seconds is overkill for client-side, but just in case gmod decides to delay EntityRemoved call and some bad networking happens. (future proof lol)