### PR TITLE
Fix vote cleanup edge cases

### DIFF
--- a/gamemode/modules/voting/sv_questions.lua
+++ b/gamemode/modules/voting/sv_questions.lua
@@ -51,8 +51,11 @@ function DarkRP.createQuestion(question, quesid, ent, delay, callback, fromPly, 
 end
 
 function DarkRP.destroyQuestion(id)
-    umsg.Start("KillQuestionVGUI", Questions[id].Ent)
-        umsg.String(Questions[id].ID)
+    local question = Questions[id]
+    if not question then return end
+
+    umsg.Start("KillQuestionVGUI", question.Ent)
+        umsg.String(question.ID)
     umsg.End()
 
     Questions[id] = nil

--- a/gamemode/modules/voting/sv_votes.lua
+++ b/gamemode/modules/voting/sv_votes.lua
@@ -40,7 +40,7 @@ function Vote:handleEnd()
     win = win or self.yea > self.nay and 1 or self.nay > self.yea and -1 or 0
 
     umsg.Start("KillVoteVGUI", self:getFilter())
-        umsg.String(self.id)
+        umsg.Short(self.id)
     umsg.End()
 
     Votes[self.id] = nil

--- a/gamemode/modules/voting/sv_votes.lua
+++ b/gamemode/modules/voting/sv_votes.lua
@@ -40,7 +40,7 @@ function Vote:handleEnd()
     win = win or self.yea > self.nay and 1 or self.nay > self.yea and -1 or 0
 
     umsg.Start("KillVoteVGUI", self:getFilter())
-        umsg.Short(self.id)
+        umsg.String(self.id)
     umsg.End()
 
     Votes[self.id] = nil

--- a/gamemode/modules/workarounds/sh_workarounds.lua
+++ b/gamemode/modules/workarounds/sh_workarounds.lua
@@ -28,11 +28,11 @@ if not DarkRP.disabledDefaults["workarounds"]["os.date() Windows crash"] and sys
         if (isstring(format) or isnumber(format)) then
             format = string.gsub(format, "%%[^aAbBcdHIjmMpSUwWxXyYz]", replace)
         elseif (format ~= nil) then
-            argError(Val, 1, "string")
+            argError(format, 1, "string")
         end
 
         if (not (time == nil or isnumber(time)) and (not isstring(time) or tonumber(time) == nil)) then
-            argError(Val, 2, "number")
+            argError(time, 2, "number")
         end
 
         return osdate(format, time, ...)


### PR DESCRIPTION
## Summary
- send the vote id with the same usermessage type that the client reads when closing vote panels
- make question destruction a no-op when the question has already gone away
- pass the actual bad argument into the Windows os.date workaround error helper

## Why
These are small cleanup paths that could currently either leave the client reading the wrong usermessage type or throw a Lua error while handling an already-removed question / invalid os.date argument.

## Checks
- git diff --check
- .github/scripts/check-modified-subtree.sh