### PR TITLE
Guard spawned entity failure paths

### DIFF
--- a/entities/entities/food/init.lua
+++ b/entities/entities/food/init.lua
@@ -50,5 +50,7 @@ end
 
 function ENT:OnRemove()
     local ply = self:Getowning_ent()
+    if not IsValid(ply) then return end
+
     ply.maxFoods = ply.maxFoods and ply.maxFoods - 1 or 0
 end

--- a/entities/entities/money_printer/init.lua
+++ b/entities/entities/money_printer/init.lua
@@ -76,7 +76,9 @@ function ENT:BurstIntoFlames()
     self.burningup = true
     local burntime = math.random(8, 18)
     self:Ignite(burntime, 0)
-    timer.Simple(burntime, function() self:Fireball() end)
+    timer.Simple(burntime, function()
+        if IsValid(self) then self:Fireball() end
+    end)
 end
 
 function ENT:Fireball()

--- a/entities/entities/spawned_ammo/init.lua
+++ b/entities/entities/spawned_ammo/init.lua
@@ -8,7 +8,7 @@ function ENT:Initialize()
     self:SetSolid(SOLID_VPHYSICS)
     self:SetUseType(SIMPLE_USE)
     local phys = self:GetPhysicsObject()
-    phys:Wake()
+    if phys:IsValid() then phys:Wake() end
 end
 
 function ENT:Use(activator, caller)

--- a/entities/entities/spawned_shipment/commands.lua
+++ b/entities/entities/spawned_shipment/commands.lua
@@ -19,6 +19,7 @@ local function createShipment(ply, args)
         return
     end
 
+    local playerUse = ent.PlayerUse
     ent.PlayerUse = false
 
     local shipID
@@ -30,11 +31,18 @@ local function createShipment(ply, args)
     end
 
     if not shipID or ent.USED then
+        ent.PlayerUse = playerUse
         DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("unable", "/makeshipment", ""))
         return
     end
 
     local crate = ents.Create(CustomShipments[shipID].shipmentClass or "spawned_shipment")
+    if not IsValid(crate) then
+        ent.PlayerUse = playerUse
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("unable", "/makeshipment", ""))
+        return
+    end
+
     crate.SID = ply.SID
     crate:SetPos(ent:GetPos())
     crate.nodupe = true
@@ -48,7 +56,7 @@ local function createShipment(ply, args)
     SafeRemoveEntity(ent)
 
     local phys = crate:GetPhysicsObject()
-    phys:Wake()
+    if phys:IsValid() then phys:Wake() end
 end
 DarkRP.defineChatCommand("makeshipment", createShipment, 0.3)
 
@@ -81,9 +89,15 @@ local function splitShipment(ply, args)
     local count = math.floor(ent:Getcount() / 2)
     ent:Setcount(ent:Getcount() - count)
 
+    local crate = ents.Create("spawned_shipment")
+    if not IsValid(crate) then
+        ent:Setcount(ent:Getcount() + count)
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("unable", "/splitshipment", ""))
+        return
+    end
+
     ent:StartSpawning()
 
-    local crate = ents.Create("spawned_shipment")
     crate.locked = true
     crate.SID = ply.SID
     crate:SetPos(ent:GetPos())
@@ -98,6 +112,6 @@ local function splitShipment(ply, args)
     crate:Spawn()
 
     local phys = crate:GetPhysicsObject()
-    phys:Wake()
+    if phys:IsValid() then phys:Wake() end
 end
 DarkRP.defineChatCommand("splitshipment", splitShipment, 0.3)

--- a/entities/entities/spawned_weapon/init.lua
+++ b/entities/entities/spawned_weapon/init.lua
@@ -10,7 +10,7 @@ function ENT:Initialize()
     self:SetSolid(SOLID_VPHYSICS)
     self:SetUseType(SIMPLE_USE)
     local phys = self:GetPhysicsObject()
-    phys:Wake()
+    if phys:IsValid() then phys:Wake() end
 
     if self:Getamount() == 0 then
         self:Setamount(1)

--- a/gamemode/modules/base/sv_purchasing.lua
+++ b/gamemode/modules/base/sv_purchasing.lua
@@ -75,6 +75,11 @@ local function BuyPistol(ply, args)
     end
 
     local weapon = ents.Create("spawned_weapon")
+    if not IsValid(weapon) then
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("unable", "/buy", args))
+        return ""
+    end
+
     weapon:SetModel(shipment.model)
     weapon:SetWeaponClass(shipment.entity)
     weapon:SetPos(tr.HitPos)
@@ -177,6 +182,11 @@ local function BuyShipment(ply, args)
     local tr = util.TraceLine(trace)
 
     local crate = ents.Create(found.shipmentClass or "spawned_shipment")
+    if not IsValid(crate) then
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("unable", "/buyshipment", args))
+        return ""
+    end
+
     crate.SID = ply.SID
     crate:Setowning_ent(ply)
     crate:SetContents(foundKey, found.amount)
@@ -192,9 +202,9 @@ local function BuyShipment(ply, args)
     DarkRP.placeEntity(crate, tr, ply)
 
     local phys = crate:GetPhysicsObject()
-    phys:Wake()
-    if found.weight then
-        phys:SetMass(found.weight)
+    if phys:IsValid() then
+        phys:Wake()
+        if found.weight then phys:SetMass(found.weight) end
     end
 
     if CustomShipments[foundKey].onBought then
@@ -206,7 +216,7 @@ local function BuyShipment(ply, args)
         ply:addMoney(-cost)
         DarkRP.notify(ply, 0, 4, DarkRP.getPhrase("you_bought", args, DarkRP.formatMoney(cost)))
     else
-        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("unable", "/buyshipment", arg))
+        DarkRP.notify(ply, 1, 4, DarkRP.getPhrase("unable", "/buyshipment", args))
     end
 
     ply.LastShipmentSpawn = CurTime()


### PR DESCRIPTION
## Summary
- validate spawned weapon/shipment entities before writing fields or placing them
- guard physics wake/mass calls when physics initialization fails
- preserve the original spawned weapon state when /makeshipment cannot create a crate
- skip delayed money printer explosions after the printer has already been removed
- avoid touching food owner counters after the owner entity is gone

## Why
These paths mostly depend on configurable entity classes/models. When creation or physics initialization fails, the code could continue into method calls on invalid entities or physics objects. The changes keep the normal success path the same and bail out earlier on failed creation paths.

## Checks
- git diff --check
- .github/scripts/check-modified-subtree.sh