### PR TITLE
Replacing a hardcoded value with an initialized variable for unknown PVars

### DIFF
--- a/gamemode/modules/base/sh_entityvars.lua
+++ b/gamemode/modules/base/sh_entityvars.lua
@@ -26,7 +26,7 @@ end
 
 -- Unknown values have unknown types and unknown identifiers, so this is sent inefficiently
 local function writeUnknown(name, value)
-    net.WriteUInt(UNKNOWN_DARKRPVAR, 8)
+    net.WriteUInt(UNKNOWN_DARKRPVAR, DARKRP_ID_BITS)
     net.WriteString(name)
     net.WriteType(value)
 end
@@ -47,7 +47,7 @@ end
 function DarkRP.writeNetDarkRPVarRemoval(name)
     local DarkRPVar = DarkRP.RegisteredDarkRPVars[name]
     if not DarkRPVar then
-        net.WriteUInt(UNKNOWN_DARKRPVAR, 8)
+        net.WriteUInt(UNKNOWN_DARKRPVAR, DARKRP_ID_BITS)
         net.WriteString(name)
         return
     end
@@ -72,7 +72,7 @@ end
 
 function DarkRP.readNetDarkRPVarRemoval()
     local id = net.ReadUInt(DARKRP_ID_BITS)
-    return id == 255 and net.ReadString() or DarkRP.RegisteredDarkRPVarsById[id].name
+    return id == UNKNOWN_DARKRPVAR and net.ReadString() or DarkRP.RegisteredDarkRPVarsById[id].name
 end
 
 -- The money is a double because it accepts higher values than Int and UInt, which are undefined for >32 bits


### PR DESCRIPTION
Changing DARKRP_ID_BITS causes problems reading network messages