### PR TITLE
Guard stale FAdmin action targets

### DIFF
--- a/gamemode/modules/fadmin/cl_fadmin_darkrp.lua
+++ b/gamemode/modules/fadmin/cl_fadmin_darkrp.lua
@@ -21,6 +21,8 @@ FAdmin.StartHooks["DarkRP"] = function()
         function(ply) return LocalPlayer():isCP() end,
         function(ply, button)
             Derma_StringRequest("Warrant reason", "Enter the reason for the warrant", "", function(Reason)
+                if not IsValid(ply) then return end
+
                 RunConsoleCommand("darkrp", "warrant", ply:SteamID(), Reason)
             end)
         end)
@@ -35,6 +37,8 @@ FAdmin.StartHooks["DarkRP"] = function()
         function(ply, button)
             if not ply:getDarkRPVar("wanted") then
                 Derma_StringRequest("wanted reason", "Enter the reason to arrest this player", "", function(Reason)
+                    if not IsValid(ply) then return end
+
                     RunConsoleCommand("darkrp", "wanted", ply:SteamID(), Reason)
                 end)
             else

--- a/gamemode/modules/fadmin/fadmin/playeractions/ragdoll/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/ragdoll/sv_init.lua
@@ -252,7 +252,11 @@ local function Ragdoll(ply, cmd, args)
             if not HangOn then return false end
 
             doll:SetPos(HangOn:GetPos() - Vector(-50,0,10))
-            timer.Simple(0.2, function() constraint.Rope(doll, HangOn, 10, 0, Vector(-2.4,0,-0.6), Vector(0,0,53), 10, 40, 0, 4, "cable/rope", false) end)
+            timer.Simple(0.2, function()
+                if not IsValid(doll) or not IsValid(HangOn) then return end
+
+                constraint.Rope(doll, HangOn, 10, 0, Vector(-2.4,0,-0.6), Vector(0,0,53), 10, 40, 0, 4, "cable/rope", false)
+            end)
         elseif string.find(RagdollType, "kick") == 1 then -- Best ragdoll mod EVER
             ragdollKick(target)
         end

--- a/gamemode/modules/fadmin/fadmin/playeractions/slay/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/slay/sv_init.lua
@@ -27,6 +27,8 @@ local function Slay(ply, cmd, args)
             elseif SlayType == "rocket" then
                 target:SetVelocity(Vector(0,0,1000))
                 timer.Simple(1, function()
+                    if not IsValid(target) then return end
+
                     local effectdata = EffectData()
                     effectdata:SetStart(target:GetPos())
                     effectdata:SetOrigin(target:GetPos())

--- a/gamemode/modules/fadmin/fadmin/playeractions/teleport/sv_init.lua
+++ b/gamemode/modules/fadmin/fadmin/playeractions/teleport/sv_init.lua
@@ -22,13 +22,21 @@ local function TPToPos(ply, cmd, args)
 
     local x, y, z = string.match(args[1] or "", "([-0-9\\.]+),%s?([-0-9\\.]+),%s?([-0-9\\.]+)")
     local vx, vy, vz = string.match(args[2] or "", "([-0-9\\.]+),%s?([-0-9\\.]+),%s?([-0-9\\.]+)")
-    local pos = Vector(tonumber(x), tonumber(y), tonumber(z))
-    local vel = Vector(tonumber(vx), tonumber(vy), tonumber(vz))
 
     if not args[1] or not x or not y or not z then return false end
+    x, y, z = tonumber(x), tonumber(y), tonumber(z)
+    if not x or not y or not z then return false end
+
+    local pos = Vector(x, y, z)
+    local vel
+
+    if vx and vy and vz then
+        vx, vy, vz = tonumber(vx), tonumber(vy), tonumber(vz)
+        if vx and vy and vz then vel = Vector(vx, vy, vz) end
+    end
 
     ply:SetPos(pos)
-    if vx and vy and vz then ply:SetVelocity(vel) end
+    if vel then ply:SetVelocity(vel) end
     zapEffect(ply)
 
     return true, pos, vel
@@ -95,7 +103,8 @@ local function Bring(ply, cmd, args)
             PHYSGUN = true
         end
         timer.Simple(0, function()
-            if not IsValid(target) then return end
+            if not IsValid(target) or not IsValid(BringTo) then return end
+
             local tracedata = {}
             tracedata.start = BringTo:GetShootPos()
             tracedata.endpos = tracedata.start + BringTo:GetAimVector() * 50
@@ -113,7 +122,14 @@ local function Bring(ply, cmd, args)
 
             zapEffect(target)
 
-            if PHYSGUN then timer.Simple(0.5, function() target:Give("weapon_physgun") target:SelectWeapon("weapon_physgun") end) end
+            if PHYSGUN then
+                timer.Simple(0.5, function()
+                    if not IsValid(target) then return end
+
+                    target:Give("weapon_physgun")
+                    target:SelectWeapon("weapon_physgun")
+                end)
+            end
         end)
     end
 

--- a/gamemode/modules/fadmin/fadmin/restrict/sv_restrict.lua
+++ b/gamemode/modules/fadmin/fadmin/restrict/sv_restrict.lua
@@ -31,6 +31,7 @@ end
 local function UnRestrictWeapons(ply, cmd, args)
     if not FAdmin.Access.PlayerHasPrivilege(ply, "Restrict") then FAdmin.Messages.SendMessage(ply, 5, "No access!") return false end
     local Weapon = args[1]
+    if not Weapon then return false end
 
     sql.Query("DELETE FROM FADMIN_RESTRICTEDENTS WHERE ENTITY = " .. sql.SQLStr(Weapon) .. " AND TYPE = " .. sql.SQLStr("Weapons") .. ";")
 

--- a/gamemode/modules/fadmin/fadmin/restrict/sv_restrict.lua
+++ b/gamemode/modules/fadmin/fadmin/restrict/sv_restrict.lua
@@ -31,7 +31,7 @@ end
 local function UnRestrictWeapons(ply, cmd, args)
     if not FAdmin.Access.PlayerHasPrivilege(ply, "Restrict") then FAdmin.Messages.SendMessage(ply, 5, "No access!") return false end
     local Weapon = args[1]
-    if not Weapon then return false end
+    if not Weapon then FAdmin.Messages.SendMessage(ply, 5, "Please provide a weapon!") return false end
 
     sql.Query("DELETE FROM FADMIN_RESTRICTEDENTS WHERE ENTITY = " .. sql.SQLStr(Weapon) .. " AND TYPE = " .. sql.SQLStr("Weapons") .. ";")
 


### PR DESCRIPTION
## Summary
- validate players/entities inside delayed FAdmin action callbacks before using them
- reject malformed TPToPos coordinates before constructing vectors
- avoid running scoreboard warrant/wanted commands after the selected player becomes invalid
- return early when UnRestrictWeapon is called without a weapon argument

## Why
Several admin actions keep player or entity references across timers or UI prompts. If the player disconnects, the target disappears, or the command is malformed before the callback runs, the old reference could be used directly and throw a Lua error.

## Checks
- git diff --check
- .github/scripts/check-modified-subtree.sh