### PR TITLE
localize weapon class

### DIFF
--- a/entities/weapons/weaponchecker/shared.lua
+++ b/entities/weapons/weaponchecker/shared.lua
@@ -275,9 +275,10 @@ function SWEP:Succeed()
     local stripped = {}
 
     self:GetStrippableWeapons(ent, function(wep)
-        ent:StripWeapon(wep:GetClass())
-        stripped[wep:GetClass()] = {
-            class = wep:GetClass(),
+        local class = wep:GetClass()
+        ent:StripWeapon(class)
+        stripped[class] = {
+            class = class,
             primaryAmmoCount = ent:GetAmmoCount(wep:GetPrimaryAmmoType()),
             primaryAmmoType = wep:GetPrimaryAmmoType(),
             secondaryAmmoCount = ent:GetAmmoCount(wep:GetSecondaryAmmoType()),


### PR DESCRIPTION
Noticed wep:GetClass() was called 3 times in a row while reading the weapon checker code.