### PR TITLE
Fix nested net message for unregistered DarkRPVars

### DIFF
--- a/gamemode/modules/base/sh_entityvars.lua
+++ b/gamemode/modules/base/sh_entityvars.lua
@@ -36,24 +36,9 @@ local function readUnknown()
     return net.ReadString(), net.ReadType(net.ReadUInt(8))
 end
 
-local warningsShown = {}
-local function warnRegistration(name)
-    if warningsShown[name] then return end
-    warningsShown[name] = true
-
-    DarkRP.errorNoHalt(string.format([[Warning! DarkRPVar '%s' wasn't registered!
-        Please contact the author of the DarkRP Addon to fix this.
-        Until this is fixed you don't need to worry about anything. Everything will keep working.
-        It's just that registering DarkRPVars would make DarkRP faster.]], name), 4)
-end
-
 function DarkRP.writeNetDarkRPVar(name, value)
     local DarkRPVar = DarkRP.RegisteredDarkRPVars[name]
-    if not DarkRPVar then
-        warnRegistration(name)
-
-        return writeUnknown(name, value)
-    end
+    if not DarkRPVar then return writeUnknown(name, value) end
 
     net.WriteUInt(DarkRPVar.id, DARKRP_ID_BITS)
     return DarkRPVar.writeFn(value)
@@ -62,8 +47,6 @@ end
 function DarkRP.writeNetDarkRPVarRemoval(name)
     local DarkRPVar = DarkRP.RegisteredDarkRPVars[name]
     if not DarkRPVar then
-        warnRegistration(name)
-
         net.WriteUInt(UNKNOWN_DARKRPVAR, 8)
         net.WriteString(name)
         return

--- a/gamemode/modules/base/sv_entityvars.lua
+++ b/gamemode/modules/base/sv_entityvars.lua
@@ -15,6 +15,20 @@ util.AddNetworkString("DarkRP_DarkRPVarDisconnect")
 Player vars
 ---------------------------------------------------------------------------]]
 
+local warningsShown = {}
+local function checkDarkRPVarRegistration(name)
+    local DarkRPVar = DarkRP.RegisteredDarkRPVars[name]
+    if DarkRPVar then return end
+
+    if warningsShown[name] then return end
+    warningsShown[name] = true
+
+    DarkRP.errorNoHalt(string.format([[Warning! DarkRPVar '%s' wasn't registered!
+        Please contact the author of the DarkRP Addon to fix this.
+        Until this is fixed you don't need to worry about anything. Everything will keep working.
+        It's just that registering DarkRPVars would make DarkRP faster.]], name), 4)
+end
+
 --[[---------------------------------------------------------------------------
 Remove a player's DarkRPVar
 ---------------------------------------------------------------------------]]
@@ -25,6 +39,8 @@ function meta:removeDarkRPVar(var, target)
 
     DarkRP.ServerDarkRPVars[self] = DarkRP.ServerDarkRPVars[self] or {}
     DarkRP.ServerDarkRPVars[self][var] = nil
+
+    checkDarkRPVarRegistration(var)
 
     net.Start("DarkRP_PlayerVarRemoval")
         net.WriteUInt(self:UserID(), 16)
@@ -45,6 +61,8 @@ function meta:setDarkRPVar(var, value, target)
 
     DarkRP.ServerDarkRPVars[self] = DarkRP.ServerDarkRPVars[self] or {}
     DarkRP.ServerDarkRPVars[self][var] = value
+
+    checkDarkRPVarRegistration(var)
 
     net.Start("DarkRP_PlayerVar")
         net.WriteUInt(self:UserID(), 16)


### PR DESCRIPTION
Fixes https://github.com/FPtje/DarkRP/issues/3287
The simplerr error caused a nested net message to be attempted to be sent when an unregistered DarkRPVar was set or removed. This happened because the warning function called DarkRP.error, which internally sends a net message.