### PR TITLE
OnChangedTeam called Clientside

### DIFF
--- a/gamemode/modules/base/cl_gamemode_functions.lua
+++ b/gamemode/modules/base/cl_gamemode_functions.lua
@@ -75,9 +75,11 @@ function GM:teamChanged(before, after)
 end
 
 local function OnChangedTeam(um)
-    local oldTeam, newTeam = um:ReadShort(), um:ReadShort()
-    hook.Call("teamChanged", GAMEMODE, oldTeam, newTeam) -- backwards compatibility
-    hook.Call("OnPlayerChangedTeam", GAMEMODE, LocalPlayer(), oldTeam, newTeam)
+    local ply, oldTeam, newTeam = um:ReadEntity() ,um:ReadShort(), um:ReadShort()
+    hook.Call("OnPlayerChangedTeam", GAMEMODE, ply, oldTeam, newTeam)
+    if ply == LocalPlayer() then
+        hook.Call("teamChanged", GAMEMODE, oldTeam, newTeam) -- backwards compatibility
+    end
 end
 usermessage.Hook("OnChangedTeam", OnChangedTeam)
 

--- a/gamemode/modules/jobs/sv_jobs.lua
+++ b/gamemode/modules/jobs/sv_jobs.lua
@@ -183,7 +183,8 @@ function meta:changeTeam(t, force, suppressNotification, ignoreMaxMembers)
         util.Effect("entity_remove", effectdata)
     end
 
-    umsg.Start("OnChangedTeam", self)
+    umsg.Start("OnChangedTeam")
+        umsg.Entity(self)
         umsg.Short(prevTeam)
         umsg.Short(t)
     umsg.End()


### PR DESCRIPTION
OnChangedTeam is now triggered on the client for all players, even if you are not the one changing jobs.

Before this merge request, the OnChangedTeam hook was only called on the client for the player who actually changed their job.