### PR TITLE
fix: job switch failing when target job slot is full

### DIFF
--- a/gamemode/modules/jobs/sv_jobs.lua
+++ b/gamemode/modules/jobs/sv_jobs.lua
@@ -380,9 +380,9 @@ local function ExecSwitchJob(answer, ent, ply, target)
     local Pteam = ply:Team()
     local Tteam = target:Team()
 
-    if not ply:changeTeam(Tteam, nil, nil, true) then return end
-    if not target:changeTeam(Pteam, nil, nil, true) then
-        ply:changeTeam(Pteam, true) -- revert job change
+    if not target:changeTeam(Pteam, nil, nil, true) then return end
+    if not ply:changeTeam(Tteam, nil, nil, true) then
+        target:changeTeam(Tteam, true)
         return
     end
     DarkRP.notify(ply, 2, 4, DarkRP.getPhrase("job_switch"))


### PR DESCRIPTION
Corrects the order of team changes when switching jobs between players.

The current issue (example):
Mafiosi tries to /switchjob with the Mafiaboss
-> Fails because the job slot is already full

Now it works like this:
Mafiosi tries to /switchjob with the Mafiaboss:
-> Mafiaboss switches to Mafiosi first (freeing the slot), then Mafiosi switches to Mafiaboss. No more issues.