### PR TITLE
Sanitize name on player creation to avoid SQL errors

### DIFF
--- a/gamemode/modules/base/sv_data.lua
+++ b/gamemode/modules/base/sv_data.lua
@@ -477,7 +477,7 @@ function meta:restorePlayerData()
         self.DarkRPUnInitialized = nil
 
         local info = data and data[1] or {}
-        if not info.rpname or info.rpname == "NULL" then info.rpname = string.gsub(self:SteamName(), "\\\"", "\"") end
+        if not info.rpname or info.rpname == "NULL" then info.rpname = string.sub(string.gsub(self:SteamName(), "\\\"", "\""), 1, 30) end
 
         info.wallet = info.wallet or GAMEMODE.Config.startingmoney
         info.salary = DarkRP.retrieveSalary(self)
@@ -497,7 +497,7 @@ function meta:restorePlayerData()
 
         self:setDarkRPVar("money", GAMEMODE.Config.startingmoney)
         self:setSelfDarkRPVar("salary", DarkRP.retrieveSalary(self))
-        local name = string.gsub(self:SteamName(), "\\\"", "\"")
+        local name = string.sub(string.gsub(self:SteamName(), "\\\"", "\""), 1, 30)
         self:setDarkRPVar("rpname", name)
 
         self.DarkRPDataRetrievalFailed = true -- marker on the player that says shit is fucked


### PR DESCRIPTION
Hello,

A few players with too long names tried to joined on the server and caused MySQL error (real steamid was hidden in the log below):
```
gamemodes/darkrp/gamemode/libraries/mysqlite/mysqlite.lua:290: Data too long for column 'rpname' at row 1 (REPLACE INTO darkrp_player VALUES(<STEAMID>, "(1)woenl tasker woenl tasker woenl tasker woadsakjwhbdjkawhbdawjkhb", 0, 150000);)
stack traceback:
       [C]: at 0xe9ed09f6
       [C]: in function 'error'
```
       
So here is a fix. 
The maximum amount of characters was set the same as in **GM:CanChangeRPName** hook.

Kind regards,
Aleksandrs.